### PR TITLE
Ensure VEYE is detected in early boot

### DIFF
--- a/wifibroadcast-scripts/.profile
+++ b/wifibroadcast-scripts/.profile
@@ -52,6 +52,18 @@ if [ "$TTY" == "/dev/tty1" ]; then
             CAM="1"
             AIR="1"
         fi
+
+        #
+        # No pi camera detected, but we still might have a VEYE, and the only way to detect
+        # it is to have i2c_vc enabled already, and then probe the i2c-0 bus
+        #
+        i2cdetect -y 0 | grep  "30: -- -- -- -- -- -- -- -- -- -- -- 3b -- -- -- --"
+        grepRet=$?
+
+        if [[ $grepRet -eq 0 ]] ; then
+            CAM="1"
+            AIR="1"
+        fi
     fi
 
 


### PR DESCRIPTION
This was removed in 2.0.0rc2 due to a mixup during the change to use `vcgencmd` to detect multiple regular pi cameras and the hdmi-csi board