### PR TITLE
Draw current/measure/max air rate, current/set video bitrate

### DIFF
--- a/wifibroadcast-base/openhdlib.h
+++ b/wifibroadcast-base/openhdlib.h
@@ -66,6 +66,7 @@ typedef struct {
 	uint32_t lost_per_block_cnt;
 	uint32_t tx_restart_cnt;
 	uint32_t kbitrate;
+	uint32_t current_air_datarate_kbit;
 	uint32_t wifi_adapter_cnt;
 	wifi_adapter_rx_status_t adapter[MAX_PENUMBRA_INTERFACES];
 } wifibroadcast_rx_status_t;

--- a/wifibroadcast-base/rssirx.c
+++ b/wifibroadcast-base/rssirx.c
@@ -307,6 +307,7 @@ void status_memory_init(wifibroadcast_rx_status_t *s) {
 	s->tx_restart_cnt = 0;
 	s->wifi_adapter_cnt = 0;
 	s->kbitrate = 0;
+	s->current_air_datarate_kbit = 0;
 
 	int i;
 	for(i=0; i<8; ++i) {

--- a/wifibroadcast-base/rx.c
+++ b/wifibroadcast-base/rx.c
@@ -61,6 +61,8 @@ long long current_timestamp() {
 long long prev_time = 0;
 long long now = 0;
 int bytes_written = 0;
+int bytes_received = 0;
+long long current_air_datarate_ts = 0;
 
 int packets_missing;
 int packets_missing_last;
@@ -518,6 +520,16 @@ void process_packet(monitor_interface_t *interface, block_buffer_t *block_buffer
 //	rx_status->adapter[adapter_no].last_update = dbm_ts_now[adapter_no];
 //	fprintf(stderr,"lu[%d]: %lld\n",adapter_no,rx_status->adapter[adapter_no].last_update);
 //	rx_status->adapter[adapter_no].last_update = current_timestamp();
+
+	bytes_received = bytes_received + bytes;
+	long long now = current_timestamp();
+	if (now - current_air_datarate_ts > 500) {
+		double bits_received = (bytes_received * 8);
+		double bits_per_second = (bits_received / (now - current_air_datarate_ts)) * 1000.0;
+		rx_status->current_air_datarate_kbit = bits_per_second / 1024;
+		current_air_datarate_ts = now;
+		bytes_received = 0;
+	}
 
 	process_payload(pu8Payload, bytes, checksum_correct, block_buffer_list, adapter_no);
 }

--- a/wifibroadcast-osd/main.c
+++ b/wifibroadcast-osd/main.c
@@ -122,6 +122,21 @@ int main(int argc, char *argv[]) {
     long long prev_cpu_time = current_timestamp();
     long long delta = 0;
 
+
+
+    FILE *datarate_file = fopen("/tmp/DATARATE.txt", "r");
+    if (datarate_file == NULL) {
+        perror("ERROR: Could not open /tmp/DATARATE.txt");
+        exit(EXIT_FAILURE);
+    }
+
+    double datarate = 0.0;
+    fscanf(datarate_file, "%lf", &datarate);
+    fclose(datarate_file);
+
+    td.datarate = datarate;
+
+
     int cpuload_gnd = 0;
     int temp_gnd = 0;
     int undervolt_gnd = 0;

--- a/wifibroadcast-osd/render.h
+++ b/wifibroadcast-osd/render.h
@@ -41,7 +41,7 @@ void draw_total_signal(int8_t signal, int goodblocks, int badblocks, int packets
 void draw_card_signal(int8_t signal, int signal_good, int card, int adapter_cnt, int restart_count, int packets, int wrongcrcs, int type, int totalpackets, int totalpacketslost, float pos_x, float pos_y, float scale);
 void draw_uplink_signal(int8_t uplink_signal, int uplink_lostpackets, int8_t rc_signal, int rc_lostpackets, float pos_x, float pos_y, float scale);
 
-void draw_kbitrate(int cts, int kbitrate, uint16_t kbitrate_measured_tx, uint16_t kbitrate_tx, uint32_t fecs_skipped, uint32_t injection_failed, long long injection_time, int armed, float pos_x, float pos_y, float scale, float mbit_warn, float mbit_caution, float declutter);
+void draw_kbitrate(int cts, int kbitrate, uint16_t kbitrate_tx, uint16_t current_air_datarate_kbit, uint16_t kbitrate_measured_tx, double hw_datarate_mbit, uint32_t fecs_skipped, uint32_t injection_failed, long long injection_time,int armed, float pos_x, float pos_y, float scale, float mbit_warn, float mbit_caution, float declutter);
 void draw_sys(uint8_t cpuload_air, uint8_t temp_air, uint8_t cpuload_gnd, uint8_t temp_gnd, int armed, float pos_x, float pos_y, float scale, float load_warn, float load_caution, float temp_warn, float temp_caution, float declutter);
 void draw_message(int severity, char line1[30], char line2[30], char line3[30], float pos_x, float pos_y, float scale);
 

--- a/wifibroadcast-osd/telemetry.h
+++ b/wifibroadcast-osd/telemetry.h
@@ -9,6 +9,7 @@
 typedef struct {
 	uint32_t validmsgsrx;
 	uint32_t datarx;
+	double datarate;
 
 	float voltage;
 	float ampere;

--- a/wifibroadcast-scripts/rx_functions.sh
+++ b/wifibroadcast-scripts/rx_functions.sh
@@ -69,6 +69,15 @@ function rx_function {
         echo 5 > /sys/kernel/debug/ieee80211/phy4/ath9k_htc/chanbw
     fi
 
+	if [ "$VIDEO_WIFI_BITRATE" == "19.5" ]; then # set back to 18 to match air side in tx_functions.sh
+		VIDEO_WIFI_BITRATE=18
+    fi
+    if [ "$VIDEO_WIFI_BITRATE" == "5.5" ]; then # set back to 6 to match air side logic in tx_functions.sh
+		VIDEO_WIFI_BITRATE=5
+    fi
+	# on the ground side this is read by the osd code so we can display it alongside the current/measured air datarate
+	echo $VIDEO_WIFI_BITRATE > /tmp/DATARATE.txt
+
     sleep 0.5
 
     # videofifo1: local display, hello_video.bin


### PR DESCRIPTION
This changes the OSD on the ground station so that the video bitrate and radio data rate display make sense, and so that the real data rate from air -> ground (including FECs) is shown at all times.

The radio data line will now flash yellow if real data usage over the air exceeds the measured data rate or channel capacity, and will flash red if it exceeds 75% of the hardware data rate. That 75% is arbitrary, we may want to adjust it downward depending on testing.

**Note**: this PR does not send the new information to connected Android devices yet, this is due to the way the telemetry in OpenHD is being sent over the hotspot connection, it can't simply be altered without breaking existing apps. It can however be added soon without breaking anything.

### Background

The old OSD code shows the current *video* bitrate next to the measured *radio* data rate, making it appear as though they are directly related, which is misleading and hides excessive data usage problems that could affect frame rate or cause sudden increase in latency.

For example, in the old OSD this is what the video bitrate display looks like:

> 5.7 Mbit
> 5.8 (9.6)

Here, 5.7 is the *current video bitrate*, measured on the ground side, 5.8 is the *requested video bitrate* on the air side (variable based on view complexity and lighting), and 9.6 is the *measured radio data rate*, or the estimated channel capacity, which can be affected by interference. The measured capacity *should* be an indication of how much raw data can be sent from air -> ground per second, including FECs.

What you can't see is the real amount of raw data actually being sent from air -> ground per second, which is *significantly* higher than the video bitrate due to FEC encoding. 

The new OSD will show the same information and the missing information, like this:

> 5.7/5.8
> (8.8/9.6/18.0)

Here, the same 5.7, 5.8, and 9.6 numbers from the previous example are present, but they are grouped correctly so that video and radio rates are never directly compared. The numbers are arranged so that the live rates are always on the far left, and numbers should always be lower than the number to their right. If not, you may have a problem and as mentioned before the radio line will flash to indicate warning and critical conditions.

The 8.8 number is the actual radio data rate per second, which was not visible before. You can see it is nearly at the measured channel capacity of 9.6. This is a potentially unsafe situation, if the video bitrate spikes due to sudden scene changes (very common), the real data usage could far exceed the channel capacity and that could cause frame loss or latency (which people have already encountered during flight).

The 18.0 number is the hardware data rate we are using to send wifi frames from air -> ground. The real data capacity is always going to be lower than the hardware rate for a variety of reasons, but it should still be visible and acknowledged.