### PR TITLE
Dynamic wbc tmp

### DIFF
--- a/wifibroadcast-scripts/global_functions.sh
+++ b/wifibroadcast-scripts/global_functions.sh
@@ -4,6 +4,10 @@ function tmessage {
     fi
 }
 
+function detect_memory {
+	TOTAL_MEMORY=$(cat /proc/meminfo | grep 'MemTotal' | awk '{print $2}')
+}
+
 function detect_hardware {
 	HARDWARE=$(cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}')
 

--- a/wifibroadcast-scripts/main.sh
+++ b/wifibroadcast-scripts/main.sh
@@ -85,6 +85,24 @@ if [ "$CAM" == "0" ]; then
 fi	
 
 
+###############################################################################
+# Create /wbc_tmp dynamically based on available ram
+###############################################################################
+
+detect_memory
+
+mkdir -p /wbc_tmp
+# use 1/4 of available ram by default for /wbc_tmp, which is used for recording telemetry and video
+# when VIDEO_TMP=memory. We need to do this to avoid crashes or safety issues caused by running out of
+# memory, which is easy to do when the ground station has just 512MB ram to start with and has 128MB set
+# aside for the GPU, like the Pi3a+
+available_for_wbc_tmp=$((${TOTAL_MEMORY} / 4))
+
+# add a little extra margin 
+available_for_wbc_tmp_final=$((${available_for_wbc_tmp} + 30000))
+
+mount -t tmpfs -o size=${available_for_wbc_tmp_final}K tmpfs /wbc_tmp
+
 
 ###############################################################################
 # Execute the different segments of the system on different TTY consoles


### PR DESCRIPTION
This avoids `/wbc_tmp` being too large and causing crashes or safety issues, which is possible on Pi3A+ and perhaps even Pi3B+ when GPU memory is increased beyond 128M.

In either case this change will prevent `/wbc_tmp` from ever using more than 1/4 of *available* ram plus an additional 30MB.