### PR TITLE
Always allocate rcData as 9 * uint16_t

### DIFF
--- a/wifibroadcast-rc-Ath9k/rctx.c
+++ b/wifibroadcast-rc-Ath9k/rctx.c
@@ -82,7 +82,7 @@ int IsTrimDone[8] =  { 0 };
 	return (uint16_t *)retval;
 	}
 #else
-	static uint16_t rcData[8]; // interval [1000;2000]
+	static uint16_t rcData[9]; // interval [1000;2000]
 #endif
 
 static SDL_Joystick *js;


### PR DESCRIPTION
The original code allocates 8 * uint16_t when JSSWITCHES isn't defined,
but 9 * uint16_t when JSSWITCHES is defined.

However there are spots in the code that write to rcData[8], which makes it look like you can do that all the time.

This change ensures that the available space in that array is always the same.