### PR TITLE
Don't use red color on bitrate if set manually

### DIFF
--- a/wifibroadcast-osd/render.c
+++ b/wifibroadcast-osd/render.c
@@ -996,12 +996,12 @@ void draw_kbitrate(int cts, int kbitrate, uint16_t kbitrate_measured_tx, uint16_
     #else
     TextEnd(getWidth(pos_x)-width_value, getHeight(pos_y),"ﵴ", osdicons, text_scale * 0.8);
     #endif
-    if (mbit > mbit_measured*mbit_warn) {
+    if (mbit_measured != 0 && mbit > mbit_measured*mbit_warn) {
         Stroke(COLOR_WARNING); //red
-    Fill(COLOR_WARNING); 
-    } else if (mbit > mbit_measured*mbit_caution) {
+        Fill(COLOR_WARNING); 
+    } else if (mbit_measured != 0 && mbit > mbit_measured*mbit_caution) {
         Stroke(COLOR_CAUTION); //yellow
-    Fill(COLOR_CAUTION); 
+        Fill(COLOR_CAUTION); 
     } else {    
         Fill(COLOR); //normal
         Stroke(OUTLINECOLOR);


### PR DESCRIPTION
If auto bitrate is in use, turning the bitrate red in the OSD is helpful to indicate that real bitrate usage is approaching or has exceeded the measured available bitrate.

However when manual bitrate is in use, there is nothing to indicate what would be "too much" because there's no measurement to compare it with in the first place.

At the moment the OSD is saying "the bitrate you configured is too much" and that's not the case.

In the future we might want to still set this red based on some other criteria, or always measure available bandwidth periodically.