### PR TITLE
Fix draw_TOTAL_DISTANCE, value is already KM/h

### DIFF
--- a/wifibroadcast-osd/render.c
+++ b/wifibroadcast-osd/render.c
@@ -1331,7 +1331,7 @@ void draw_TOTAL_AMPS(float current, float pos_x, float pos_y, float scale){
     Text(getWidth(pos_x), getHeight(pos_y), " mAh", myfont, text_scale*0.6);
  
 }
-void draw_TOTAL_DIST(int gpsspeed, float pos_x, float pos_y, float scale){
+void draw_TOTAL_DIST(double kmh, float pos_x, float pos_y, float scale){
     Stroke(OUTLINECOLOR);
     Fill(COLOR);
  
@@ -1339,11 +1339,9 @@ void draw_TOTAL_DIST(int gpsspeed, float pos_x, float pos_y, float scale){
     long time_diff = current_ts() - dist_ts;
     dist_ts = current_ts();
 
-    float _kmh = (float)gpsspeed * 3.6;
-
     float _hours = (float)time_diff / (float)3600000;
 
-    float added_distance = _kmh * _hours;
+    float added_distance = kmh * _hours;
 
     total_dist = total_dist + added_distance;
  

--- a/wifibroadcast-osd/render.h
+++ b/wifibroadcast-osd/render.h
@@ -52,7 +52,7 @@ void draw_batt_status(float voltage, float current, float pos_x, float pos_y, fl
 
 // totals
 void draw_TOTAL_AMPS(float current, float pos_x, float pos_y, float scale);
-void draw_TOTAL_DIST(int gpsspeed, float pos_x, float pos_y, float scale);
+void draw_TOTAL_DIST(double kmh, float pos_x, float pos_y, float scale);
 void draw_TOTAL_TIME(float fly_time, float pos_x, float pos_y, float scale); 
 
 void draw_position(float lat, float lon, float pos_x, float pos_y, float scale);


### PR DESCRIPTION
The telemetry code for each protocol is already standardizing the value of the gps speed to KM/h so the 3.6 multiplication is already being done elsewhere.

This changes the function signature to properly document the unit of the variable.

This partially reverts 340b8aad858d807a31873a994b2ed4243703a27d

Closes: #263