### PR TITLE
Fix SmartSync state transitions and messages

### DIFF
--- a/RemoteSettings/Ground/RemoteSettingsSync.py
+++ b/RemoteSettings/Ground/RemoteSettingsSync.py
@@ -924,8 +924,9 @@ else:
 
 StartRC_Reader(SmartSyncRC_Channel)
 
+SendInfoToDisplay(5, "SmartSync: initializing")
+
 if SmartSync_StartupMode != 1:
-    SendInfoToDisplay(5, "SmartSync: initializing")
     SendSmartSyncState(SmartSyncState.WaitingForTrigger, 0)
 
     for i in range(0, 10):
@@ -956,7 +957,6 @@ if SmartSync_StartupMode != 1:
 
 
 if SmartSync_StartupMode == 1:
-    SendInfoToDisplay(5, "SmartSync: initializing")
     SendSmartSyncState(SmartSyncState.WaitingForAir, 0)
 
     #if InitWlan() != False:
@@ -966,9 +966,6 @@ if SmartSync_StartupMode == 1:
                 if SmartSyncGround_Countdown > 5:
                     SendInfoToDisplay(5, "SmartSync: starting timer")
                     StartTime = datetime.now()
-                else:
-                    SendInfoToDisplay(5, "SmartSync: timer < 5 seconds, disabled")
-
                 InitUDPServer()
             else:
                 SendInfoToDisplay(3, "SmartSync: can't initialize radio TX")

--- a/RemoteSettings/Ground/RemoteSettingsSync.py
+++ b/RemoteSettings/Ground/RemoteSettingsSync.py
@@ -632,7 +632,6 @@ def IsTimeToExit():
 
 def InitUDPServer():
     for i in range(0,10):
-        SendSmartSyncState(SmartSyncState.WaitingForTrigger, 0)
         sleep(0.02)
 
     global RecvSocket


### PR DESCRIPTION
These appear on the new boot screen, some of the messages were unnecessary and the state transition from "waiting for GPIO" to "waiting for air" was reverting once the UDP thread started.