### PR TITLE
Add support for automating frequency selection

### DIFF
--- a/wifibroadcast-scripts/configure_nics.sh
+++ b/wifibroadcast-scripts/configure_nics.sh
@@ -10,6 +10,7 @@ else
     CONFIGFILE="openhd-settings-1.txt"
 fi
 
+source /home/pi/wifibroadcast-scripts/global_functions.sh
 
 
 function tmessage {
@@ -600,6 +601,10 @@ function prepare_nic {
 
 
 read_config_file
+
+detect_wfb_primary_band
+
+auto_frequency_select
 
 if [ "$CAM" == "0" ]; then
     if [[ "$MirrorDSI_To_HDMI" == "y" || "$MirrorDSI_To_HDMI" == "Y" ]]; then

--- a/wifibroadcast-scripts/global_functions.sh
+++ b/wifibroadcast-scripts/global_functions.sh
@@ -169,6 +169,36 @@ function detect_hardware {
 }
 
 
+function detect_wfb_primary_band {
+    lsmod | grep 88XXau
+    grepRet=$?
+    if [[ $grepRet -eq 0 ]] ; then
+        export WFB_PRIMARY_BAND_58="1"
+        export WFB_PRIMARY_BAND_24="0"
+        echo "58" > /tmp/wfb_primary_band
+        return
+    fi
+
+    # every other card we support is 2.4-only, so we default to 2.4
+    export WFB_PRIMARY_BAND_58="0"
+    export WFB_PRIMARY_BAND_24="1"
+    echo "24" > /tmp/wfb_primary_band
+}
+
+
+function auto_frequency_select {
+    if [[ "${WFB_PRIMARY_BAND_58}" == "1" ]]; then
+        if [[ "${FREQ}" == "auto" ]]; then
+            export FREQ="5180"
+        fi
+    else
+        if [[ "${FREQ}" == "auto" ]]; then
+            export FREQ="2412"
+        fi
+    fi
+}
+
+
 #
 # If /boot/i2c_vc exists, we check to see if i2c_vc is already enabled in
 # config.txt, and if not we enable it and reboot. 

--- a/wifibroadcast-scripts/main.sh
+++ b/wifibroadcast-scripts/main.sh
@@ -37,6 +37,10 @@ migration_helper
 configure_hello_video_args
 
 
+detect_wfb_primary_band
+
+auto_frequency_select
+
 
 echo "-------------------------------------"
 echo "SETTINGS FILE: $CONFIGFILE"


### PR DESCRIPTION
We detect if an 8812 card is connected, in which case 5.8g band is available for SmartSync and normal use so we prioritize it, otherwise we use 2.4g.

If in any case we don't know what band is available or the settings file doesn't explicitly say "auto" or a specific frequency, we default to the same frequency we use by default anyway, 2412Mhz.