### PR TITLE
Openhdvid update

### DIFF
--- a/openhd-camera/openhdvid
+++ b/openhd-camera/openhdvid
@@ -134,7 +134,11 @@ class OpenHDCamera:
                 self.record_local = False
                 print("Not enough space available to record locally", file=sys.stderr)
             else:
-                self.camera.start_recording(option.record, 'h264', resize=(option.width_record, option.height_record), splitter_port=2)
+                # don't hook up the resize component in the pipeline if the resolution is the same as the main stream
+                if option.width_record == option.width and option.height_record == option.height:
+                    self.camera.start_recording(option.record, 'h264', splitter_port=2)
+                else:
+                    self.camera.start_recording(option.record, 'h264', resize=(option.width_record, option.height_record), splitter_port=2)
                 print("Recording to file " + option.record, file=sys.stderr)
 
         print("Camera running", file=sys.stderr)

--- a/openhd-camera/openhdvid
+++ b/openhd-camera/openhdvid
@@ -14,6 +14,7 @@ import picamera
 #from pymavlink import mavutil
 #mavutil.set_dialect('openhd')
 
+sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
 
 class OpenHDCamera:
     def __init__(self, option):

--- a/openhd-camera/openhdvid
+++ b/openhd-camera/openhdvid
@@ -17,7 +17,7 @@ import picamera
 
 class OpenHDCamera:
     def __init__(self, option):
-        print("OpenHDCamera.__init__()")
+        print("OpenHDCamera.__init__()", file=sys.stderr)
         #self.mav = mavutil.mavlink_connection('udpin:localhost:14550', 
         #                                      planner_format=False,
         #                                      notimestamps=True,
@@ -105,8 +105,7 @@ class OpenHDCamera:
         self.inline_headers = option.inline_headers
         self.sps_timing = option.sps_timing
         self.bitrate = option.bitrate
-        print("Camera initialized")
-        print(option)
+        print("Camera initialized", file=sys.stderr)
 
     def check_used_space(self, path):
         total, used, free = shutil.disk_usage(path)
@@ -116,7 +115,7 @@ class OpenHDCamera:
         return percent_used
 
     def run(self):
-        print("OpenHDCamera.run()")
+        print("OpenHDCamera.run()", file=sys.stderr)
 
         self.camera.start_recording(self.output, 
                                     format=self.codec.lower(), 
@@ -132,12 +131,12 @@ class OpenHDCamera:
             percent_used = self.check_used_space(option.record)
             if percent_used > 90.0:
                 self.record_local = False
-                print("Not enough space available to record locally")
+                print("Not enough space available to record locally", file=sys.stderr)
             else:
                 self.camera.start_recording(option.record, 'h264', resize=(option.width_record, option.height_record), splitter_port=2)
-                print("Recording to file " + option.record)
+                print("Recording to file " + option.record, file=sys.stderr)
 
-        print("Camera running")
+        print("Camera running", file=sys.stderr)
 
         #self.event = mavutil.periodic_event(30)
         
@@ -147,7 +146,7 @@ class OpenHDCamera:
             #if self.event.trigger():
             #    self.mav.mav.openhd_camera_status_send(brightness=75)
             #msg = self.mav.recv_match(type='HEARTBEAT', blocking=True)
-            #print(msg)
+            #print(msg, file=sys.stderr)
 
             # this can be replaced with a pymavlink event trigger once pymavlink is available on the image
             now = time.time()
@@ -159,7 +158,7 @@ class OpenHDCamera:
 
                 if percent_used > 90.0:
                     self.record_local = False
-                    print("Available space less than 10%, stopping video recording")
+                    print("Available space less than 10%, stopping video recording", file=sys.stderr)
                     self.camera.stop_recording(splitter_port=2)
             sleep(0.05)
 

--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -319,6 +319,9 @@ NotIMX290=`/usr/bin/vcgencmd get_camera | nice grep -c detected=1`
 if [ "$NotIMX290" == "1" ];  then
     if [ "$ENABLE_OPENHDVID" == "Y" ]; then
 		CAMERA_PROGRAM="openhdvid"
+		if [ "$AIR_VIDEO_RECORDING" == "Y" ]; then
+			EXTRAPARAMS="${EXTRAPARAMS} --record ${AIR_VIDEO_RECORDING_PATH} -wr ${AIR_VIDEO_RECORDING_WIDTH} -hr ${AIR_VIDEO_RECORDING_HEIGHT}"
+		fi
 	else
 		CAMERA_PROGRAM="raspivid"
 	fi
@@ -360,6 +363,9 @@ echo $BITRATE_5
 if [ "$NotIMX290" == "1" ]; then
     if [ "$ENABLE_OPENHDVID" == "Y" ]; then
 		CAMERA_PROGRAM="openhdvid"
+		if [ "$AIR_VIDEO_RECORDING" == "Y" ]; then
+			EXTRAPARAMS="${EXTRAPARAMS} --record ${AIR_VIDEO_RECORDING_PATH} -wr ${AIR_VIDEO_RECORDING_WIDTH} -hr ${AIR_VIDEO_RECORDING_HEIGHT}"
+		fi
 	else
 		CAMERA_PROGRAM="raspivid"
 	fi


### PR DESCRIPTION
* Write openhdvid log messages to stderr since stdout is supposed to be piped to tx_rawsock
* Disable stdout buffering
* Don't resize video in openhdvid if record resolution is the same as main stream resolution
    * The PiCamera recording support can optionally resize the video, which occurs before the encoding step but may introduce additional latency. We want to try and eliminate any chance that the GPU will decide to add latency on the main stream.
* Add separate settings for openhdvid recording options
    * Requires a separate PR for the builder to add these options to the default settings files