### PR TITLE
Prevent the old MouseListener from using 100% CPU

### DIFF
--- a/wifibroadcast-misc/LCD/MouseListener.c
+++ b/wifibroadcast-misc/LCD/MouseListener.c
@@ -317,6 +317,8 @@ void *eventThread(void *arg) {
                     //printf("Right button\n");
                 }
             }
+
+            usleep(50000);
         }
     }
 }


### PR DESCRIPTION
This is the code responsible for adjusting the brightness when the old OSD is used with a touchscreen.

It's unlikely most people who have touchscreens are still using the old OSD, but this thing runs even when there's no touchscreen attached, and it was using 100% of a CPU core.