### PR TITLE
Fix rc buttons

### DIFF
--- a/JoystickIn/JoystickIn/processUDP.c
+++ b/JoystickIn/JoystickIn/processUDP.c
@@ -40,6 +40,7 @@
 #define BUFLEN 21  //Max length of buffer
 #define PORT 5565   //The port on which to listen for incoming data
 
+#define SWITCH_COUNT 16
 
 int rc_received_yet = 0;
 int serialport = 0;
@@ -82,7 +83,7 @@ struct rcdata_s {
 	unsigned int chan7 : 11;
 	unsigned int chan8 : 11;
 	unsigned int Is16  : 8;
-        unsigned int switches : 16;
+        unsigned int switches : SWITCH_COUNT;
 } __attribute__ ((__packed__));
 struct rcdata_s rcdata;
 

--- a/JoystickIn/JoystickIn/processUDP.c
+++ b/JoystickIn/JoystickIn/processUDP.c
@@ -40,7 +40,6 @@
 #define BUFLEN 21  //Max length of buffer
 #define PORT 5565   //The port on which to listen for incoming data
 
-#define SWITCH_COUNT 16
 
 int rc_received_yet = 0;
 int serialport = 0;

--- a/RemoteSettings/Ground/helper/JoystickSender.c
+++ b/RemoteSettings/Ground/helper/JoystickSender.c
@@ -31,6 +31,7 @@
 #define BUFLEN 2  //Max length of buffer
 #define PORT 1260 //SettingsSync py script in
 
+#define SWITCH_COUNT 16
 
 static SDL_Joystick *js;
 char *ifname = NULL;
@@ -80,33 +81,31 @@ void readAxis(SDL_Event *event) {
 
 
 static int eventloop_joystick (void) {
-  SDL_Event event;
-  while (SDL_PollEvent (&event)) {
-    switch (event.type) {
-		case SDL_JOYAXISMOTION:
-			//printf ("Joystick %d, Axis %d moved to %d\n", event.jaxis.which, event.jaxis.axis, event.jaxis.value);
-			readAxis(&event);
-			return 2;
-			break;
-#ifdef	JSSWITCHES  // channels 9 - 16 as switches
-		case SDL_JOYBUTTONDOWN:
-			if (event.jbutton.button < JSSWITCHES) { // newer Taranis software can send 24 buttons - we use 16
-				rcData[8] |= 1 << event.jbutton.button;
-			}
-			return 5;
-			break;
-		case SDL_JOYBUTTONUP:
-			if (event.jbutton.button < JSSWITCHES) {
-				rcData[8] &= ~(1 << event.jbutton.button);
-			}
-			return 4;
-			break;
-#endif
+	SDL_Event event;
+	while (SDL_PollEvent (&event)) {
+		switch (event.type) {
+			case SDL_JOYAXISMOTION:
+				//printf ("Joystick %d, Axis %d moved to %d\n", event.jaxis.which, event.jaxis.axis, event.jaxis.value);
+				readAxis(&event);
+				return 2;
+				break;
+			case SDL_JOYBUTTONDOWN:
+				if (event.jbutton.button < SWITCH_COUNT) { // newer Taranis software can send 24 buttons - we use 16
+					rcData[8] |= 1 << event.jbutton.button;
+				}
+				return 5;
+				break;
+			case SDL_JOYBUTTONUP:
+				if (event.jbutton.button < SWITCH_COUNT) {
+					rcData[8] &= ~(1 << event.jbutton.button);
+				}
+				return 4;
+				break;
 			case SDL_QUIT:
-			return 0;
-    }
-    usleep(100);
-  }
+				return 0;
+		}
+		usleep(100);
+	}
   return 1;
 }
 

--- a/RemoteSettings/Ground/helper/JoystickSender.c
+++ b/RemoteSettings/Ground/helper/JoystickSender.c
@@ -19,6 +19,8 @@
 #include <sys/ipc.h>
 #include <sys/shm.h>
 
+#include "openhdlib.h"
+
 #define UPDATE_NTH_TIME 8 
 #define AXIS_INITIAL 1500
 
@@ -30,8 +32,6 @@
 #define SERVER "127.0.0.1"
 #define BUFLEN 2  //Max length of buffer
 #define PORT 1260 //SettingsSync py script in
-
-#define SWITCH_COUNT 16
 
 static SDL_Joystick *js;
 char *ifname = NULL;

--- a/RemoteSettings/Ground/helper/build.sh
+++ b/RemoteSettings/Ground/helper/build.sh
@@ -1,1 +1,1 @@
-gcc -lrt JoystickSender.c -o JoystickSender `sdl-config --libs` `sdl-config --cflags`
+gcc -lrt -I/home/pi/wifibroadcast-base JoystickSender.c -o JoystickSender `sdl-config --libs` `sdl-config --cflags`

--- a/wifibroadcast-base/openhdlib.h
+++ b/wifibroadcast-base/openhdlib.h
@@ -5,6 +5,7 @@
 #include "wifibroadcast.h"
 
 #define	MAX_PENUMBRA_INTERFACES 8
+#define SWITCH_COUNT 16
 
 
 typedef struct {

--- a/wifibroadcast-base/rx_rc_telemetry.c
+++ b/wifibroadcast-base/rx_rc_telemetry.c
@@ -87,7 +87,6 @@ wifibroadcast_rx_status_t_rc *rx_status_rc = NULL;
 uint16_t sumdcrc = 0;
 uint16_t ibuschecksum = 0;
 
-#define SWITCH_COUNT 16
 
 const uint16_t sumdcrc16_table[256] = {
     0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7, 0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,

--- a/wifibroadcast-base/rx_rc_telemetry_buf.c
+++ b/wifibroadcast-base/rx_rc_telemetry_buf.c
@@ -139,7 +139,7 @@ struct rcdata_s {
 	unsigned int chan6 : 11;
 	unsigned int chan7 : 11;
 	unsigned int chan8 : 11;
-	unsigned int switches : 16;
+	unsigned int switches : SWITCH_COUNT;
 } __attribute__ ((__packed__));
 struct rcdata_s rcdata;
 */

--- a/wifibroadcast-rc-Ath9k/airswitches.c
+++ b/wifibroadcast-rc-Ath9k/airswitches.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#define JSSWITCHES 16
+#define SWITCH_COUNT 16
 
 struct rcdata_s {
 	unsigned int chan1 : 11;
@@ -19,13 +19,11 @@ struct rcdata_s {
 	unsigned int chan6 : 11;
 	unsigned int chan7 : 11;
 	unsigned int chan8 : 11;
-	unsigned int switches : 16;
+	unsigned int switches : SWITCH_COUNT;
 } __attribute__ ((__packed__));
 
 
 void main (void) {
-#ifdef JSSWITCHES  // 
-
 //	uint16_t *rcdata = 0; // 
 	struct rcdata_s *rcdata = NULL;
 	void *retval;
@@ -40,9 +38,7 @@ void main (void) {
 	}
 	if (rcdata == NULL)	{	//Error
 		printf("-1\n");
-	} else
-		printf("%d\n",rcdata->switches);
-#else
-	printf("-1\n");
-#endif
+	} else {
+		printf("%d\n", rcdata->switches);
+	}
 }

--- a/wifibroadcast-rc-Ath9k/airswitches.c
+++ b/wifibroadcast-rc-Ath9k/airswitches.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#define SWITCH_COUNT 16
+#include "openhdlib.h"
 
 struct rcdata_s {
 	unsigned int chan1 : 11;

--- a/wifibroadcast-rc-Ath9k/rcswitches.c
+++ b/wifibroadcast-rc-Ath9k/rcswitches.c
@@ -7,10 +7,10 @@
 #include <sys/mman.h>
 #include <stdint.h>
 #include <string.h>
-#define JSSWITCHES 16
+#define SWITCH_COUNT 16
+
 //int main (int argc, char *argv[]) {
 void main (void) {
-#ifdef JSSWITCHES  // 
     int done = 1;
 	uint16_t *rcdata = 0; // 
 	void *retval;
@@ -26,9 +26,7 @@ void main (void) {
 	}
 	if (rcdata == 0)	{	//Error
 		printf("-1\n");
-	} else
+	} else {
 		printf("%d\n",rcdata[8]);
-#else
-	printf("-1\n");
-#endif
+	}
 }

--- a/wifibroadcast-rc-Ath9k/rcswitches.c
+++ b/wifibroadcast-rc-Ath9k/rcswitches.c
@@ -7,7 +7,8 @@
 #include <sys/mman.h>
 #include <stdint.h>
 #include <string.h>
-#define SWITCH_COUNT 16
+
+#include "openhdlib.h"
 
 //int main (int argc, char *argv[]) {
 void main (void) {

--- a/wifibroadcast-rc-Ath9k/rctx.c
+++ b/wifibroadcast-rc-Ath9k/rctx.c
@@ -71,8 +71,6 @@ static uint16_t validButton5 = 0;
 bool validButtons = false;
 int discardCounter = 0;							  
 
-#define SWITCH_COUNT 16
-
 uint16_t *rc_channels_memory_open(void) {
 	int fd = shm_open("/wifibroadcast_rc_channels", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 

--- a/wifibroadcast-rc-Ath9k/rctx.c
+++ b/wifibroadcast-rc-Ath9k/rctx.c
@@ -53,51 +53,48 @@ int PWMCount=0;
 int ActivateChannel=0;
 int IsTrimDone[8] =  { 0 };
 
-#ifdef JSSWITCHES  // 1 or 2 byte more for channels 9 - 16/24 as switches
+static uint16_t *rcData = NULL;
+static uint16_t lastValidCh0 = AXIS0_INITIAL; 
+static uint16_t lastValidCh1 = AXIS1_INITIAL; 
+static uint16_t lastValidCh2 = AXIS2_INITIAL; 
+static uint16_t lastValidCh3 = AXIS3_INITIAL; 
+static uint16_t lastValidCh4 = AXIS4_INITIAL; 
+static uint16_t lastValidCh5 = AXIS5_INITIAL; 
+static uint16_t lastValidCh6 = AXIS6_INITIAL; 
+static uint16_t lastValidCh7 = AXIS7_INITIAL; 
 
-	static uint16_t *rcData = NULL;
-    static uint16_t lastValidCh0 = AXIS0_INITIAL; 
-	static uint16_t lastValidCh1 = AXIS1_INITIAL; 
-	static uint16_t lastValidCh2 = AXIS2_INITIAL; 
-	static uint16_t lastValidCh3 = AXIS3_INITIAL; 
-	static uint16_t lastValidCh4 = AXIS4_INITIAL; 
-	static uint16_t lastValidCh5 = AXIS5_INITIAL; 
-	static uint16_t lastValidCh6 = AXIS6_INITIAL; 
-	static uint16_t lastValidCh7 = AXIS7_INITIAL; 
+static uint16_t validButton1 = 0;
+static uint16_t validButton2 = 0;
+static uint16_t validButton3 = 0;
+static uint16_t validButton4 = 0;
+static uint16_t validButton5 = 0;
+bool validButtons = false;
+int discardCounter = 0;							  
 
-	static uint16_t validButton1 = 0;
-	static uint16_t validButton2 = 0;
-	static uint16_t validButton3 = 0;
-	static uint16_t validButton4 = 0;
-	static uint16_t validButton5 = 0;
-	bool validButtons = false;
-	int discardCounter = 0;							  
+#define SWITCH_COUNT 16
 
-	uint16_t *rc_channels_memory_open(void) {
+uint16_t *rc_channels_memory_open(void) {
+	int fd = shm_open("/wifibroadcast_rc_channels", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 
-		int fd = shm_open("/wifibroadcast_rc_channels", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+	if (fd < 0) {
+		fprintf(stderr, "rc shm_open\n");
+		exit(1);
+	}
 
-		if(fd < 0) {
-			fprintf(stderr,"rc shm_open\n");
-			exit(1);
-		}
+	if (ftruncate(fd, 9 * sizeof(uint16_t)) == -1) {
+		fprintf(stderr, "rc ftruncate\n");
+		exit(1);
+	}
 
-		if (ftruncate(fd, 9 * sizeof(uint16_t)) == -1) {
-			fprintf(stderr,"rc ftruncate\n");
-			exit(1);
-		}
-
-		void *retval = mmap(NULL, 9 * sizeof(uint16_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-		if (retval == MAP_FAILED) {
-			fprintf(stderr,"rc mmap\n");
-			exit(1);
-		}
+	void *retval = mmap(NULL, 9 * sizeof(uint16_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (retval == MAP_FAILED) {
+		fprintf(stderr,"rc mmap\n");
+		exit(1);
+	}
 
 	return (uint16_t *)retval;
-	}
-#else
-	static uint16_t rcData[9]; // interval [1000;2000]
-#endif
+}
+
 
 static SDL_Joystick *js;
 char *ifname = NULL;
@@ -137,9 +134,7 @@ struct framedata_s {
     unsigned int chan6 : 11;
     unsigned int chan7 : 11;
     unsigned int chan8 : 11;
-#ifdef JSSWITCHES
-    unsigned int switches : JSSWITCHES; // 8 or 16 bits for rc channels 9 - 16/24  as switches
-#endif
+    unsigned int switches : SWITCH_COUNT; // 16 bits for rc channels 9 - 24  as switches
 } __attribute__ ((__packed__));
 
 struct framedata_s framedatas;
@@ -176,9 +171,8 @@ struct framedata_n {
     unsigned int chan6 : 11;
     unsigned int chan7 : 11;
     unsigned int chan8 : 11;
-#ifdef JSSWITCHES
-    unsigned int switches : JSSWITCHES; // 8 or 16 bits for rc channels 9 - 16/24  as switches
-#endif
+    unsigned int switches : SWITCH_COUNT; // 16 bits for rc channels 9 - 24  as switches
+
 } __attribute__ ((__packed__));
 
 struct framedata_n framedatan;
@@ -293,35 +287,33 @@ void readAxis(SDL_Event *event) {
 
 
 static int eventloop_joystick (void) {
-  SDL_Event event;
-  while (SDL_PollEvent (&event)) {
-    switch (event.type) {
-		case SDL_JOYAXISMOTION:
-			//printf ("Joystick %d, Axis %d moved to %d\n", event.jaxis.which, event.jaxis.axis, event.jaxis.value);
-			readAxis(&event);
-			return 2;
-			break;
-#ifdef	JSSWITCHES  // channels 9 - 16 as switches
-		case SDL_JOYBUTTONDOWN:
-			if (event.jbutton.button < JSSWITCHES) { // newer Taranis software can send 24 buttons - we use 16
-				rcData[8] |= 1 << event.jbutton.button;
-				validButton1 = rcData[8];			  
-			}
-			return 5;
-			break;
-		case SDL_JOYBUTTONUP:
-			if (event.jbutton.button < JSSWITCHES) {
-				rcData[8] &= ~(1 << event.jbutton.button);
-			}
-			return 4;
-			break;
-#endif
+	SDL_Event event;
+	while (SDL_PollEvent (&event)) {
+		switch (event.type) {
+			case SDL_JOYAXISMOTION:
+				//printf ("Joystick %d, Axis %d moved to %d\n", event.jaxis.which, event.jaxis.axis, event.jaxis.value);
+				readAxis(&event);
+				return 2;
+				break;
+			case SDL_JOYBUTTONDOWN:
+				if (event.jbutton.button < SWITCH_COUNT) { // newer Taranis software can send 24 buttons - we use 16
+					rcData[8] |= 1 << event.jbutton.button;
+					validButton1 = rcData[8];			  
+				}
+				return 5;
+				break;
+			case SDL_JOYBUTTONUP:
+				if (event.jbutton.button < SWITCH_COUNT) {
+					rcData[8] &= ~(1 << event.jbutton.button);
+				}
+				return 4;
+				break;
 			case SDL_QUIT:
-			return 0;
-    }
-    usleep(100);
-  }
-  return 1;
+				return 0;
+		}
+		usleep(100);
+	}
+	return 1;
 }
 
 void sendRC(unsigned char seqno, telemetry_data_t *td) {
@@ -337,10 +329,8 @@ void sendRC(unsigned char seqno, telemetry_data_t *td) {
     framedatas.chan6 = rcData[5];
     framedatas.chan7 = rcData[6];
     framedatas.chan8 = rcData[7];
-#ifdef JSSWITCHES
-	framedatas.switches = rcData[8];	/// channels 9 - 24 as switches
-//	printf ("rcdata0:%x\t",rcData[8]);
-#endif
+    framedatas.switches = rcData[8]; // channels 9 - 24 as switches
+
 //  printf ("rcdata0:%d\n",rcData[0]);
 
     framedatan.seqnumber = seqno;
@@ -352,10 +342,8 @@ void sendRC(unsigned char seqno, telemetry_data_t *td) {
     framedatan.chan6 = rcData[5];
     framedatan.chan7 = rcData[6];
     framedatan.chan8 = rcData[7];
-#ifdef JSSWITCHES
-	framedatan.switches = rcData[8];	/// channels 9 - 24 as switches
-//	printf ("rcdata0:%x\t",rcData[8]);
-#endif
+    framedatan.switches = rcData[8]; // channels 9 - 24 as switches
+
 //  printf ("rcdata0:%d\n",rcData[0]);
 
     int best_adapter = 0;
@@ -460,14 +448,9 @@ void packMessage(int seqno)
         messageRCEncrypt[16] = seqno & 0xFF;
         messageRCEncrypt[17] = seqno >> 8;
 	messageRCEncrypt[18] = 0;
-	#ifdef JSSWITCHES
-//      		framedatas.switches = rcData[8]; /// channels 9 - 24 as switches
-//      		framedatan.switches = rcData[8]; /// channels 9 - 24 as switches
-//        		printf ("rcdata0:%x\t",rcData[8]);
 	messageRCEncrypt[18] = 1;
 	messageRCEncrypt[19] = rcData[8] & 0xFF;
 	messageRCEncrypt[20] = rcData[8] >> 8;
-	#endif
 }
 
 void CheckTrimChannel(int Channel)
@@ -737,10 +720,9 @@ int main (int argc, char *argv[]) {
 
 	// we need to prefill channels since we have no values for them as
 	// long as the corresponding axis has not been moved yet
-#ifdef	JSSWITCHES
 	rcData = rc_channels_memory_open();
-	rcData[8]=0;		/// switches
-#endif
+	rcData[8] = 0; // switches
+
 	rcData[0]=AXIS0_INITIAL;
 	rcData[1]=AXIS1_INITIAL;
 	rcData[2]=AXIS2_INITIAL;
@@ -825,10 +807,8 @@ int main (int argc, char *argv[]) {
 			lastValidCh7 = rcData[7];
 			#endif
 
-#ifdef JSSWITCHES
 			validButton3 = validButton2;
 			validButton2 = validButton1;
-#endif
 
 			tmp = TrimChannel;
 			//fprintf(stderr, "TrimChannelPWMBefore: %d \n", rcData[tmp]);
@@ -843,7 +823,6 @@ int main (int argc, char *argv[]) {
 				        exit(1);
 				    }
 			    } else {
-					#ifdef JSSWITCHES
 				    if (validButton1 == validButton2 && validButton1 == validButton3 && validButton2 == validButton3) {
 					    sendRC(seqno, &td);
 					    validButton1 = rcData[8];
@@ -853,9 +832,6 @@ int main (int argc, char *argv[]) {
 					    printf("RC Blocks discarded: " "%" PRIu16 "\n", discardCounter);
 					    //printf("FAIL: " "%" PRIu16 "\n", rcData[8]);
 				    }
-					#else
-					sendRC(seqno, &td);
-					#endif
 			    }
 			    usleep(2000); // wait 2ms between sending multiple frames to lower collision probability
 		    }

--- a/wifibroadcast-rc-Ath9k/rctxUDP_IN.c
+++ b/wifibroadcast-rc-Ath9k/rctxUDP_IN.c
@@ -32,7 +32,6 @@
 #define PORT2 1258 //BandSwitch py script in
 #define PORT3 1259 //IP or USB camera switch py script in
 
-#define SWITCH_COUNT 16
 
 char messageRCEncrypt[40];   //Encrypted RC Message
 

--- a/wifibroadcast-rc-Ath9k/rctxUDP_IN.c
+++ b/wifibroadcast-rc-Ath9k/rctxUDP_IN.c
@@ -32,6 +32,7 @@
 #define PORT2 1258 //BandSwitch py script in
 #define PORT3 1259 //IP or USB camera switch py script in
 
+#define SWITCH_COUNT 16
 
 char messageRCEncrypt[40];   //Encrypted RC Message
 
@@ -42,36 +43,32 @@ int IsEncrypt = 0;
 int IsIPCameraSwitcherEnabled = 0;
 int IsBandSwitcherEnabled = 0;
 
-#ifdef JSSWITCHES  // 1 or 2 byte more for channels 9 - 16/24 as switches
+static uint16_t *rcData = NULL;
 
-	static uint16_t *rcData = NULL;
+uint16_t *rc_channels_memory_open(void) {
 
-	uint16_t *rc_channels_memory_open(void)
-	{
+	int fd = shm_open("/wifibroadcast_rc_channels", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 
-		int fd = shm_open("/wifibroadcast_rc_channels", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+	if (fd < 0) {
+		fprintf(stderr,"rc shm_open\n");
+		exit(1);
+	}
 
-		if(fd < 0) {
-			fprintf(stderr,"rc shm_open\n");
-			exit(1);
-		}
+	if (ftruncate(fd, 9 * sizeof(uint16_t)) == -1) {
+		fprintf(stderr,"rc ftruncate\n");
+		exit(1);
+	}
 
-		if (ftruncate(fd, 9 * sizeof(uint16_t)) == -1) {
-			fprintf(stderr,"rc ftruncate\n");
-			exit(1);
-		}
-
-		void *retval = mmap(NULL, 9 * sizeof(uint16_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-		if (retval == MAP_FAILED) {
-			fprintf(stderr,"rc mmap\n");
-			exit(1);
-		}
+	void *retval = mmap(NULL, 9 * sizeof(uint16_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	
+	if (retval == MAP_FAILED) {
+		fprintf(stderr,"rc mmap\n");
+		exit(1);
+	}
 
 	return (uint16_t *)retval;
-	}
-#else
-	static uint16_t rcData[8]; // interval [1000;2000]
-#endif
+}
+
 
 static SDL_Joystick *js;
 char *ifname = NULL;
@@ -112,7 +109,7 @@ struct framedata_s {
     unsigned int chan7 : 11;
     unsigned int chan8 : 11;
 
-    unsigned int switches : 16; // 8 or 16 bits for rc channels 9 - 16/24  as switches
+    unsigned int switches : SWITCH_COUNT; // 16 bits for rc channels 9 - 24  as switches
 
 } __attribute__ ((__packed__));
 
@@ -150,9 +147,7 @@ struct framedata_n {
     unsigned int chan6 : 11;
     unsigned int chan7 : 11;
     unsigned int chan8 : 11;
-#ifdef JSSWITCHES
-    unsigned int switches : JSSWITCHES; // 8 or 16 bits for rc channels 9 - 16/24  as switches
-#endif
+    unsigned int switches : SWITCH_COUNT; // 16 bits for rc channels 9 - 24 as switches
 } __attribute__ ((__packed__));
 
 struct framedata_n framedatan;
@@ -433,11 +428,8 @@ int main (int argc, char *argv[]) {
 
 	// we need to prefill channels since we have no values for them as
 	// long as the corresponding axis has not been moved yet
-#ifdef	JSSWITCHES
 	rcData = rc_channels_memory_open();
-	rcData[8]=0;		/// switches
-#endif
-
+	rcData[8] = 0;		/// switches
 
 
 	


### PR DESCRIPTION
The old code was hardcoding the RC struct memory layout on the air side as if the incoming RC packet data was 13 bytes long and contained data for 16 switches, ignoring the `JSSWITCHES` setting in `joyconfig.txt`.

The ground side however was honoring the setting and only sending the proper number of bits to the air side in RC packets.

The air side was therefore reading past the end of the packet in memory and sending garbage values to the flight controller.

Further, the settings file claimed you could send either 8 or 16 switches, but this was totally impossible as we are always sending 8 axis channels, leaving only another 10 possible for Mavlink and none of the other RC protocols were being given switch data at all.