### PR TITLE
Ensure OpenHDBoot stops even if OSD is disabled

### DIFF
--- a/wifibroadcast-scripts/osd_rx_functions.sh
+++ b/wifibroadcast-scripts/osd_rx_functions.sh
@@ -47,12 +47,12 @@ function osdrx_function {
         pause_while
         sleep 5
 
+        systemctl stop openhdboot
+
         if [ "${DISPLAY_OSD}" == "Y" ]; then
             if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                systemctl stop openhdboot
                 systemctl start qopenhd
             else
-                systemctl stop openhdboot
                 systemctl start osd
             fi
         fi


### PR DESCRIPTION
People use plain video with no OSD, so we want to make sure that still works. At the moment the boot screen is accidentally remaining visible if the OSD is disabled.