### PR TITLE
Use named ports for MSP/Mavlink router, use 115200 baud to remove bottleneck

### DIFF
--- a/wifibroadcast-scripts/hotspot_functions.sh
+++ b/wifibroadcast-scripts/hotspot_functions.sh
@@ -40,8 +40,8 @@ function hotspot_check_function {
 
     pause_while
 
-    nice cat /root/telemetryfifo5 > /dev/pts/0 &
-    /usr/local/bin/mavlink-routerd -e 127.0.0.1:14550 /dev/pts/1:115200 &
+    nice cat /root/telemetryfifo5 > /dev/openhd_mavlink1 &
+    /usr/local/bin/mavlink-routerd -e 127.0.0.1:14550 /dev/openhd_mavlink2:115200 &
 
     #
     # Phone can be connected at any time, so always start hotspot programs
@@ -103,7 +103,7 @@ function hotspot_check_function {
 
 
     #if [ "$TELEMETRY_UPLINK" == "msp" ]; then
-        #cat /root/mspfifo > /dev/pts/2 &
+        #cat /root/mspfifo > /dev/openhd_msp1 &
         #ser2net
     #fi
 

--- a/wifibroadcast-scripts/hotspot_functions.sh
+++ b/wifibroadcast-scripts/hotspot_functions.sh
@@ -41,7 +41,7 @@ function hotspot_check_function {
     pause_while
 
     nice cat /root/telemetryfifo5 > /dev/pts/0 &
-    /usr/local/bin/mavlink-routerd -e 127.0.0.1:14550 /dev/pts/1:57600 &
+    /usr/local/bin/mavlink-routerd -e 127.0.0.1:14550 /dev/pts/1:115200 &
 
     #
     # Phone can be connected at any time, so always start hotspot programs

--- a/wifibroadcast-scripts/rx_functions.sh
+++ b/wifibroadcast-scripts/rx_functions.sh
@@ -19,7 +19,7 @@ function rx_function {
     #
     # Setup virtual serial ports
     #
-    stty -F /dev/pts/0 -icrnl -ocrnl -imaxbel -opost -isig -icanon -echo -echoe -ixoff -ixon 57600
+    stty -F /dev/pts/0 -icrnl -ocrnl -imaxbel -opost -isig -icanon -echo -echoe -ixoff -ixon 115200
     stty -F /dev/pts/1 -icrnl -ocrnl -imaxbel -opost -isig -icanon -echo -echoe -ixoff -ixon 115200
 
     echo

--- a/wifibroadcast-scripts/rx_functions.sh
+++ b/wifibroadcast-scripts/rx_functions.sh
@@ -11,16 +11,16 @@ function rx_function {
     #
     # Start virtual serial port for cmavnode and ser2net
     #
-    ionice -c 3 nice socat -lf /wbc_tmp/socat1.log -d -d pty,raw,echo=0 pty,raw,echo=0 & > /dev/null 2>&1
+    ionice -c 3 nice socat -lf /wbc_tmp/socat1.log -d -d pty,raw,echo=0,link=/dev/openhd_mavlink2 pty,raw,echo=0,link=/dev/openhd_mavlink1 & > /dev/null 2>&1
     sleep 1
-    ionice -c 3 nice socat -lf /wbc_tmp/socat2.log -d -d pty,raw,echo=0 pty,raw,echo=0 & > /dev/null 2>&1
+    ionice -c 3 nice socat -lf /wbc_tmp/socat2.log -d -d pty,raw,echo=0,link=/dev/openhd_msp2 pty,raw,echo=0,link=/dev/openhd_msp1 & > /dev/null 2>&1
     sleep 1
 
     #
     # Setup virtual serial ports
     #
-    stty -F /dev/pts/0 -icrnl -ocrnl -imaxbel -opost -isig -icanon -echo -echoe -ixoff -ixon 115200
-    stty -F /dev/pts/1 -icrnl -ocrnl -imaxbel -opost -isig -icanon -echo -echoe -ixoff -ixon 115200
+    stty -F /dev/openhd_mavlink2 -icrnl -ocrnl -imaxbel -opost -isig -icanon -echo -echoe -ixoff -ixon 115200
+    stty -F /dev/openhd_msp2 -icrnl -ocrnl -imaxbel -opost -isig -icanon -echo -echoe -ixoff -ixon 115200
 
     echo
 

--- a/wifibroadcast-scripts/uplink_functions.sh
+++ b/wifibroadcast-scripts/uplink_functions.sh
@@ -344,13 +344,13 @@ function uplinktx_function {
                 #
                 # We can and should do the same for the other protocols, but we don't yet
                 #
-                VSERIALPORT=/dev/pts/0
+                VSERIALPORT=/dev/openhd_mavlink1
                 UPLINK_TX_CMD="nice /home/pi/wifibroadcast-base/tx_telemetry -p 3 -c 0 -r 2 -x 0 -d 12 -y 0"
             else
                 #
                 # Non-mavlink telemetry is all handled the same
                 # 
-                VSERIALPORT=/dev/pts/2
+                VSERIALPORT=/dev/openhd_msp1
                 UPLINK_TX_CMD="nice /home/pi/wifibroadcast-base/tx_telemetry -p 3 -c 0 -r 2 -x 1 -d 12 -y 0"
             fi
 
@@ -371,9 +371,9 @@ function uplinktx_function {
             nice stty -F $EXTERNAL_TELEMETRY_SERIALPORT_GROUND $EXTERNAL_TELEMETRY_SERIALPORT_GROUND_STTY_OPTIONS $EXTERNAL_TELEMETRY_SERIALPORT_GROUND_BAUDRATE
             
             if [ "$TELEMETRY_UPLINK" == "mavlink" ]; then
-                VSERIALPORT=/dev/pts/0
+                VSERIALPORT=/dev/openhd_mavlink1
             else
-                VSERIALPORT=/dev/pts/2
+                VSERIALPORT=/dev/openhd_msp1
             fi
             
             UPLINK_TX_CMD="$EXTERNAL_TELEMETRY_SERIALPORT_GROUND"


### PR DESCRIPTION
This uses named virtual serial ports to wire up mavlink router and the MSP connection on the ground, so that they aren't dependent on the "first come first serve" /dev/pts/X naming.

This also updates the connection between the telemetry system and mavlink-router so that it is no longer bottlenecked at 57600. The telemetry system itself is much faster, so this was just potentially slowing things down if someone had set 115200 on the air side.