### PR TITLE
Move video/FEC calculation out of tx_rawsock

### DIFF
--- a/wifibroadcast-base/tx_rawsock.c
+++ b/wifibroadcast-base/tx_rawsock.c
@@ -766,7 +766,8 @@ int main(int argc, char *argv[]) {
 
 			if (now - prev_time > 250000) {
 				prev_time = current_timestamp();
-				bitrate[i_bitrate] = ((pcntnow - pcntprev) * param_packet_length * 8) * 4;
+				int fec_size = param_data_packets_per_block + param_fec_packets_per_block;
+				bitrate[i_bitrate] = ((pcntnow - pcntprev) * (param_packet_length * fec_size / param_data_packets_per_block) * 8) * 4;
 				pcntprev = pcnt;
 				measure_count++;
 				i_bitrate++;


### PR DESCRIPTION
This ensures that the raw bandwidth measurement includes the correct total data rate based on the configured video packets + FEC packets, and prints the details of how we arrived at the final video bitrate in the terminal on the air side.