### PR TITLE
Fix manual bitrate display in OSD

### DIFF
--- a/wifibroadcast-base/rssitx.c
+++ b/wifibroadcast-base/rssitx.c
@@ -546,7 +546,7 @@ int main (int argc, char *argv[]) {
 	int bitrate_measured_kbit;
 	pFile = fopen ("/tmp/bitrate_measured_kbit","r");
 	if(NULL == pFile) {
-    	    perror("ERROR: Could not open /tmp/measured_kbit");
+    	    perror("ERROR: Could not open /tmp/bitrate_measured_kbit");
     	    exit(EXIT_FAILURE);
 	}
 	fscanf(pFile, "%i\n", &bitrate_measured_kbit);

--- a/wifibroadcast-osd/render.c
+++ b/wifibroadcast-osd/render.c
@@ -971,9 +971,17 @@ void draw_kbitrate(int cts, int kbitrate, uint16_t kbitrate_measured_tx, uint16_
     float ms = (float)injection_time / 1000;
 
     if (cts == 0) {
-    sprintf(buffer, "%.1f (%.1f)", mbit_tx, mbit_measured);
+        if (mbit_measured == 0) {
+            sprintf(buffer, "%.1f (-)", mbit_tx);
+        } else {
+            sprintf(buffer, "%.1f (%.1f)", mbit_tx, mbit_measured);
+        }
     } else {
-    sprintf(buffer, "%.1f (%.1f) CTS", mbit_tx, mbit_measured);
+        if (mbit_measured == 0) {
+            sprintf(buffer, "%.1f (-) CTS", mbit_tx);
+        } else {
+            sprintf(buffer, "%.1f (%.1f) CTS", mbit_tx, mbit_measured);
+        }
     }
     Text(getWidth(pos_x)-width_value-width_symbol, getHeight(pos_y)-height_text_small, buffer, myfont, text_scale*0.6);
 

--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -192,6 +192,8 @@ function tx_function {
 			echo "$BITRATE_MEASURED_KBIT kBit/s * $BITRATE_PERCENT% = $BITRATE_KBIT kBit/s video bitrate"
 		else
 			BITRATE=$(($VIDEO_BITRATE*1000))
+			BITRATE_MEASURED_KBIT=0
+			BITRATE_KBIT=${VIDEO_BITRATE}
 			echo "Using fixed bitrate: $VIDEO_BITRATE kBit"
 		fi
 	else


### PR DESCRIPTION
This causes the "set bitrate" display on the OSD to match the configured video bitrate if the user is not using auto bitrate.

This also shows "--" for the measured bitrate when the system is not doing an automatic bitrate measurement. Previously it was showing garbage values.