### PR TITLE
Add recording bitrate setting to openhdvid

### DIFF
--- a/openhd-camera/openhdvid
+++ b/openhd-camera/openhdvid
@@ -106,6 +106,7 @@ class OpenHDCamera:
         self.inline_headers = option.inline_headers
         self.sps_timing = option.sps_timing
         self.bitrate = option.bitrate
+        self.record_bitrate = option.record_bitrate
         print("Camera initialized", file=sys.stderr)
 
     def check_used_space(self, path):
@@ -136,9 +137,9 @@ class OpenHDCamera:
             else:
                 # don't hook up the resize component in the pipeline if the resolution is the same as the main stream
                 if option.width_record == option.width and option.height_record == option.height:
-                    self.camera.start_recording(option.record, 'h264', splitter_port=2)
+                    self.camera.start_recording(option.record, 'h264', splitter_port=2, bitrate=self.record_bitrate)
                 else:
-                    self.camera.start_recording(option.record, 'h264', resize=(option.width_record, option.height_record), splitter_port=2)
+                    self.camera.start_recording(option.record, 'h264', resize=(option.width_record, option.height_record), splitter_port=2, bitrate=self.record_bitrate)
                 print("Recording to file " + option.record, file=sys.stderr)
 
         print("Camera running", file=sys.stderr)
@@ -194,6 +195,7 @@ if __name__ == '__main__':
     parser.add_argument('--record', '-rec', action="store", dest="record", type=str)
     parser.add_argument('--width_record', '-wr', action="store", dest="width_record", type=int, default=1280)
     parser.add_argument('--height_record', '-hr', action="store", dest="height_record", type=int, default=720)
+    parser.add_argument('--bitrate_record', '-br', action="store", dest="bitrate_record", type=int, default=4000000)
 
 
     parser.add_argument('--output', '-o', action="store", dest="output", type=str, default="-")


### PR DESCRIPTION
This adds an `openhdvid` parameter called `--bitrate_record` or `-br` for short, which sets the recording bitrate separately from the main bitrate.

This is only intended for early experimentation, openhdvid will be replaced by the camera service in OpenHD 2.1 or 2.2, and that will have full support for recording.

To test it, set `-rec /home/pi/my_video.h264 -wr 1280 -hr 720 -br 12000000` (or any other resolution supported by the pi camera). This will record a 720p raw h264 file at 12Mbit, regardless of what the main stream bitrate is set to. Note that you must choose the recording parameters carefully: if the recording resolution is different than the stream resolution, the Pi will choose to add a resize step to one of them, which will add latency. You must also be sure not to exceed the h264 encoder's maximum encoding rate, it might be able to cope with 2x 720p streams at different bitrates but 1080p60 is near (or over) the limit even for one stream.

