### PR TITLE
Allow hotspot TX power to be changed live

### DIFF
--- a/RemoteSettings/RemoteSettings.py
+++ b/RemoteSettings/RemoteSettings.py
@@ -303,6 +303,13 @@ while True:
                 subprocess.check_call(['/usr/local/bin/txpower_atheros',  filter ])
         except Exception as e:
             print("TxPowerGround except: " + str(e) )
+        try:
+            if VariableNamAndData.startswith('HOTSPOT_TXPOWER=') == True:
+                splitResult = VariableNamAndData.split("=")
+                filter = re.sub("\D", "", splitResult[1])
+                subprocess.check_call(['/sbin/iw', "dev", "wifihotspot0", "set", "txpower", "fixed", filter ])
+        except Exception as e:
+            print("HOTSPOT_TXPOWER except: " + str(e) )
         ConfirmSave(VariableNameReport)
         complete_response = {}
         read_wbc_settings(complete_response)


### PR DESCRIPTION
This processes the `HOTSPOT_TXPOWER` setting whenever it is saved and immediately uses the value to change the hotspot power setting on the `wifihotspot0` interface. 

The setting still gets saved in the `openhd-settings-1.txt` file.

This prevents users from having to reboot the ground station just to change the hotspot power level.