### PR TITLE
Add bandwidth measurement support to tx_rawsock

### DIFF
--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -185,7 +185,8 @@ function tx_function {
 	if [ "$UNDERVOLT" == "0" ]; then
 		if [ "$VIDEO_BITRATE" == "auto" ]; then
 			echo -n "Measuring max. available bitrate .. "
-			BITRATE_MEASURED=`/home/pi/wifibroadcast-base/tx_measure -p 77 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS`
+			BITRATE_MEASURED=$(cat /dev/zero | /home/pi/wifibroadcast-base/tx_rawsock -z 1 -p 77 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH -t $VIDEO_FRAMETYPE -d $VIDEO_WIFI_BITRATE -M $UseMCS -S $UseSTBC -L $UseLDPC -y 0 $NICS)
+			echo "Measured: ${BITRATE_MEASURED}"
 			BITRATE=$((BITRATE_MEASURED*$BITRATE_PERCENT/100))
 			BITRATE_KBIT=$((BITRATE/1000))
 			BITRATE_MEASURED_KBIT=$((BITRATE_MEASURED/1000))


### PR DESCRIPTION
Use the argument "-z 1" (-m and -M are already used for other things).

This will allow us to get rid of the tx_measure program, which is 90% duplicated from an old version of tx_rawsock.