### PR TITLE
Add QOpenHD support behind a feature flag

### DIFF
--- a/RemoteSettings/Ground/KillForwardRTPSecondaryCamera.sh
+++ b/RemoteSettings/Ground/KillForwardRTPSecondaryCamera.sh
@@ -1,5 +1,4 @@
 ps -ef | nice grep "gst-launch-1.0 udpsrc port=5612" | nice grep -v grep | awk '{print $2}' | xargs kill -9 > /dev/null 2>/dev/null
-ps -ef | nice grep "wfb_rx -u 5621 -p 23 -c 127.0.0.1" | nice grep -v grep | awk '{print $2}' | xargs kill -9 > /dev/null 2>/dev/null
 ps -ef | nice grep "wfb_rx -u 5612 -p 23 -c 127.0.0.1" | nice grep -v grep | awk '{print $2}' | xargs kill -9 > /dev/null 2>/dev/null
 ps -ef | nice grep "hello_video.bin.240-befi" | nice grep -v grep | awk '{print $2}' | xargs kill -9 > /dev/null 2>/dev/null
 sleep 0.2

--- a/RemoteSettings/Ground/RxForwardSecondaryRTP.sh
+++ b/RemoteSettings/Ground/RxForwardSecondaryRTP.sh
@@ -18,4 +18,10 @@ cd /home/pi/cameracontrol/IPCamera/svpcom_wifibroadcast/
 
 NICS_LIST=`ls /sys/class/net/ | nice grep -v eth0 | nice grep -v lo | nice grep -v usb | nice grep -v intwifi | nice grep -v wlan | nice grep -v relay | nice grep -v wifihotspot`
 
-./wfb_rx -u 5621 -p 23 -c 127.0.0.1 -n $VIDEO_BLOCKS_SECONDARY -k $VIDEO_FECS_SECONDARY $NICS_LIST >/dev/null 2>/dev/null
+./wfb_rx -u 5612 -p 23 -c 127.0.0.1 -n $VIDEO_BLOCKS_SECONDARY -k $VIDEO_FECS_SECONDARY $NICS_LIST >/dev/null 2>/dev/null &
+
+if [ "$ENABLE_QOPENHD" == "Y" ]; then
+    gst-launch-1.0 udpsrc port=5612 ! tee name=t !  queue ! udpsink host=127.0.0.1 port=5621 t. ! udpsink host=127.0.0.1 port=$VIDEO_UDP_PORT2
+else
+    gst-launch-1.0 udpsrc port=5612 ! queue ! udpsink host=127.0.0.1 port=5621
+fi

--- a/RemoteSettings/Ground/RxForwardSecondaryRTPAndDisplayLocally.sh
+++ b/RemoteSettings/Ground/RxForwardSecondaryRTPAndDisplayLocally.sh
@@ -20,4 +20,8 @@ NICS_LIST=`ls /sys/class/net/ | nice grep -v eth0 | nice grep -v lo | nice grep 
 
 ./wfb_rx -u 5612 -p 23 -c 127.0.0.1 -n $VIDEO_BLOCKS_SECONDARY -k $VIDEO_FECS_SECONDARY $NICS_LIST >/dev/null 2>/dev/null &
 
-gst-launch-1.0 udpsrc port=5612 !  tee name=t !  queue ! udpsink host=127.0.0.1 port=5621 t. ! "application/x-rtp,media=video" ! rtph264depay  ! video/x-h264, stream-format="byte-stream" ! filesink location=/dev/stdout | /opt/vc/src/hello_pi/hello_video/hello_video.bin.240-befi
+if [ "$ENABLE_QOPENHD" == "Y" ]; then
+    gst-launch-1.0 udpsrc port=5612 !  tee name=t !  queue ! udpsink host=127.0.0.1 port=5621 t. ! udpsink host=127.0.0.1 port=$VIDEO_UDP_PORT2
+else
+    gst-launch-1.0 udpsrc port=5612 !  tee name=t !  queue ! udpsink host=127.0.0.1 port=5621 t. ! "application/x-rtp,media=video" ! rtph264depay  ! video/x-h264, stream-format="byte-stream" ! filesink location=/dev/stdout | /opt/vc/src/hello_pi/hello_video/hello_video.bin.240-befi
+fi

--- a/RemoteSettings/dhcpeventThread.sh
+++ b/RemoteSettings/dhcpeventThread.sh
@@ -15,6 +15,8 @@ echo $op
 #echo $ip
 #echo $hostname
 
+export PATH=/home/pi/wifibroadcast-status:${PATH}
+
 if [ ! -f /tmp/mavlink_router_pipe ]; then 
     sleep 1
 fi
@@ -29,7 +31,11 @@ if [[ $op == "old" || $op == "add" ]]; then
 	echo "add $IP"  > /dev/udp/127.0.0.1/9125
 	echo "add udp $IP $IP 14550 0" > /tmp/mavlink_router_pipe
 	if [ "$QUIET" == "N" ]; then
-        	nice /home/pi/wifibroadcast-status/wbc_status "External device connected: $IP" 5 55 0 &
+            if [ "$ENABLE_QOPENHD" == "Y" ]; then
+                qstatus "External device connected: $IP" 3
+            else
+                wbc_status "External device connected: $IP" 5 55 0 &
+            fi
         fi
         IPTHERE=1
         while [  $IPTHERE -eq 1 ]; do
@@ -54,6 +60,10 @@ if [[ $op == "old" || $op == "add" ]]; then
         done
 
         if [ "$QUIET" == "N" ]; then
-                nice /home/pi/wifibroadcast-status/wbc_status "External device gone: $IP" 5 55 0 &
+                if [ "$ENABLE_QOPENHD" == "Y" ]; then
+                    qstatus "External device gone: $IP" 3
+                else
+                    wbc_status "External device gone: $IP" 5 55 0 &
+                fi
         fi
 fi

--- a/wifibroadcast-scripts/alive_functions.sh
+++ b/wifibroadcast-scripts/alive_functions.sh
@@ -22,10 +22,12 @@ function check_alive_function {
 		
 		ALIVE=`nice /home/pi/wifibroadcast-base/check_alive`
 		if [ $ALIVE == "0" ]; then
-			echo "no new packets, restarting hello_video and sleeping for 5s ..."
-			ps -ef | nice grep "cat /root/videofifo1" | nice grep -v grep | awk '{print $2}' | xargs kill -9
-			ps -ef | nice grep "$DISPLAY_PROGRAM" | nice grep -v grep | awk '{print $2}' | xargs kill -9
-			ionice -c 1 -n 4 nice -n -10 cat /root/videofifo1 | ionice -c 1 -n 4 nice -n -10 $DISPLAY_PROGRAM > /dev/null 2>&1 &
+			if [ "$ENABLE_QOPENHD" != "Y" ]; then
+				echo "no new packets, restarting hello_video and sleeping for 5s ..."
+				ps -ef | nice grep "cat /root/videofifo1" | nice grep -v grep | awk '{print $2}' | xargs kill -9
+				ps -ef | nice grep "$DISPLAY_PROGRAM" | nice grep -v grep | awk '{print $2}' | xargs kill -9
+				ionice -c 1 -n 4 nice -n -10 cat /root/videofifo1 | ionice -c 1 -n 4 nice -n -10 $DISPLAY_PROGRAM > /dev/null 2>&1 &
+			fi
 			sleep 5
 		else
 			echo "received packets, doing nothing ..."

--- a/wifibroadcast-scripts/global_functions.sh
+++ b/wifibroadcast-scripts/global_functions.sh
@@ -553,12 +553,14 @@ function collect_errorlog {
 function wbclogger_function {
   if [ "$CAM" == "0" ]; then # if we are RX ...
 
-    # Waiting until video is running ...
-    VIDEORXRUNNING=0
-    while [ $VIDEORXRUNNING -ne 1 ]; do
-		VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
-		sleep 1
-    done
+	if [ "$ENABLE_QOPENHD" != "Y" ]; then
+		# Waiting until video is running ...
+		VIDEORXRUNNING=0
+		while [ $VIDEORXRUNNING -ne 1 ]; do
+			VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
+			sleep 1
+		done
+	fi
 	
     echo
 	

--- a/wifibroadcast-scripts/main.sh
+++ b/wifibroadcast-scripts/main.sh
@@ -17,6 +17,9 @@ TTY=`tty`
 # GPIO variable
 CONFIGFILE=`/root/wifibroadcast_misc/gpio-config.py`
 
+export PATH=/home/pi/wifibroadcast-status:${PATH}
+
+
 # Check for the camera
 check_camera_attached
 

--- a/wifibroadcast-scripts/rssi_rx_functions.sh
+++ b/wifibroadcast-scripts/rssi_rx_functions.sh
@@ -10,16 +10,17 @@ function MAIN_RSSI_RX_FUNCTION {
 
 function rssirx_function {
     echo
-    echo -n "Waiting until video is running ..."
-	
-    VIDEORXRUNNING=0
-	
-    while [ $VIDEORXRUNNING -ne 1 ]; do
-        sleep 0.5
-        VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
-        echo -n "."
-    done
-	
+    if [ "$ENABLE_QOPENHD" != "Y" ]; then
+        echo -n "Waiting until video is running ..."
+        
+        VIDEORXRUNNING=0
+        
+        while [ $VIDEORXRUNNING -ne 1 ]; do
+            sleep 0.5
+            VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
+            echo -n "."
+        done
+	fi
     echo
     
 	# get NICS (exclude devices with wlanx)

--- a/wifibroadcast-scripts/tether_functions.sh
+++ b/wifibroadcast-scripts/tether_functions.sh
@@ -23,7 +23,11 @@ function tether_check_function {
 			nice pump -h wifibrdcast -i usb0 --no-dns --keep-up --no-resolvconf --no-ntp || {
 				echo "ERROR: Could not configure IP for USB tethering device!"
 				nice killall wbc_status > /dev/null 2>&1
-				nice /home/pi/wifibroadcast-status/wbc_status "ERROR: Could not configure IP for USB tethering device!" 7 55 0
+				if [ "$ENABLE_QOPENHD" == "Y" ]; then
+				    qstatus "ERROR: Could not configure IP for USB tethering device!" 5
+				else
+				    wbc_status "ERROR: Could not configure IP for USB tethering device!" 7 55 0 &
+				fi
 				collect_errorlog
 				sleep 365d
 			}

--- a/wifibroadcast-scripts/uplink_functions.sh
+++ b/wifibroadcast-scripts/uplink_functions.sh
@@ -141,13 +141,15 @@ function mspdownlinktx_function {
 function uplinktx_function {
     # wait until video is running to make sure NICS are configured
     echo
-    echo -n "Waiting until video is running ..."
-    VIDEORXRUNNING=0
-    while [ $VIDEORXRUNNING -ne 1 ]; do
-		VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
-		sleep 1
-		echo -n "."
-    done
+	if [ "$ENABLE_QOPENHD" != "Y" ]; then
+		echo -n "Waiting until video is running ..."
+		VIDEORXRUNNING=0
+		while [ $VIDEORXRUNNING -ne 1 ]; do
+			VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
+			sleep 1
+			echo -n "."
+		done
+	fi
 	
     sleep 1
 	
@@ -202,15 +204,17 @@ function uplinktx_function {
 # runs on RX (ground pi)
 function mspdownlinkrx_function {
     echo
-    echo -n "Waiting until video is running ..."
-	
-    VIDEORXRUNNING=0
-	
-    while [ $VIDEORXRUNNING -ne 1 ]; do
-		sleep 0.5
-		VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
-		echo -n "."
-	done
+    if [ "$ENABLE_QOPENHD" != "Y" ]; then
+		echo -n "Waiting until video is running ..."
+
+		VIDEORXRUNNING=0
+		
+		while [ $VIDEORXRUNNING -ne 1 ]; do
+			sleep 0.5
+			VIDEORXRUNNING=`pidof $DISPLAY_PROGRAM | wc -w`
+			echo -n "."
+		done
+	fi
 	
     echo
     echo "Video running ..."

--- a/wifibroadcast-status/Makefile
+++ b/wifibroadcast-status/Makefile
@@ -2,7 +2,7 @@ CPPFLAGS+= -I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads -I/opt/v
 LDFLAGS+= -lfreetype -lz
 LDFLAGS+=-L/opt/vc/lib/ -lbrcmGLESv2 -lbrcmEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -lm -lshapes
 
-all: wbc_status
+all: wbc_status qstatus
 
 %.o: %.c
 	gcc -c -o $@ $< $(CPPFLAGS)
@@ -11,7 +11,9 @@ all: wbc_status
 wbc_status: wbc_status.o
 	gcc -o $@ $^ $(LDFLAGS)
 
+qstatus: qstatus.o
+	gcc -o $@ $^
 
 clean:
-	rm -f wbc_status *.o *~
+	rm -f wbc_status qstatus *.o *~
 

--- a/wifibroadcast-status/qstatus.c
+++ b/wifibroadcast-status/qstatus.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct {
+    uint8_t level;
+    int message[1024];
+} __attribute__((packed)) localmessage_t;
+
+
+#define MESSAGE_FIFO "/tmp/messagefifo1"
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        exit(1);
+    }
+
+    int fifoFP = open(MESSAGE_FIFO, O_WRONLY);
+    if (fifoFP == -1) {
+        return 1;
+    }
+
+    int level = atoi(argv[2]);
+
+    localmessage_t message;
+
+    message.level = level;
+    strncpy(message.message, argv[1], 1024);
+    write(fifoFP, &message, sizeof(message));
+    close(fifoFP);
+    return 0;
+}


### PR DESCRIPTION
This should preserve existing Open.HD behavior unless `ENABLE_QOPENHD=Y` in `openhd-settings-1.txt`

If the variable is missing from the settings file, it behaves as if `ENABLE_QOPENHD=N`.

This includes support for 2nd camera stream display but continues to use `hello_video` on the ground station for the primary video stream due to GStreamer jitter (affects every platform and occurs even without involving QOpenHD at all).