### PR TITLE
Add optional support for using openhdvid

### DIFF
--- a/RemoteSettings/KillRaspivid.sh
+++ b/RemoteSettings/KillRaspivid.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+if [ -e "/tmp/settings.sh" ]; then
+    OK=`bash -n /tmp/settings.sh`
+    if [ "$?" == "0" ]; then
+        source /tmp/settings.sh
+    fi
+fi
 
-ps -ef | nice grep "raspivid" | nice grep -v grep | awk '{print $2}' | xargs kill -9
+if [ "$ENABLE_OPENHDVID" == "Y" ]; then
+	CAMERA_PROGRAM="openhdvid"
+else
+	CAMERA_PROGRAM="raspivid"
+fi
+
+ps -ef | nice grep "${CAMERA_PROGRAM}" | nice grep -v grep | awk '{print $2}' | xargs kill -9
 ps -ef | nice grep "tx_rawsock -p 0 -b" | nice grep -v grep | awk '{print $2}' | xargs kill -9

--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -317,7 +317,12 @@ echo "#!/bin/bash" >  /dev/shm/startReadCameraTransferExteranlBitrate.sh
 
 NotIMX290=`/usr/bin/vcgencmd get_camera | nice grep -c detected=1`
 if [ "$NotIMX290" == "1" ];  then
-	echo "nice -n -9 raspivid -w $WIDTH -h $HEIGHT -fps $FPS -b \$1 -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransferExteranlBitrate.sh
+    if [ "$ENABLE_OPENHDVID" == "Y" ]; then
+		CAMERA_PROGRAM="openhdvid"
+	else
+		CAMERA_PROGRAM="raspivid"
+	fi
+	echo "nice -n -9 ${CAMERA_PROGRAM} -w $WIDTH -h $HEIGHT -fps $FPS -b \$1 -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransferExteranlBitrate.sh
 else
 	echo "nice -n -9 /home/pi/raspberrypi/veye_raspcam/source/veye_raspivid -w $WIDTH -h $HEIGHT -fps $FPS -b \$1 -g $KEYFRAMERATE -t 0 $EXTRAPARAMS_IMX290 -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransferExteranlBitrate.sh
 fi
@@ -353,9 +358,15 @@ echo $BITRATE_5
 
 
 if [ "$NotIMX290" == "1" ]; then
-	echo "nice -n -9 raspivid -w $WIDTH -h $HEIGHT -fps $FPS -b $BITRATE -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransfer.sh
-	echo "nice -n -9 raspivid -w $WIDTH -h $HEIGHT -fps $FPS -b $BITRATE_10 -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransfer_10.sh
-	echo "nice -n -9 raspivid -w $WIDTH -h $HEIGHT -fps $FPS -b $BITRATE_5 -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransfer_5.sh
+    if [ "$ENABLE_OPENHDVID" == "Y" ]; then
+		CAMERA_PROGRAM="openhdvid"
+	else
+		CAMERA_PROGRAM="raspivid"
+	fi
+
+	echo "nice -n -9 ${CAMERA_PROGRAM} -w $WIDTH -h $HEIGHT -fps $FPS -b $BITRATE -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransfer.sh
+	echo "nice -n -9 ${CAMERA_PROGRAM} -w $WIDTH -h $HEIGHT -fps $FPS -b $BITRATE_10 -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransfer_10.sh
+	echo "nice -n -9 ${CAMERA_PROGRAM} -w $WIDTH -h $HEIGHT -fps $FPS -b $BITRATE_5 -g $KEYFRAMERATE -t 0 $EXTRAPARAMS -o - | nice -n -9 /home/pi/wifibroadcast-base/tx_rawsock -p 0 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS" >> /dev/shm/startReadCameraTransfer_5.sh
 else
 
 

--- a/wifibroadcast-scripts/uplink_functions.sh
+++ b/wifibroadcast-scripts/uplink_functions.sh
@@ -111,10 +111,16 @@ function mspdownlinktx_function {
     echo
     echo -n "Waiting until video TX is running ..."
     VIDEOTXRUNNING=0
+
+	if [ "$ENABLE_OPENHDVID" == "Y" ]; then
+		CAMERA_PROGRAM="openhdvid"
+	else
+		CAMERA_PROGRAM="raspivid"
+	fi
 	
     while [ $VIDEOTXRUNNING -ne 1 ]; do
 		sleep 0.5
-		VIDEOTXRUNNING=`pidof raspivid | wc -w`
+		VIDEOTXRUNNING=`ps -ef | nice grep "${CAMERA_PROGRAM}" | nice grep -v grep | awk '{print $2}' | wc -w`
 		echo -n "."
     done
 	


### PR DESCRIPTION
This adds support for *optionally* using `openhdvid` instead of `raspivid` for the main camera. It is disabled by default.

To enable it, set `ENABLE_OPENHDVID=Y` in the `openhd-settings-1/2/3/4.txt` files.

When enabled, the system should behave exactly as it did before, all existing `raspivid` arguments are accepted by `openhdvid` as well, although not all of them *do* the same thing at the moment (some `raspivid` options aren't really useful to Open.HD in the first place).

When `openhdvid` is enabled you can optionally enable air-side video recording by adding the following arguments to `EXTRAPARAMS`:

    -wr 1280 -hr 720 --record /home/pi/mainvideo.h264

Not that as of right now there is no way to automatically retrieve that recording except for using SSH or removing the SD card, but at some point soon it will be possible to retrieve it using QOpenHD.