### PR TITLE
Add support for disabling ground video recording

### DIFF
--- a/wifibroadcast-scripts/rx_functions.sh
+++ b/wifibroadcast-scripts/rx_functions.sh
@@ -127,10 +127,12 @@ function rx_function {
 		VIDEOFILE=/video_tmp/videotmp.raw
 		echo "VIDEOFILE=/video_tmp/videotmp.raw" > /tmp/videofile
 		rm $VIDEOFILE > /dev/null 2>&1
-    else
+	elif [ "$VIDEO_TMP" == "memory" ]; then
 		VIDEOFILE=/wbc_tmp/videotmp.raw
 		echo "VIDEOFILE=/wbc_tmp/videotmp.raw" > /tmp/videofile
-    fi
+	else
+		echo "Video save disabled"
+	fi
 
 
 	# tracker disabled
@@ -245,7 +247,9 @@ function rx_function {
 			ionice -c 1 -n 4 nice -n -10 cat /root/videofifo1 | ionice -c 1 -n 4 nice -n -10 $DISPLAY_PROGRAM > /dev/null 2>&1 &
 		#fi
 
-		ionice -c 3 nice cat /root/videofifo3 >> $VIDEOFILE &
+		if [ "$VIDEO_TMP" != "none" ]; then
+			ionice -c 3 nice cat /root/videofifo3 >> $VIDEOFILE &
+		fi
 
 		if [ "$RELAY" == "Y" ]; then
 		        /root/wifibroadcast/sharedmem_init_tx
@@ -282,8 +286,11 @@ function rx_function {
 		IsFirstTime=1
 		#MYADDEND
 		
-		
-		ionice -c 1 -n 3 /home/pi/wifibroadcast-base/rx -p 0 -d 1 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH $NICS | ionice -c 1 -n 4 nice -n -10 tee >(ionice -c 1 -n 4 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo2 > /dev/null 2>&1) >(ionice -c 1 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo4 > /dev/null 2>&1) >(ionice -c 3 nice /home/pi/wifibroadcast-misc/ftee /root/videofifo3 > /dev/null 2>&1) | ionice -c 1 -n 4 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo1 > /dev/null 2>&1
+		if [ "$VIDEO_TMP" != "none" ]; then
+			ionice -c 1 -n 3 /home/pi/wifibroadcast-base/rx -p 0 -d 1 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH $NICS | ionice -c 1 -n 4 nice -n -10 tee >(ionice -c 1 -n 4 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo2 > /dev/null 2>&1) >(ionice -c 1 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo4 > /dev/null 2>&1) >(ionice -c 3 nice /home/pi/wifibroadcast-misc/ftee /root/videofifo3 > /dev/null 2>&1) | ionice -c 1 -n 4 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo1 > /dev/null 2>&1
+		else
+			ionice -c 1 -n 3 /home/pi/wifibroadcast-base/rx -p 0 -d 1 -b $VIDEO_BLOCKS -r $VIDEO_FECS -f $VIDEO_BLOCKLENGTH $NICS | ionice -c 1 -n 4 nice -n -10 tee >(ionice -c 1 -n 4 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo2 > /dev/null 2>&1) >(ionice -c 1 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo4 > /dev/null 2>&1) | ionice -c 1 -n 4 nice -n -10 /home/pi/wifibroadcast-misc/ftee /root/videofifo1 > /dev/null 2>&1
+		fi
 
 		RX_EXITSTATUS=${PIPESTATUS[0]}
 		check_exitstatus $RX_EXITSTATUS

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -60,13 +60,15 @@ function save_function {
     ps -ef | nice grep "rx -p 0" | nice grep -v grep | awk '{print $2}' | xargs kill -9
     ps -ef | nice grep "ftee /root/videofifo" | nice grep -v grep | awk '{print $2}' | xargs kill -9
 
-    # find out if video is on ramdisk or sd
-    source /tmp/videofile
-    echo "VIDEOFILE: $VIDEOFILE"
+    if [ "$VIDEO_TMP" != "none" ]; then
+        # find out if video is on ramdisk or sd
+        source /tmp/videofile
+        echo "VIDEOFILE: $VIDEOFILE"
 
-    # start re-play of recorded video ....
-    # nice /opt/vc/src/hello_pi/hello_video/hello_video.bin.player $VIDEOFILE $FPS &
-    nice /rootfs/home/pi/wifibroadcast-hello_video/hello_video.bin.player $VIDEOFILE $FPS &
+        # start re-play of recorded video ....
+        # nice /opt/vc/src/hello_pi/hello_video/hello_video.bin.player $VIDEOFILE $FPS &
+        nice /rootfs/home/pi/wifibroadcast-hello_video/hello_video.bin.player $VIDEOFILE $FPS &
+    fi
 
     killall wbc_status > /dev/null 2>&1
 	if [ "$ENABLE_QOPENHD" == "Y" ]; then
@@ -154,8 +156,7 @@ function save_function {
 			mkdir $DIR_NAME_SCREENSHOT
 			cp /wbc_tmp/screenshot* $DIR_NAME_SCREENSHOT > /dev/null 2>&1
 		fi
-
-		if [ -s "$VIDEOFILE" ]; then
+		if [ -s "$VIDEOFILE" ] && [ "$VIDEO_TMP" != "none" ]; then
 			if [ -d "/media/usb$VIDEO_SAVE_PATH" ]; then
 				echo "Video save path $VIDEO_SAVE_PATH found"
 			else
@@ -229,7 +230,9 @@ function save_function {
 
     #killall tracker
     # re-start video/telemetry recording
-    ionice -c 3 nice cat /root/videofifo3 >> $VIDEOFILE &
+    if [ "$VIDEO_TMP" != "none" ]; then
+        ionice -c 3 nice cat /root/videofifo3 >> $VIDEOFILE &
+    fi
     ionice -c 3 nice cat /root/telemetryfifo3 >> /wbc_tmp/telemetrydowntmp.raw &
 
     killall wbc_status > /dev/null 2>&1


### PR DESCRIPTION
Just set `VIDEO_TMP=none` in `openhd-settings-1.txt`, video will not be saved and the processes that run when inserting a USB stick will only save telemetry