### PR TITLE
Add early boot NIC status reporting

### DIFF
--- a/RemoteSettings/dhcpeventThread.sh
+++ b/RemoteSettings/dhcpeventThread.sh
@@ -15,7 +15,7 @@ echo $op
 #echo $ip
 #echo $hostname
 
-export PATH=/home/pi/wifibroadcast-status:${PATH}
+export PATH=/usr/local/bin:${PATH}
 
 if [ ! -f /tmp/mavlink_router_pipe ]; then 
     sleep 1

--- a/wifibroadcast-scripts/.profile
+++ b/wifibroadcast-scripts/.profile
@@ -61,7 +61,9 @@ if [ "$TTY" == "/dev/tty1" ]; then
         sleep 1
 
         systemctl start openhd_microservice@status
-        sleep 1
+        while [ ! -f /tmp/status_service ]; do
+            sleep 0.1
+        done
 
         /home/pi/wifibroadcast-scripts/configure_nics.sh
 
@@ -84,7 +86,9 @@ if [ "$TTY" == "/dev/tty1" ]; then
         sleep 1
 
         systemctl start openhd_microservice@status
-        sleep 1
+        while [ ! -f /tmp/status_service ]; do
+            sleep 0.1
+        done
         
         #
         # No cameras found, and we did not see GPIO7 pulled low, so this is a ground station

--- a/wifibroadcast-scripts/.profile
+++ b/wifibroadcast-scripts/.profile
@@ -1,6 +1,7 @@
 # Change to script folder and execute main entry point
 TTY=`tty`
 
+export PATH=/usr/local/bin:${PATH}
 
 if [ "$TTY" == "/dev/tty1" ]; then
     echo "tty1"
@@ -64,8 +65,8 @@ if [ "$TTY" == "/dev/tty1" ]; then
 
         /home/pi/wifibroadcast-scripts/configure_nics.sh
 
-        /home/pi/wifibroadcast-status/qstatus "Configured NIC(s)" 5
-        /home/pi/wifibroadcast-status/qstatus "Running SmartSync" 5
+        qstatus "Configured NIC(s)" 5
+        qstatus "Running SmartSync" 5
 
         /usr/bin/python3 /home/pi/RemoteSettings/Air/RemoteSettingSyncAir.py
 
@@ -92,8 +93,8 @@ if [ "$TTY" == "/dev/tty1" ]; then
         /home/pi/wifibroadcast-scripts/configure_nics.sh
         retCode=$?
 
-        /home/pi/wifibroadcast-status/qstatus "Configured NIC(s)" 5
-        /home/pi/wifibroadcast-status/qstatus "Running SmartSync" 5
+        qstatus "Configured NIC(s)" 5
+        qstatus "Running SmartSync" 5
 
         # now we will run SmartSync, using either GPIOs or Joystick to control it
 
@@ -110,7 +111,7 @@ if [ "$TTY" == "/dev/tty1" ]; then
         echo "0" > /tmp/ReadyToGo
         
         echo "Configuring system"
-        /home/pi/wifibroadcast-status/qstatus "Configuring system" 5
+        qstatus "Configuring system" 5
     fi
 fi
 

--- a/wifibroadcast-scripts/global_functions.sh
+++ b/wifibroadcast-scripts/global_functions.sh
@@ -33,13 +33,13 @@ function start_microservices {
     if [ "$TTY" != "/dev/tty1" ]; then
         return
     fi
-    /home/pi/wifibroadcast-status/qstatus "Starting power microservice" 5
+    qstatus "Starting power microservice" 5
 
     systemctl start openhd_microservice@power
 
     # gpio service only runs on the air side
     if [ "${CAM}" -ge 1 ]; then 
-        /home/pi/wifibroadcast-status/qstatus "Starting GPIO microservice" 5
+        qstatus "Starting GPIO microservice" 5
         systemctl start openhd_microservice@gpio
     fi
 }
@@ -163,7 +163,7 @@ function detect_hardware {
         ;;
     esac
 
-    /home/pi/wifibroadcast-status/qstatus "Running on $MODEL system" 5
+    qstatus "Running on $MODEL system" 5
 
     echo "Running on $MODEL system"
 }
@@ -311,7 +311,7 @@ function check_lifepowered_pi_attached {
 
         if [ "$TTY" == "/dev/tty1" ]; then
             echo "Detected LiFePO4wered Pi power hat"
-            /home/pi/wifibroadcast-status/qstatus "Detected LiFePO4wered Pi power hat" 5
+            qstatus "Detected LiFePO4wered Pi power hat" 5
         fi
     else
         export LIFEPO4WERED_PI="0"
@@ -328,7 +328,7 @@ function check_hdmi_csi_attached {
 
         if [ "$TTY" == "/dev/tty1" ]; then
             echo "Detected HDMI CSI input board"
-            /home/pi/wifibroadcast-status/qstatus "Detected HDMI CSI input board" 5
+            qstatus "Detected HDMI CSI input board" 5
         fi
     else
         export HDMI_CSI="0"
@@ -376,7 +376,7 @@ function check_camera_attached {
 
                 CAM="1"
 
-                /home/pi/wifibroadcast-status/qstatus "Detected VEYE camera" 5
+                qstatus "Detected VEYE camera" 5
             else
                 echo  "0" > /tmp/cam
 
@@ -390,7 +390,7 @@ function check_camera_attached {
 
             echo ${CAM} > /tmp/cam
 
-            /home/pi/wifibroadcast-status/qstatus "Detected ${CAM} official Raspberry Pi camera(s)" 5
+            qstatus "Detected ${CAM} official Raspberry Pi camera(s)" 5
         fi
     else
         echo -n "Waiting until TX/RX has been determined"
@@ -449,7 +449,7 @@ function read_config_file {
             source /tmp/settings.sh
         else
             echo "ERROR: openhd-settings file contains syntax error(s)!"
-            /home/pi/wifibroadcast-status/qstatus "ERROR: openhd-settings file contains syntax error(s)!" 3
+            qstatus "ERROR: openhd-settings file contains syntax error(s)!" 3
 
             collect_errorlog
 
@@ -457,7 +457,7 @@ function read_config_file {
         fi
     else
         echo "ERROR: openhd-settings file not found!"
-        /home/pi/wifibroadcast-status/qstatus "ERROR: openhd-settings file not found!" 3
+        qstatus "ERROR: openhd-settings file not found!" 3
 
         collect_errorlog
         
@@ -985,7 +985,7 @@ function prepare_nic {
     
     if [ "$DRIVER" != "rt2800usb" ] && [ "$DRIVER" != "mt7601u" ] && [ "$DRIVER" != "ath9k_htc" ]; then
         tmessage "WARNING: Unsupported or experimental wifi card: $DRIVER"
-        /home/pi/wifibroadcast-status/qstatus "WARNING: Unsupported or experimental wifi card: $DRIVER" 4
+        qstatus "WARNING: Unsupported or experimental wifi card: $DRIVER" 4
     fi
 
     case $DRIVER in
@@ -1001,7 +1001,7 @@ function prepare_nic {
         ifconfig $1 up || {
             echo
             echo "ERROR: Bringing up interface $1 failed!"
-            /home/pi/wifibroadcast-status/qstatus "ERROR: Bringing up interface $1 failed!" 3
+            qstatus "ERROR: Bringing up interface $1 failed!" 3
             collect_errorlog
             sleep 365d
         }
@@ -1016,7 +1016,7 @@ function prepare_nic {
             iw dev $1 set bitrates legacy-2.4 $UplinkSpeed || {
                 echo
                 echo "ERROR: Setting bitrate on $1 failed!"
-                /home/pi/wifibroadcast-status/qstatus "ERROR: Setting bitrate on $1 failed!" 3
+                qstatus "ERROR: Setting bitrate on $1 failed!" 3
                 
                 collect_errorlog
                 
@@ -1040,7 +1040,7 @@ function prepare_nic {
                 iw dev $1 set bitrates legacy-2.4 $VIDEO_WIFI_BITRATE || {
                     echo
                     echo "ERROR: Setting bitrate on $1 failed!"
-                    /home/pi/wifibroadcast-status/qstatus "ERROR: Setting bitrate on $1 failed!" 3
+                    qstatus "ERROR: Setting bitrate on $1 failed!" 3
 
                     collect_errorlog
                     
@@ -1062,7 +1062,7 @@ function prepare_nic {
         ifconfig $1 down || {
             echo
             echo "ERROR: Bringing down interface $1 failed!"
-            /home/pi/wifibroadcast-status/qstatus "ERROR: Bringing down interface $1 failed!" 3
+            qstatus "ERROR: Bringing down interface $1 failed!" 3
 
             collect_errorlog
             
@@ -1075,7 +1075,7 @@ function prepare_nic {
         iw dev $1 set monitor none || {
             echo
             echo "ERROR: Setting monitor mode on $1 failed!"
-            /home/pi/wifibroadcast-status/qstatus "ERROR: Setting monitor mode on $1 failed!" 3
+            qstatus "ERROR: Setting monitor mode on $1 failed!" 3
 
             collect_errorlog
             
@@ -1093,7 +1093,7 @@ function prepare_nic {
         ifconfig $1 up || {
             echo
             echo "ERROR: Bringing up interface $1 failed!"
-            /home/pi/wifibroadcast-status/qstatus "ERROR: Bringing up interface $1 failed!" 3
+            qstatus "ERROR: Bringing up interface $1 failed!" 3
             
             collect_errorlog
 
@@ -1110,7 +1110,7 @@ function prepare_nic {
             iw dev $1 set freq $2 || {
                 echo
                 echo "ERROR: Setting frequency $2 MHz on $1 failed!"
-                /home/pi/wifibroadcast-status/qstatus "ERROR: Setting frequency $2 Mhz on $1 failed!" 3
+                qstatus "ERROR: Setting frequency $2 Mhz on $1 failed!" 3
 
                 collect_errorlog
                 
@@ -1134,7 +1134,7 @@ function prepare_nic {
         iw dev $1 set monitor none || {
             echo
             echo "ERROR: Setting monitor mode on $1 failed!"
-            /home/pi/wifibroadcast-status/qstatus "ERROR: Setting monitor mode on $1 failed!" 3
+            qstatus "ERROR: Setting monitor mode on $1 failed!" 3
 
             collect_errorlog
             
@@ -1149,7 +1149,7 @@ function prepare_nic {
         ifconfig $1 up || {
             echo
             echo "ERROR: Bringing up interface $1 failed!"
-            /home/pi/wifibroadcast-status/qstatus "ERROR: Bringing up interfce $1 failed!" 3
+            qstatus "ERROR: Bringing up interfce $1 failed!" 3
 
             collect_errorlog
             
@@ -1166,7 +1166,7 @@ function prepare_nic {
             iw dev $1 set freq $2 || {
                 echo
                 echo "ERROR: Setting frequency $2 MHz on $1 failed!"
-                /home/pi/wifibroadcast-status/qstatus "ERROR: Setting frequency $2 MHz on $1 failed!" 3
+                qstatus "ERROR: Setting frequency $2 MHz on $1 failed!" 3
 
                 collect_errorlog
                 
@@ -1187,7 +1187,7 @@ function prepare_nic {
             iw dev $1 set txpower fixed $3 || {
                 echo
                 echo "ERROR: Setting TX power to $3 on $1 failed!"
-                /home/pi/wifibroadcast-status/qstatus "ERROR: Setting TX power to $3 on $1 failed!" 3
+                qstatus "ERROR: Setting TX power to $3 on $1 failed!" 3
 
                 collect_errorlog
                 

--- a/wifibroadcast-scripts/main.sh
+++ b/wifibroadcast-scripts/main.sh
@@ -16,7 +16,7 @@ TTY=`tty`
 # GPIO variable
 CONFIGFILE=`/root/wifibroadcast_misc/gpio-config.py`
 
-export PATH=/home/pi/wifibroadcast-status:${PATH}
+export PATH=/usr/local/bin:${PATH}
 
 autoenable_i2c_vc
 
@@ -47,7 +47,7 @@ echo "SETTINGS FILE: $CONFIGFILE"
 echo "-------------------------------------"
 if [ "$TTY" == "/dev/tty1" ]; then
     echo "Using settings file $CONFIGFILE"
-    /home/pi/wifibroadcast-status/qstatus "Using settings file $CONFIGFILE" 5
+    qstatus "Using settings file $CONFIGFILE" 5
 fi
 
 #

--- a/wifibroadcast-status/Makefile
+++ b/wifibroadcast-status/Makefile
@@ -9,10 +9,10 @@ all: wbc_status qstatus
  
 
 wbc_status: wbc_status.o
-	gcc -o $@ $^ $(LDFLAGS)
+	gcc -o /usr/local/bin/$@ $^ $(LDFLAGS)
 
 qstatus: qstatus.o
-	gcc -o $@ $^
+	gcc -o /usr/local/bin/$@ $^
 
 clean:
 	rm -f wbc_status qstatus *.o *~


### PR DESCRIPTION
This will forward all NIC setup events to the status microservice, including issues detecting or configuring NICs early during boot.

If something goes wrong the boot screen will remain visible with the last critical error shown, allowing users to know what happened just from looking at the screen. We will likely want to add a few more checks in this part of the system for other cases, but power issues and wifi card issues are covered already.

This PR also removes one of the sleep statements and uses a temporary signal to ensure the status service is ready before proceeding with early boot. This should be done with a systemd target soon instead, but it's ok for now.