### PR TITLE
Add safer Python implementation of UDPSplitter

### DIFF
--- a/UDPSplitter/udpsplitter.py
+++ b/UDPSplitter/udpsplitter.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import socket
+from threading import Thread
+from time import sleep
+import sys
+
+remote_addresses = []
+
+def data_thread(data_in_port, data_out_port):
+    data_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    data_socket.bind(("", data_in_port))
+    print("Forwarding from port " + str(data_in_port) + " to " + str(data_out_port))
+    while True:
+        try:
+            data, addr = data_socket.recvfrom(1500)
+            for address in remote_addresses:
+                data_socket.sendto(data, (address, data_out_port))
+        except Exception as e:
+            print("Error in data stream: " + str(e))
+
+
+
+def command_thread(command_port):
+    command_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    command_socket.bind(("localhost", command_port))
+    print("Command port: " + str(command_port))
+    while True:
+        try:
+            data, addr = command_socket.recvfrom(1024)
+            received_command = data.decode("utf-8").rstrip().split(' ')
+            if len(received_command) == 2:
+                command = received_command[0]
+                arg = received_command[1]
+                if command == "add":
+                    print("Adding remote address: " + arg)
+                    remote_addresses.append(arg)
+                elif command == "del":
+                    print("Removing remote address: " + arg)
+                    remote_addresses.remove(arg)
+
+        except Exception as e:
+            print("Error in command API: " + str(e))
+        sleep(0.1)
+
+
+if len(sys.argv) < 4:
+    print("Usage:")
+    print("")
+    print("./udpplitter.py PORT_COMMAND PORT_IN PORT_OUT")
+    print("")
+    print("UDP API:")
+    print("")
+    print("The UDP command port listens for 2 commands:")
+    print("add 192.168.2.20")
+    print("del 192.168.2.20")
+    print("")
+    print("When add is called, the address will be added to the list")
+    print("of remote addresses that data will be forwarded to.")
+    exit(1)
+
+command_port  = int(sys.argv[1])
+data_in_port  = int(sys.argv[2])
+data_out_port = int(sys.argv[3])
+
+data_thread_handle = Thread(target=data_thread, args=(data_in_port, data_out_port))
+command_thread_handle = Thread(target=command_thread, args=(command_port,))
+
+data_thread_handle.start()
+command_thread_handle.start()
+
+data_thread_handle.join()
+command_thread_handle.join()
+

--- a/wifibroadcast-scripts/UDPsplitterhelper.sh
+++ b/wifibroadcast-scripts/UDPsplitterhelper.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 while true; do
-/home/pi/RemoteSettings/UDPSplitter $1 $2 $3
+/home/pi/UDPSplitter/udpsplitter.py $1 $2 $3
 sleep 1
 done


### PR DESCRIPTION
A single python list is the only global state here, and python lists themselves are thread safe (we never modify list elements so the usual concern of data races is not an issue).

Exceptions in the 2 loops are intentionally ignored. Unless something goes wrong with the sockets themselves (which is unlikely but could be explicitly handled if necessary), they should just keep running.

Uses 6-11% CPU time in testing on a pi3+, profiling would help reduce that a bit more but it's not likely to be an issue.

Closes #150