### PR TITLE
Use flight mode functions ported from QOpenHD

### DIFF
--- a/wifibroadcast-osd/Makefile
+++ b/wifibroadcast-osd/Makefile
@@ -8,7 +8,7 @@ all: osd
 /tmp/%.o: %.c
 	gcc $(CFLAGS) -c -o $@ $< $(CPPFLAGS)
 
-osd: /tmp/main.o /tmp/render.o /tmp/telemetry.o /tmp/frsky.o /tmp/ltm.o /tmp/mavlink.o /tmp/smartport.o /tmp/vot.o
+osd: /tmp/main.o /tmp/render.o /tmp/telemetry.o /tmp/flightmode.o /tmp/frsky.o /tmp/ltm.o /tmp/mavlink.o /tmp/smartport.o /tmp/vot.o
 	gcc -o /tmp/$@ $^ $(LDFLAGS)
 
 clean:

--- a/wifibroadcast-osd/flightmode.c
+++ b/wifibroadcast-osd/flightmode.c
@@ -1,0 +1,393 @@
+#include <stdint.h>
+
+#include "flightmode.h"
+
+#include <openhd/mavlink.h>
+
+
+char * sub_mode_from_enum(SUB_MODE mode) {
+    switch (mode) {
+       case SUB_MODE_MANUAL:
+            return "MAN";
+       case SUB_MODE_ACRO:
+            return "ACRO";
+       case SUB_MODE_AUTO:
+            return "AUTO";
+       case SUB_MODE_GUIDED:
+            return "GUIDED";
+       case SUB_MODE_STABILIZE:
+            return "STAB";
+       case SUB_MODE_ALT_HOLD:
+            return "ALTHOLD";
+       case SUB_MODE_CIRCLE:
+            return "CIRCLE";
+       case SUB_MODE_SURFACE:
+            return "SURFACE";
+       case SUB_MODE_POSHOLD:
+            return "POSHOLD";
+    }
+    return "-----";
+}
+
+char * rover_mode_from_enum(ROVER_MODE mode) {
+    switch (mode) {
+       case ROVER_MODE_HOLD:
+            return "HOLD";
+       case ROVER_MODE_MANUAL:
+            return "MANUAL";
+       case ROVER_MODE_STEERING:
+            return "STEER";
+       case ROVER_MODE_INITIALIZING:
+            return "INIT";
+       case ROVER_MODE_SMART_RTL:
+            return "SMRTL";
+       case ROVER_MODE_ACRO:
+            return "ACRO";
+       case ROVER_MODE_AUTO:
+            return "AUTO";
+       case ROVER_MODE_RTL:
+            return "RTL";
+       case ROVER_MODE_LOITER:
+            return "LOITER";
+       case ROVER_MODE_GUIDED:
+            return "GUIDED";
+    }
+    return "-----";
+}
+
+char * chinese_copter_mode_from_enum(COPTER_MODE mode) {
+    switch (mode) {
+        case COPTER_MODE_STABILIZE: 
+            return "自   稳"; 
+        case COPTER_MODE_ACRO: 
+            return "特   技"; 
+        case COPTER_MODE_ALT_HOLD: 
+            return "定   高"; 
+        case COPTER_MODE_AUTO: 
+            return "自   动"; 
+        case COPTER_MODE_GUIDED: 
+            return "指   引"; 
+        case COPTER_MODE_LOITER: 
+            return "悬   停"; 
+        case COPTER_MODE_RTL: 
+            return "返   航"; 
+        case COPTER_MODE_CIRCLE: 
+            return "绕   圈"; 
+        case COPTER_MODE_LAND: 
+            return "降   落"; 
+        case COPTER_MODE_DRIFT: 
+            return "漂   移"; 
+        case COPTER_MODE_SPORT: 
+            return "运   动"; 
+        case COPTER_MODE_FLIP: 
+            return "翻   滚"; 
+        case COPTER_MODE_AUTOTUNE: 
+            return "自 动 调 参"; 
+        case COPTER_MODE_POSHOLD: 
+            return "定   点"; 
+        case COPTER_MODE_BRAKE: 
+            return "制   动"; 
+        case COPTER_MODE_THROW: 
+            return "抛   飞"; 
+        case COPTER_MODE_AVOID_ADSB: 
+            return "避   障"; 
+        case COPTER_MODE_GUIDED_NOGPS: 
+            return "无 GPS 指 引"; 
+        case COPTER_MODE_SMART_RTL:
+            return "SMARTRTL";
+    }
+    return "-----";
+}
+
+char * copter_mode_from_enum(COPTER_MODE mode) {
+    switch (mode) {
+       case COPTER_MODE_LAND:
+            return "LAND";
+       case COPTER_MODE_FLIP:
+            return "FLIP";
+       case COPTER_MODE_BRAKE:
+            return "BRAKE";
+       case COPTER_MODE_DRIFT:
+            return "DRIFT";
+       case COPTER_MODE_SPORT:
+            return "SPORT";
+       case COPTER_MODE_THROW:
+            return "THROW";
+       case COPTER_MODE_POSHOLD:
+            return "POSHOLD";
+       case COPTER_MODE_ALT_HOLD:
+            return "ALTHOLD";
+       case COPTER_MODE_SMART_RTL:
+            return "SMRTL";
+       case COPTER_MODE_GUIDED_NOGPS:
+            return "GUIDEDNOGPS";
+       case COPTER_MODE_CIRCLE:
+            return "CIRCLE";
+       case COPTER_MODE_STABILIZE:
+            return "STAB";
+       case COPTER_MODE_ACRO:
+            return "ACRO";
+       case COPTER_MODE_AUTOTUNE:
+            return "AUTOTUNE";
+       case COPTER_MODE_AUTO:
+            return "AUTO";
+       case COPTER_MODE_RTL:
+            return "RTL";
+       case COPTER_MODE_LOITER:
+            return "LOITER";
+       case COPTER_MODE_AVOID_ADSB:
+            return "AVOIDADSB";
+       case COPTER_MODE_GUIDED:
+            return "GUIDED";
+    }
+    return "-----";
+}
+
+char * chinese_plane_mode_from_enum(PLANE_MODE mode) {
+    switch (mode) {
+        case PLANE_MODE_MANUAL:
+            return "手   动";
+        case PLANE_MODE_CIRCLE:
+            return "盘   旋";
+        case PLANE_MODE_STABILIZE:
+            return "自   稳";
+        case PLANE_MODE_TRAINING:
+            return "教   练";
+        case PLANE_MODE_ACRO:
+            return "特   技";
+        case PLANE_MODE_FLY_BY_WIRE_A:
+            return "自   稳";
+        case PLANE_MODE_FLY_BY_WIRE_B:
+            return "自 稳 定 高";
+        case PLANE_MODE_CRUISE:
+            return "巡   航";
+        case PLANE_MODE_AUTOTUNE:
+            return "自 动 调 参";
+        case PLANE_MODE_AUTO:
+            return "自   动";
+        case PLANE_MODE_RTL:
+            return "返   航";
+        case PLANE_MODE_LOITER:
+            return "定   点";
+        case PLANE_MODE_TAKEOFF:
+            return "TAKEOFF";
+        case PLANE_MODE_AVOID_ADSB:
+            return "AVOIDADSB";
+        case PLANE_MODE_GUIDED:
+            return "指   引";
+        case PLANE_MODE_INITIALIZING:
+            return "INIT";
+        case PLANE_MODE_QSTABILIZE:
+            return "QSTAB";
+        case PLANE_MODE_QHOVER:
+            return "QHOVER";
+        case PLANE_MODE_QLOITER:
+            return "QLOITER";
+        case PLANE_MODE_QLAND:
+            return "QLAND";
+        case PLANE_MODE_QRTL:
+            return "QRTL";
+        case PLANE_MODE_QAUTOTUNE:
+            return "QAUTOTUNE";
+    }
+    return "-----";
+}
+
+char * plane_mode_from_enum(PLANE_MODE mode) {
+    switch (mode) {
+        case PLANE_MODE_MANUAL:
+            return "MAN";
+        case PLANE_MODE_CIRCLE:
+            return "CIRCLE";
+        case PLANE_MODE_STABILIZE:
+            return "STAB";
+        case PLANE_MODE_TRAINING:
+            return "TRAIN";
+        case PLANE_MODE_ACRO:
+            return "ACRO";
+        case PLANE_MODE_FLY_BY_WIRE_A:
+            return "FBWA";
+        case PLANE_MODE_FLY_BY_WIRE_B:
+            return "FBWB";
+        case PLANE_MODE_CRUISE:
+            return "CRUISE";
+        case PLANE_MODE_AUTOTUNE:
+            return "AUTOTUNE";
+        case PLANE_MODE_AUTO:
+            return "AUTO";
+        case PLANE_MODE_RTL:
+            return "RTL";
+        case PLANE_MODE_LOITER:
+            return "LOITER";
+        case PLANE_MODE_TAKEOFF:
+            return "TAKEOFF";
+        case PLANE_MODE_AVOID_ADSB:
+            return "AVOIDADSB";
+        case PLANE_MODE_GUIDED:
+            return "GUIDED";
+        case PLANE_MODE_INITIALIZING:
+            return "INIT";
+        case PLANE_MODE_QSTABILIZE:
+            return "QSTAB";
+        case PLANE_MODE_QHOVER:
+            return "QHOVER";
+        case PLANE_MODE_QLOITER:
+            return "QLOITER";
+        case PLANE_MODE_QLAND:
+            return "QLAND";
+        case PLANE_MODE_QRTL:
+            return "QRTL";
+        case PLANE_MODE_QAUTOTUNE:
+            return "QAUTOTUNE";
+    }
+    return "-----";
+}
+
+char * tracker_mode_from_enum(TRACKER_MODE mode) {
+    switch (mode) {
+       case TRACKER_MODE_MANUAL:
+            return "MAN";
+       case TRACKER_MODE_STOP:
+            return "STOP";
+       case TRACKER_MODE_SCAN:
+            return "SCAN";
+       case TRACKER_MODE_SERVO_TEST:
+            return "SERVOTEST";
+       case TRACKER_MODE_AUTO:
+            return "AUTO";
+       case TRACKER_MODE_INITIALIZING:
+            return "INIT";
+    }
+    return "-----";
+}
+
+char * vot_mode_from_telemetry(uint8_t mode) {
+    switch (mode) {
+        case 0:
+            return "2D";
+        case 1:
+            return "2DAH";
+        case 2:
+            return "2DHH";
+        case 3:
+            return "2DAHH";
+        case 4:
+            return "LOITER";
+        case 5:
+            return "3D";
+        case 6:
+            return "3DHH";
+        case 7:
+            return "RTH";
+        case 8:
+            return "LAND";
+        case 9:
+            return "CART";
+        case 10:
+            return "CARTLOI";
+        case 11:
+            return "POLAR";
+        case 12:
+            return "POLARLOI";
+        case 13:
+            return "CENTERSTICK";
+        case 14:
+            return "OFF";
+        case 15:
+            return "WAYPOINT";
+        case 16:
+            return "MAX";
+    }
+    return "-----";
+}
+
+
+char * chinese_ltm_mode_from_telem(int mode) {
+    switch (mode) {
+        case 0:
+            return "手   动";
+        case 1:
+            return "RATE";
+        case 2:
+            return "自   稳";
+        case 3:
+            return "半 自 稳";
+        case 4:
+            return "特   技";
+        case 5:
+            return "自 稳 1";
+        case 6:
+            return "自 稳 2";
+        case 7:
+            return "自 稳 3";
+        case 8:
+            return "定   高";
+        case 9:
+            return "GPS 定点";
+        case 10:
+            return "自   动";
+        case 11:
+            return "无   头";
+        case 12:
+            return "绕   圈";
+        case 13:
+            return "返   航";
+        case 14:
+            return "跟   随";
+        case 15:
+            return "降   落";
+        case 16:
+            return "线 性 增 稳";
+        case 17:
+            return "增 稳 定 高";
+        case 18:
+            return "巡   航";
+    }
+    return "-----";
+}
+
+
+char * ltm_mode_from_telem(int mode) {
+    switch (mode) {
+        case 0:
+            return "MAN";
+        case 1:
+            return "RATE";
+        case 2:
+            return "ANGLE";
+        case 3:
+            return "HORIZON";
+        case 4:
+            return "ACRO";
+        case 5:
+            return "STAB1";
+        case 6:
+            return "STAB2";
+        case 7:
+            return "STAB3";
+        case 8:
+            return "ALTHOLD";
+        case 9:
+            return "GPSHOLD";
+        case 10:
+            return "WAY";
+        case 11:
+            return "HEADFREE";
+        case 12:
+            return "CIRCLE";
+        case 13:
+            return "RTH";
+        case 14:
+            return "FOLLOWME";
+        case 15:
+            return "LAND";
+        case 16:
+            return "FBWA";
+        case 17:
+            return "FBWB";
+        case 18:
+            return "CRUISE";
+    }
+    return "-----";
+}
+

--- a/wifibroadcast-osd/flightmode.h
+++ b/wifibroadcast-osd/flightmode.h
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+
+#include <openhd/mavlink.h>
+
+
+char * sub_mode_from_enum(SUB_MODE mode);
+
+char * rover_mode_from_enum(ROVER_MODE mode);
+
+char * copter_mode_from_enum(COPTER_MODE mode);
+
+char * plane_mode_from_enum(PLANE_MODE mode);
+
+char * tracker_mode_from_enum(TRACKER_MODE mode);
+
+char * vot_mode_from_telemetry(uint8_t mode);
+
+char * ltm_mode_from_telem(int mode);
+

--- a/wifibroadcast-osd/render.c
+++ b/wifibroadcast-osd/render.c
@@ -24,6 +24,8 @@
 #include "telemetry.h"
 #include "osdconfig.h"
 
+#include "flightmode.h"
+
 #define TO_FEET 3.28084
 #define TO_MPH 0.621371
 #define CELL_WARNING_PCT1 (CELL_WARNING1-CELL_MIN)/(CELL_MAX-CELL_MIN)*100
@@ -43,7 +45,9 @@ bool home_set;
 float home_lat;
 float home_lon;
 int home_counter;
-char buffer[40];
+
+#define TEXT_BUFFER_SIZE 40
+char buffer[TEXT_BUFFER_SIZE];
 Fontinfo myfont, osdicons;
 
 int packetslost_last[6];
@@ -636,103 +640,18 @@ void render(telemetry_data_t_osd *td, uint8_t cpuload_gnd, uint8_t temp_gnd, uin
 
     #ifdef VOT
 
-        void draw_mode(int mode, int armed, float pos_x, float pos_y, float scale){
+        void draw_mode(int mode, int armed, float pos_x, float pos_y, float scale) {
             /* 
              * Flight modes Eagletree Vector
              */
             float text_scale = getWidth(2) * scale;
 
-            switch (mode) {
-                case 0: { 
-                    sprintf(buffer, "2D"); 
+            char *fmode = vot_mode_from_telemetry(mode);
 
-                    break;
-                }
-                case 1: {
-                    sprintf(buffer, "2DAH"); 
-
-                    break;
-                }
-                case 2: {
-                    sprintf(buffer, "2DHH"); 
-
-                    break;
-                }
-                case 3: {
-                    sprintf(buffer, "2DAHH"); 
-
-                    break;
-                }
-                case 4: {
-                    sprintf(buffer, "LOITER"); 
-
-                    break;
-                }
-                case 5: {
-                    sprintf(buffer, "3D"); 
-
-                    break;
-                }
-                case 6: {
-                    sprintf(buffer, "3DHH"); 
-
-                    break;
-                }
-                case 7: {
-                    sprintf(buffer, "RTH"); 
-
-                    break;
-                }
-                case 8: {
-                    sprintf(buffer, "LAND");
-
-                    break;
-                }
-                case 9: {
-                    sprintf(buffer, "CART"); 
-
-                    break;
-                }
-                case 10: {
-                    sprintf(buffer, "CARTLOI"); 
-
-                    break;
-                }
-                case 11: {
-                    sprintf(buffer, "POLAR"); 
-
-                    break;
-                }
-                case 12: {
-                    sprintf(buffer, "POLARLOI"); 
-
-                    break;
-                }
-                case 13: {
-                    sprintf(buffer, "CENTERSTICK"); 
-
-                    break;
-                }
-                case 14: {
-                    sprintf(buffer, "OFF"); 
-
-                    break;
-                }
-                case 15: {
-                    sprintf(buffer, "WAYPOINT"); 
-
-                    break;
-                }
-                case 16: {
-                    sprintf(buffer, "MAX"); 
-
-                    break;
-                }
-                default: {
-                    sprintf(buffer, "-----"); 
-
-                    break;
-                }
+            if (armed == 1) {
+                sprintf(buffer, "[%s]", fmode);
+            } else {
+                sprintf(buffer, "%s", fmode);
             }
 
             TextMid(getWidth(pos_x), getHeight(pos_y), buffer, myfont, text_scale);
@@ -742,215 +661,33 @@ void render(telemetry_data_t_osd *td, uint8_t cpuload_gnd, uint8_t temp_gnd, uin
 
 
     #ifdef LTM
-        void draw_ltmmode(int mode, int armed, int failsafe, float pos_x, float pos_y, float scale){
+        void draw_ltmmode(int mode, int armed, int failsafe, float pos_x, float pos_y, float scale) {
             float text_scale = getWidth(2) * scale;
             
-            sprintf(buffer, "[-----]");
-
-            if (armed == 0) {
-                switch (mode) {
-                    case 0: {
-                        sprintf(buffer, "[手   动]"); 
-
-                        break;
-                    }
-                    case 1: {
-                        sprintf(buffer, "[RATE]"); 
-
-                        break;
-                    }
-                    case 2: {
-                        sprintf(buffer, "[自   稳]");  
-                         
-                        break;
-                    }
-                    }
-                    case 3: {
-                        sprintf(buffer, "[半 自 稳]");  
-
-                        break;
-                    }
-                    case 4: {
-                        sprintf(buffer, "[特   技]");  
-
-                        break;
-                    }
-                    case 5: {
-                        sprintf(buffer, "[自 稳 1]"); 
-
-                        break;
-                    }
-                    case 6: {
-                        sprintf(buffer, "[自 稳 2]"); 
-
-                        break;
-                    }
-                    case 7: {
-                        sprintf(buffer, "[自 稳 3]"); 
-
-                        break;
-                    }
-                    case 8: {
-                        sprintf(buffer, "[定   高]");  
-                        break;
-                    }
-                    case 9: {
-                        sprintf(buffer, "[GPS 定点]"); 
-                        break;
-                    }
-                    case 10: {
-                        sprintf(buffer, "[自   动]"); 
-                        break;
-                    }
-                    case 11: {
-                        sprintf(buffer, "[无   头]"); 
-                        break;
-                    }
-                    case 12: {
-                        sprintf(buffer, "[绕   圈]"); 
-                        break;
-                    }
-                    case 13: {
-                        sprintf(buffer, "[返   航]"); 
-                        break;
-                    }
-                    case 14: {
-                        sprintf(buffer, "[跟   随]"); 
-                        break;
-                    }
-                    case 15: {
-                        sprintf(buffer, "[降   落]"); 
-                        break;
-                    }
-                    case 16: {
-                        sprintf(buffer, "[线 性 增 稳]"); 
-                        break;
-                    }
-                    case 17: {
-                        sprintf(buffer, "[增 稳 定 高]"); 
-                        break;
-                    }
-                    case 18: {
-                        sprintf(buffer, "[巡   航]"); 
-                        break;
-                    }
-                    default: {
-                        break;
-                    }
-                }
-            } else  {
-                switch (mode) {
-                    case 0: {
-                        sprintf(buffer, "手   动"); 
-
-                        break;
-                    }
-                    case 1: {
-                        sprintf(buffer, "RATE"); 
-
-                        break;
-                    }
-                    case 2: {
-                        sprintf(buffer, "自   稳"); 
-
-                        break;
-                    }
-                    case 3: {
-                        sprintf(buffer, "半 自 稳"); 
-
-                        break;
-                    }
-                    case 4: {
-                        sprintf(buffer, "特   技"); 
-
-                        break;
-                    }
-                    case 5: {
-                        sprintf(buffer, "自 稳 1"); 
-
-                        break;
-                    }
-                    case 6: {
-                        sprintf(buffer, "自 稳 2"); 
-
-                        break;
-                    }
-                    case 7: {
-                        sprintf(buffer, "自 稳 3"); 
-
-                        break;
-                    } 
-                    case 8: {
-                        sprintf(buffer, "定   高"); 
-
-                        break;
-                    }
-                    case 9: {
-                        sprintf(buffer, "GPS 定点"); 
-
-                        break;
-                    }
-                    case 10: {
-                        sprintf(buffer, "自   动"); 
-
-                        break;
-                    }
-                    case 11: {
-                        sprintf(buffer, "无   头"); 
-
-                        break;
-                    }
-                    case 12: {
-                        sprintf(buffer, "绕   圈"); 
-
-                        break;
-                    }
-                    case 13: {
-                        sprintf(buffer, "返   航"); 
-
-                        break;
-                    }
-                    case 14: {
-                        sprintf(buffer, "跟   随"); 
-
-                        break;
-                    }
-                    case 15: {
-                        sprintf(buffer, "降   落"); 
-
-                        break;
-                    }
-                    case 16: {
-                        sprintf(buffer, "线 性 增 稳"); 
-
-                        break;
-                    }
-                    case 17: {
-                        sprintf(buffer, "增 稳 定 高"); 
-
-                        break;
-                    }
-                    case 18: {
-                        sprintf(buffer, "巡   航"); 
-
-                        break;
-                    }
-                    default: {
-                        break;
-                    }
-                }
-            }  
+            #if CHINESE == true
+                char *fmode = chinese_ltm_mode_from_telem((COPTER_MODE)mode);
+            #else
+                char *fmode = ltm_mode_from_telem((COPTER_MODE)mode);
+            #endif
             
             if (failsafe == 1) {
                 sprintf(buffer, "失 控 保 护");
+            } else {
+                if (armed == 1) {
+                    sprintf(buffer, "[%s]", fmode);
+                } else {
+                    sprintf(buffer, "%s", fmode);
+                }
             }
             
             TextMid(getWidth(pos_x), getHeight(pos_y), buffer, myfont, text_scale);
         } 
     #endif
 
+    #define MAVLINK
+
     #ifdef MAVLINK
-        void draw_mode(int mode, int armed, float pos_x, float pos_y, float scale){
+        void draw_mode(int mode, int armed, float pos_x, float pos_y, float scale) {
             /*
              * Autopilot mode, mavlink specific, could be used if mode is in telemetry data of other protocols as well
              */
@@ -959,197 +696,24 @@ void render(telemetry_data_t_osd *td, uint8_t cpuload_gnd, uint8_t temp_gnd, uin
             Fill(COLOR);
             Stroke(OUTLINECOLOR);
 
+            #if COPTER == true
+                #if CHINESE == true
+                    char *fmode = chinese_copter_mode_from_enum((COPTER_MODE)mode);
+                #else
+                    char *fmode = copter_mode_from_enum((COPTER_MODE)mode);
+                #endif
+            #else
+                #if CHINESE == true
+                    char *fmode = chinese_plane_mode_from_enum((PLANE_MODE)mode);
+                #else
+                    char *fmode = plane_mode_from_enum((PLANE_MODE)mode);
+                #endif
+            #endif
+            
             if (armed == 1) {
-                switch (mode) {
-                    #if COPTER == true
-                        #if CHINESE == true
-                            case 0: sprintf(buffer, "自   稳"); break;
-                            case 1: sprintf(buffer, "特   技"); break;
-                            case 2: sprintf(buffer, "定   高"); break;
-                            case 3: sprintf(buffer, "自   动"); break;
-                            case 4: sprintf(buffer, "指   引"); break;
-                            case 5: sprintf(buffer, "悬   停"); break;
-                            case 6: sprintf(buffer, "返   航"); break;
-                            case 7: sprintf(buffer, "绕   圈"); break;
-                            case 9: sprintf(buffer, "降   落"); break;
-                            case 11: sprintf(buffer, "漂   移"); break;
-                            case 13: sprintf(buffer, "运   动"); break;
-                            case 14: sprintf(buffer, "翻   滚"); break;
-                            case 15: sprintf(buffer, "自 动 调 参"); break;
-                            case 16: sprintf(buffer, "定   点"); break;
-                            case 17: sprintf(buffer, "制   动"); break;
-                            case 18: sprintf(buffer, "抛   飞"); break;
-                            case 19: sprintf(buffer, "避   障"); break;
-                            case 20: sprintf(buffer, "无 GPS 指 引"); break;
-                            case 255: sprintf(buffer, "-----"); break;
-                        #else
-                            case 0: sprintf(buffer, "STAB"); break;
-                            case 1: sprintf(buffer, "ACRO"); break;
-                            case 2: sprintf(buffer, "ALTHOLD"); break;
-                            case 3: sprintf(buffer, "AUTO"); break;
-                            case 4: sprintf(buffer, "GUIDED"); break;
-                            case 5: sprintf(buffer, "LOITER"); break;
-                            case 6: sprintf(buffer, "RTL"); break;
-                            case 7: sprintf(buffer, "CIRCLE"); break;
-                            case 9: sprintf(buffer, "LAND"); break;
-                            case 11: sprintf(buffer, "DRIFT"); break;
-                            case 13: sprintf(buffer, "SPORT"); break;
-                            case 14: sprintf(buffer, "FLIP"); break;
-                            case 15: sprintf(buffer, "AUTOTUNE"); break;
-                            case 16: sprintf(buffer, "POSHOLD"); break;
-                            case 17: sprintf(buffer, "BRAKE"); break;
-                            case 18: sprintf(buffer, "THROW"); break;
-                            case 19: sprintf(buffer, "AVOIDADSB"); break;
-                            case 20: sprintf(buffer, "GUIDEDNOGPS"); break;
-                            case 255: sprintf(buffer, "-----"); break;
-                        #endif
-                    #else       
-                        #if CHINESE == true
-                            case 0: sprintf(buffer, "手   动"); break;
-                            case 1: sprintf(buffer, "盘   旋"); break;
-                            case 2: sprintf(buffer, "自   稳"); break;
-                            case 3: sprintf(buffer, "教   练"); break;
-                            case 4: sprintf(buffer, "特   技"); break;
-                            //case 5: sprintf(buffer, "半 自 稳"); break;
-                            case 5: sprintf(buffer, "自   稳"); break;
-                            case 6: sprintf(buffer, "自 稳 定 高"); break;
-                            case 7: sprintf(buffer, "巡   航"); break;
-                            case 8: sprintf(buffer, "自 动 调 参"); break;
-                            case 10: sprintf(buffer, "自   动"); break;
-                            case 11: sprintf(buffer, "返   航"); break;
-                            case 12: sprintf(buffer, "定   点"); break;
-                            //case 15: sprintf(buffer, "抛   飞"); break;
-                            case 15: sprintf(buffer, "指   引"); break;
-                            //case 16: sprintf(buffer, "失 控 保 护"); break;
-                            case 16: sprintf(buffer, "INIT"); break;
-                            case 255: sprintf(buffer, "-----"); break;
-                        #else
-                            case 0: sprintf(buffer, "MAN"); break;
-                            case 1: sprintf(buffer, "CIRC"); break;
-                            case 2: sprintf(buffer, "STAB"); break;
-                            case 3: sprintf(buffer, "TRAI"); break;
-                            case 4: sprintf(buffer, "ACRO"); break;
-                            case 5: sprintf(buffer, "FBWA"); break;
-                            case 6: sprintf(buffer, "FBWB"); break;
-                            case 7: sprintf(buffer, "CRUZ"); break;
-                            case 8: sprintf(buffer, "TUNE"); break;
-                            case 10: sprintf(buffer, "AUTO"); break;
-                            case 11: sprintf(buffer, "RTL"); break;
-                            case 12: sprintf(buffer, "LOIT"); break;
-                            case 13: sprintf(buffer, "TAKE"); break;
-                            case 15: sprintf(buffer, "GUID"); break;
-                            case 16: sprintf(buffer, "INIT"); break;
-                            case 17: sprintf(buffer, "Q-STAB"); break;
-                            case 18: sprintf(buffer, "Q-HOVR"); break;
-                            case 19: sprintf(buffer, "Q-LOIT"); break;
-                            case 20: sprintf(buffer, "Q-LAND"); break;
-                            case 21: sprintf(buffer, "Q-RTL"); break;
-                            case 23: sprintf(buffer, "Q-ACRO"); break;
-                            case 255: sprintf(buffer, "-----"); break;
-                        #endif
-                    #endif
-                    /*
-                     * TODO: find out why strange numbers when using zs6bujs telemetry logs, default to 
-                     * something more sensible like "unknown mode"
-                     *
-                     */
-                    default: sprintf(buffer, "-----"); break; 
-                }
+                sprintf(buffer, "[%s]", fmode);
             } else {
-                switch (mode) {
-                    #if COPTER == true
-                        #if CHINESE == true
-                            case 0: sprintf(buffer, "[自   稳]"); break;
-                            case 1: sprintf(buffer, "[特   技]"); break;
-                            case 2: sprintf(buffer, "[定   高]"); break;
-                            case 3: sprintf(buffer, "[自   动]"); break;
-                            case 4: sprintf(buffer, "[指   引]"); break;
-                            case 5: sprintf(buffer, "[悬   停]"); break;
-                            case 6: sprintf(buffer, "[返   航]"); break;
-                            case 7: sprintf(buffer, "[绕   圈]"); break;
-                            case 9: sprintf(buffer, "[降   落]"); break;
-                            case 11: sprintf(buffer, "[漂   移]"); break;
-                            case 13: sprintf(buffer, "[运   动]"); break;
-                            case 14: sprintf(buffer, "[翻   滚]"); break;
-                            case 15: sprintf(buffer, "[自 动 调 参]"); break;
-                            case 16: sprintf(buffer, "[定   点]"); break;
-                            case 17: sprintf(buffer, "[制   动]"); break;
-                            case 18: sprintf(buffer, "[抛   飞]"); break;
-                            case 19: sprintf(buffer, "[避   障]"); break;
-                            case 20: sprintf(buffer, "[无 GPS 指 引]"); break;
-                            case 255: sprintf(buffer, "[-----]"); break;
-                        #else
-                            case 0: sprintf(buffer, "[STAB]"); break;
-                            case 1: sprintf(buffer, "[ACRO]"); break;
-                            case 2: sprintf(buffer, "[ALTHOLD]"); break;
-                            case 3: sprintf(buffer, "[AUTO]"); break;
-                            case 4: sprintf(buffer, "[GUID]"); break;
-                            case 5: sprintf(buffer, "[LOIT]"); break;
-                            case 6: sprintf(buffer, "[RTL]"); break;
-                            case 7: sprintf(buffer, "[CIRCLE]"); break;
-                            case 9: sprintf(buffer, "[LAND]"); break;
-                            case 11: sprintf(buffer, "[DRIFT]"); break;
-                            case 13: sprintf(buffer, "[SPORT]"); break;
-                            case 14: sprintf(buffer, "[FLIP]"); break;
-                            case 15: sprintf(buffer, "[AUTOTUNE]"); break;
-                            case 16: sprintf(buffer, "[POSHOLD]"); break;
-                            case 17: sprintf(buffer, "[BRAKE]"); break;
-                            case 18: sprintf(buffer, "[THROW]"); break;
-                            case 19: sprintf(buffer, "[AVOIDADSB]"); break;
-                            case 20: sprintf(buffer, "[GUIDEDNOGPS]"); break;
-                            case 255: sprintf(buffer, "[-----]"); break;
-                        #endif
-                    #else
-                        #if CHINESE == true
-                            case 0: sprintf(buffer, "[手   动]"); break;
-                            case 1: sprintf(buffer, "[盘   旋]"); break;
-                            case 2: sprintf(buffer, "[自   稳]"); break;
-                            case 3: sprintf(buffer, "[教   练]"); break;
-                            case 4: sprintf(buffer, "[特   技]"); break;
-                            //case 5: sprintf(buffer, "[半 自 稳]"); break;
-                            case 5: sprintf(buffer, "[自   稳]"); break;
-                            case 6: sprintf(buffer, "[自 稳 定 高]"); break;
-                            case 7: sprintf(buffer, "[巡   航]"); break;
-                            case 8: sprintf(buffer, "[自 动 调 参]"); break;
-                            case 10: sprintf(buffer, "[自   动]"); break;
-                            case 11: sprintf(buffer, "[返   航]"); break;
-                            case 12: sprintf(buffer, "[定   点]"); break;
-                            //case 15: sprintf(buffer, "[抛   飞]"); break;
-                            case 15: sprintf(buffer, "[指   引]"); break;
-                            //case 16: sprintf(buffer, "[失 控 保 护]"); break;
-                            case 16: sprintf(buffer, "[INIT]"); break;
-                            case 255: sprintf(buffer, "[-----]"); break;
-                        #else
-                            case 0: sprintf(buffer, "[MAN]"); break;
-                            case 1: sprintf(buffer, "[CIRC]"); break;
-                            case 2: sprintf(buffer, "[STAB]"); break;
-                            case 3: sprintf(buffer, "[TRAI]"); break;
-                            case 4: sprintf(buffer, "[ACRO]"); break;
-                            case 5: sprintf(buffer, "[FBWA]"); break;
-                            case 6: sprintf(buffer, "[FBWB]"); break;
-                            case 7: sprintf(buffer, "[CRUZ]"); break;
-                            case 8: sprintf(buffer, "[TUNE]"); break;
-                            case 10: sprintf(buffer, "[AUTO]"); break;
-                            case 11: sprintf(buffer, "[RTL]"); break;
-                            case 12: sprintf(buffer, "[LOIT]"); break;
-                            case 13: sprintf(buffer, "[TAKE]"); break;
-                            case 15: sprintf(buffer, "[GUID]"); break;
-                            case 16: sprintf(buffer, "[INIT]"); break;
-                            case 17: sprintf(buffer, "Q-STAB"); break;
-                            case 18: sprintf(buffer, "Q-HOVR"); break;
-                            case 19: sprintf(buffer, "Q-LOIT"); break;
-                            case 20: sprintf(buffer, "Q-LAND"); break;
-                            case 21: sprintf(buffer, "Q-RTL"); break;
-                            case 23: sprintf(buffer, "Q-ACRO"); break;
-                            case 255: sprintf(buffer, "[-----]"); break;
-                        #endif
-                    #endif
-                    /*
-                     * TODO: find out why strange numbers when using zs6bujs telemetry logs, default to something 
-                     * more sensible like "unknown mode"
-                     */
-                    default: sprintf(buffer, "[-----]"); break;
-                }
+                sprintf(buffer, "%s", fmode);
             }
             TextMid(getWidth(pos_x), getHeight(pos_y), buffer, myfont, text_scale);
         }


### PR DESCRIPTION
Mavlink now uses the proper enums from the Mavlink library so we can guarantee they're correct just by looking at them. The other protocols use magic numbers, but they should be correct. 

VOT has no Chinese modes yet, but we can translate those in QOpenHD's translation system along with everything else anyway.

This adds non-Chinese LTM flight modes to the old OSD, it had the Chinese version and QOpenHD has english modes, so now the old OSD has both.