### PR TITLE
Change auto i2c_vc to a boot file check

### DIFF
--- a/wifibroadcast-scripts/main.sh
+++ b/wifibroadcast-scripts/main.sh
@@ -19,6 +19,7 @@ CONFIGFILE=`/root/wifibroadcast_misc/gpio-config.py`
 
 export PATH=/home/pi/wifibroadcast-status:${PATH}
 
+autoenable_i2c_vc
 
 # Check for the camera
 check_camera_attached
@@ -29,9 +30,6 @@ read_config_file
 echo "-------------------------------------"
 echo "SETTINGS FILE: $CONFIGFILE"
 echo "-------------------------------------"
-
-
-autoenable_i2c_vc
 
 
 # Set the wifi parameters based on the selected datarate


### PR DESCRIPTION
The i2c_vc autoenable depends on knowing that an IMX290 is connected,
but there's no way to know that without already having i2c_vc enabled.

So there's essentially no way to fully automate it, but we can still
check for a `/boot/i2c_vc` file the same way Raspbian usually does for
`/boot/ssh` and `/boot/wpa_supplicant.conf`: just place an empty file in
the /boot partition called `/boot/i2c_vc`, and we will automatically ensure 
i2c_vc is enabled at boot.