### PR TITLE
Use separate variable for OSD hardware bitrate

### DIFF
--- a/wifibroadcast-scripts/global_functions.sh
+++ b/wifibroadcast-scripts/global_functions.sh
@@ -233,6 +233,7 @@ function datarate_to_wifi_settings {
 		UPLINK_WIFI_BITRATE=11
 		TELEMETRY_WIFI_BITRATE=11
 		VIDEO_WIFI_BITRATE=5.5
+		OSD_HW_BITRATE=5.5
                 if [ "$UseMCS" == "Y" ]; then
                         UseMCS="1"
                         VIDEO_WIFI_BITRATE="0"
@@ -244,6 +245,7 @@ function datarate_to_wifi_settings {
 		UPLINK_WIFI_BITRATE=11
 		TELEMETRY_WIFI_BITRATE=11
 		VIDEO_WIFI_BITRATE=11
+		OSD_HW_BITRATE=11
                 if [ "$UseMCS" == "Y" ]; then
                         UseMCS="1"
                         VIDEO_WIFI_BITRATE="1"
@@ -255,6 +257,7 @@ function datarate_to_wifi_settings {
 		UPLINK_WIFI_BITRATE=11
 		TELEMETRY_WIFI_BITRATE=12
 		VIDEO_WIFI_BITRATE=12
+		OSD_HW_BITRATE=12
                 if [ "$UseMCS" == "Y" ]; then
                         UseMCS="1"
                         VIDEO_WIFI_BITRATE="1"
@@ -266,6 +269,7 @@ function datarate_to_wifi_settings {
 		UPLINK_WIFI_BITRATE=11
 		TELEMETRY_WIFI_BITRATE=19.5
 		VIDEO_WIFI_BITRATE=19.5
+		OSD_HW_BITRATE=19.5
                 if [ "$UseMCS" == "Y" ]; then
                         UseMCS="1"
                         VIDEO_WIFI_BITRATE="2"
@@ -277,6 +281,7 @@ function datarate_to_wifi_settings {
 		UPLINK_WIFI_BITRATE=11
 		TELEMETRY_WIFI_BITRATE=24
 		VIDEO_WIFI_BITRATE=24
+		OSD_HW_BITRATE=24
                 if [ "$UseMCS" == "Y" ]; then
                         UseMCS="1"
                         VIDEO_WIFI_BITRATE="3"
@@ -288,6 +293,7 @@ function datarate_to_wifi_settings {
 		UPLINK_WIFI_BITRATE=12
 		TELEMETRY_WIFI_BITRATE=36
 		VIDEO_WIFI_BITRATE=36
+		OSD_HW_BITRATE=36
                 if [ "$UseMCS" == "Y" ]; then
                         UseMCS="1"
                         VIDEO_WIFI_BITRATE="4"

--- a/wifibroadcast-scripts/rx_functions.sh
+++ b/wifibroadcast-scripts/rx_functions.sh
@@ -71,12 +71,14 @@ function rx_function {
 
 	if [ "$VIDEO_WIFI_BITRATE" == "19.5" ]; then # set back to 18 to match air side in tx_functions.sh
 		VIDEO_WIFI_BITRATE=18
+		OSD_HW_BITRATE=18
     fi
     if [ "$VIDEO_WIFI_BITRATE" == "5.5" ]; then # set back to 6 to match air side logic in tx_functions.sh
 		VIDEO_WIFI_BITRATE=5
+		OSD_HW_BITRATE=5
     fi
 	# on the ground side this is read by the osd code so we can display it alongside the current/measured air datarate
-	echo $VIDEO_WIFI_BITRATE > /tmp/DATARATE.txt
+	echo $OSD_HW_BITRATE > /tmp/DATARATE.txt
 
     sleep 0.5
 


### PR DESCRIPTION
The `VIDEO_WIFI_BITRATE` variable isn't always a bitrate, on 8812 cards it's an MCS index. We should leave that alone and simply use another variable for the OSD display.