### PR TITLE
Update the video save system

### DIFF
--- a/after-install.sh
+++ b/after-install.sh
@@ -4,6 +4,7 @@ systemctl disable osd
 systemctl enable openhdconfig
 
 mkdir -p /wbc_tmp
+mkdir -p /media/usb
 
 # crude hack to avoid making people put fonts somewhere else
 cp -a /usr/local/share/openhd/osdfonts/*.ttf /boot/osdfonts/ > /dev/null 2>&1 || true

--- a/package.sh
+++ b/package.sh
@@ -238,7 +238,6 @@ fpm -a ${PACKAGE_ARCH} -s dir -t deb -n ${PACKAGE_NAME} -v ${VERSION//v} -C ${TM
   -d "pump" \
   -d "dnsmasq" \
   -d "aircrack-ng" \
-  -d "usbmount" \
   -d "ser2net" \
   -d "i2c-tools" \
   -d "dos2unix" \

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -291,7 +291,7 @@ function save_function {
             killall wbc_status > /dev/null 2>&1
 
             if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                qstatus "ERROR: Could not access USB memory stick!" 5
+                qstatus "ERROR: Could not access USB memory stick!" 3
             else
                 wbc_status "ERROR: Could not access USB memory stick!" 7 65 0 &
             fi

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -233,10 +233,10 @@ function save_function {
                     PERCENT_FINISHED=$(python -c "print(int(float(${TARGET_FILE_SIZE}) / float(${ORIGINAL_FILE_SIZE}) * 100.0))"  )
 
                     if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                        qstatus "Saving to usb ${PERCENT_FINISHED}%" 5
+                        qstatus "Saving: ${PERCENT_FINISHED}% done" 5
                     else
                         killall wbc_status > /dev/null 2>&1
-                        wbc_status "Saving to usb ${PERCENT_FINISHED}%" 7 65 0 &
+                        wbc_status "Saving: ${PERCENT_FINISHED}% done" 7 65 0 &
                     fi
                 fi
             done

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -97,9 +97,6 @@ function save_function {
         wbc_status "Saving to USB..." 7 55 0 &
     fi
 
-
-    echo -n "Accessing file system.. "
-
     #
     # Some USB drives show up as sda1, others as sda, check for both in order (checking for sda first
     # would always succeed even if sda1 exists)
@@ -109,9 +106,6 @@ function save_function {
     else
         USBDEV="/dev/sda"
     fi
-
-
-    echo "USBDEV: ${USBDEV}"
 
 
     if mount ${USBDEV} /media/usb; then
@@ -219,9 +213,6 @@ function save_function {
             
 
             USB_VIDEO_FILE=${VIDEO_SAVE_PATH}/video.${VIDEO_SAVE_FORMAT}
-
-
-            echo "USB_VIDEO_FILE: ${USB_VIDEO_FILE}"
 
 
             nice ffmpeg -framerate ${FPS} -i ${VIDEOFILE} -c:v copy ${USB_VIDEO_FILE} > /dev/null 2>&1 &

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -255,6 +255,7 @@ function save_function {
 
         MOUNTED=`mount | grep /media/usb | wc -l`
         while [ $MOUNTED -ge 1 ]; do
+            echo "Attempting to unmount USB drive"
             umount -A /media/usb > /dev/null 2>&1
             sleep 1
             MOUNTED=`mount | grep /media/usb | wc -l`

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -375,4 +375,6 @@ function save_function {
     # Let screenshot function know that it can continue taking screenshots
     #
     rm /tmp/pausewhile
+
+    echo "USB save done"
 }

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -66,7 +66,9 @@ function save_function {
     touch /tmp/pausewhile
 
     SAVE_IDENTIFIER=$(date '+%Y-%m-%d-%H-%M-%S')
-    
+    source /tmp/videofile
+
+     
 
     #
     # Kill old OSD temporarily

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -111,9 +111,9 @@ function save_function {
 
 
     if mount ${USBDEV} /media/usb; then
-        killall rssilogger
-        killall syslogger
-        killall wifibackgroundscan
+        killall rssilogger > /dev/null 2>&1
+        killall syslogger > /dev/null 2>&1
+        killall wifibackgroundscan > /dev/null 2>&1
 
 
         #
@@ -166,18 +166,18 @@ function save_function {
 
         if [ -s "/wbc_tmp/telemetrydowntmp.raw" ]; then
             cp /wbc_tmp/telemetrydowntmp.raw ${TELEMETRY_SAVE_PATH}/telemetrydown.raw
-            cp /wbc_tmp/telemetrydowntmp.txt ${TELEMETRY_SAVE_PATH}/telemetrydown.txt
+            cp /wbc_tmp/telemetrydowntmp.txt ${TELEMETRY_SAVE_PATH}/telemetrydown.txt > /dev/null 2>&1
         fi
 
-        cp /wbc_tmp/telemetrydowndebug.txt ${TELEMETRY_SAVE_PATH}/telemetrydowndebug.txt
-        cp /wbc_tmp/telemetryupdebug.txt ${TELEMETRY_SAVE_PATH}/telemetryupdebug.txt
+        cp /wbc_tmp/telemetrydowndebug.txt ${TELEMETRY_SAVE_PATH}/telemetrydowndebug.txt > /dev/null 2>&1
+        cp /wbc_tmp/telemetryupdebug.txt ${TELEMETRY_SAVE_PATH}/telemetryupdebug.txt > /dev/null 2>&1
 
 
 
         #
         # Stop capturing packet data so the file can be saved to USB
         # 
-        killall tshark
+        killall tshark > /dev/null 2>&1
 
 
         #
@@ -185,13 +185,13 @@ function save_function {
         #
         CAP_SAVE_PATH="/media/usb/${SAVE_IDENTIFIER}/cap"
         mkdir -p ${CAP_SAVE_PATH}
-        cp /wbc_tmp/*.pcap ${CAP_SAVE_PATH}/
-        cp /wbc_tmp/*.cap ${CAP_SAVE_PATH}/
+        cp /wbc_tmp/*.pcap ${CAP_SAVE_PATH}/ > /dev/null 2>&1
+        cp /wbc_tmp/*.cap ${CAP_SAVE_PATH}/ > /dev/null 2>&1
 
         #
         # Copy the airodump chart to the USB drive
         #
-        cp /wbc_tmp/airodump.png /media/usb/${SAVE_IDENTIFIER}/
+        cp /wbc_tmp/airodump.png /media/usb/${SAVE_IDENTIFIER}/ > /dev/null 2>&1
 
 
         if [ "${ENABLE_SCREENSHOTS}" == "Y" ]; then
@@ -249,7 +249,7 @@ function save_function {
         #
 
         #cp /wbc_tmp/tracker.txt /media/usb/${SAVE_IDENTIFIER}/
-        cp /wbc_tmp/debug.txt /media/usb/${SAVE_IDENTIFIER}/debug.txt
+        cp /wbc_tmp/debug.txt /media/usb/${SAVE_IDENTIFIER}/debug.txt > /dev/null 2>&1
 
         sync
 

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -255,7 +255,7 @@ function save_function {
 
         MOUNTED=`mount | grep /media/usb | wc -l`
         while [ $MOUNTED -ge 1 ]; do
-            umount -A /media/usb
+            umount -A /media/usb > /dev/null 2>&1
             sleep 1
             MOUNTED=`mount | grep /media/usb | wc -l`
         done

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -92,7 +92,7 @@ function save_function {
 
 
     if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-        qstatus "Saving to USB..." 3
+        qstatus "Saving to USB..." 5
     else
         wbc_status "Saving to USB..." 7 55 0 &
     fi
@@ -231,7 +231,7 @@ function save_function {
                     PERCENT_FINISHED=$(python -c "print(int(float(${TARGET_FILE_SIZE}) / float(${ORIGINAL_FILE_SIZE}) * 100.0))"  )
 
                     if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                        qstatus "Saving to usb ${PERCENT_FINISHED}%" 3
+                        qstatus "Saving to usb ${PERCENT_FINISHED}%" 5
                     else
                         killall wbc_status > /dev/null 2>&1
                         wbc_status "Saving to usb ${PERCENT_FINISHED}%" 7 65 0 &
@@ -259,7 +259,7 @@ function save_function {
             killall wbc_status > /dev/null 2>&1
 
             if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                qstatus "Done - USB memory stick can be removed now" 3
+                qstatus "Done - USB memory stick can be removed now" 5
             else
                 wbc_status "Done - USB memory stick can be removed now" 7 65 0 &
             fi

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -92,9 +92,9 @@ function save_function {
 
 
     if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-        qstatus "Saving to USB. This may take some time ..." 3
+        qstatus "Saving to USB..." 3
     else
-        wbc_status "Saving to USB. This may take some time ..." 7 55 0 &
+        wbc_status "Saving to USB..." 7 55 0 &
     fi
 
 

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -273,7 +273,6 @@ function save_function {
         # Stop any processes left over from the save step
         #
         killall wbc_status > /dev/null 2>&1
-        killall hello_video.bin.player > /dev/null 2>&1
 
         #
         # Clear out the temporary directories so we can start saving again
@@ -306,7 +305,6 @@ function save_function {
         # Stop any processes left over from the save step
         #
         killall wbc_status > /dev/null 2>&1
-        killall hello_video.bin.player > /dev/null 2>&1
     fi
 
 

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -92,7 +92,7 @@ function save_function {
 
 
     if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-        qstatus "Saving to USB. This may take some time ..." 5
+        qstatus "Saving to USB. This may take some time ..." 3
     else
         wbc_status "Saving to USB. This may take some time ..." 7 55 0 &
     fi
@@ -262,7 +262,7 @@ function save_function {
             killall wbc_status > /dev/null 2>&1
 
             if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                qstatus "Done - USB memory stick can be removed now" 5
+                qstatus "Done - USB memory stick can be removed now" 3
             else
                 wbc_status "Done - USB memory stick can be removed now" 7 65 0 &
             fi
@@ -294,7 +294,7 @@ function save_function {
             killall wbc_status > /dev/null 2>&1
 
             if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                qstatus "ERROR: Could not access USB memory stick!" 3
+                qstatus "ERROR: Could not access USB memory stick!" 5
             else
                 wbc_status "ERROR: Could not access USB memory stick!" 7 65 0 &
             fi

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -226,24 +226,30 @@ function save_function {
 
             nice ffmpeg -framerate ${FPS} -i ${VIDEOFILE} -c:v copy ${USB_VIDEO_FILE} > /dev/null 2>&1 &
 
+            killall wbc_status > /dev/null 2>&1
 
             FFMPEGRUNNING=1
             while [ ${FFMPEGRUNNING} -eq 1 ]; do
                 FFMPEGRUNNING=`pidof ffmpeg | wc -w`
-                #echo "FFMPEGRUNNING: ${FFMPEGRUNNING}"
 
                 sleep 4
+        
+                if [ -f ${USB_VIDEO_FILE} ]; then
+                    ORIGINAL_FILE_SIZE=$(ls -l ${VIDEOFILE} | awk '{print $5}')
+                    TARGET_FILE_SIZE=$(ls -l ${USB_VIDEO_FILE} | awk '{print $5}')
+                    PERCENT_FINISHED=$(python -c "print(int(float(${TARGET_FILE_SIZE}) / float(${ORIGINAL_FILE_SIZE}) * 100.0))"  )
 
-                killall wbc_status > /dev/null 2>&1
-
-                if [ "${ENABLE_QOPENHD}" == "Y" ]; then
-                    qstatus "Saving - please wait ..." 5
-                else
-                    wbc_status "Saving - please wait ..." 7 65 0 &
+                    if [ "${ENABLE_QOPENHD}" == "Y" ]; then
+                        qstatus "Saving to usb ${PERCENT_FINISHED}%" 3
+                    else
+                        killall wbc_status > /dev/null 2>&1
+                        wbc_status "Saving to usb ${PERCENT_FINISHED}%" 7 65 0 &
+                    fi
                 fi
             done
         fi
         
+        killall wbc_status > /dev/null 2>&1
 
         #
         # Copy telemetry logs to the USB drive

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -37,7 +37,12 @@ function MAIN_VIDEO_SAVE_FUNCTION {
                 FREETMPSPACE=`nice df -P /wbc_tmp/ | nice awk 'NR==2 {print $4}'`
 
                 if [ ${FREETMPSPACE} -lt ${LIMITFREE} ]; then
-                    echo "RAM disk full, killing cat video file writing  process ..."
+                    if [ "${ENABLE_QOPENHD}" == "Y" ]; then
+                        qstatus "Ground recording space full" 4
+                    else
+                        killall wbc_status > /dev/null 2>&1
+                        wbc_status "Ground recording space full" 7 65 0 &
+                    fi
                 
                     ps -ef | nice grep "cat /var/run/openhd/videofifo3" | nice grep -v grep | awk '{print $2}' | xargs kill -9
                     KILLED=1

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -328,6 +328,25 @@ function save_function {
     ionice -c 3 nice cat /var/run/openhd/telemetryfifo3 >> /wbc_tmp/telemetrydowntmp.raw &
 
 
+    #
+    # Re-start rssi logging
+    #
+    nice /usr/local/bin/rssilogger /wifibroadcast_rx_status_0 >> /wbc_tmp/videorssi.csv &
+    nice /usr/local/bin/rssilogger /wifibroadcast_rx_status_1 >> /wbc_tmp/telemetrydownrssi.csv &
+    nice /usr/local/bin/syslogger /wifibroadcast_rx_status_sysair >> /wbc_tmp/system.csv &
+
+    if [ "$TELEMETRY_UPLINK" != "disabled" ]; then
+        nice /usr/local/bin/rssilogger /wifibroadcast_rx_status_uplink >> /wbc_tmp/telemetryuprssi.csv &
+    fi
+
+    if [ "$RC" != "disabled" ]; then
+        nice /usr/local/bin/rssilogger /wifibroadcast_rx_status_rc >> /wbc_tmp/rcrssi.csv &
+    fi
+
+    if [ "$DEBUG" == "Y" ]; then
+        nice /usr/local/bin/wifibackgroundscan $NICS >> /wbc_tmp/wifibackgroundscan.csv &
+    fi
+
     killall wbc_status > /dev/null 2>&1
     OSDRUNNING=`pidof /usr/local/bin/osd | wc -w`
 

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -252,7 +252,13 @@ function save_function {
         cp /wbc_tmp/debug.txt /media/usb/${SAVE_IDENTIFIER}/debug.txt
 
         sync
-        nice umount /media/usb
+
+        MOUNTED=`mount | grep /media/usb | wc -l`
+        while [ $MOUNTED -ge 1 ]; do
+            umount -A /media/usb
+            sleep 1
+            MOUNTED=`mount | grep /media/usb | wc -l`
+        done
 
         #
         # Inform the user that saving is done and the USB drive can be removed

--- a/wifibroadcast-scripts/video_save_functions.sh
+++ b/wifibroadcast-scripts/video_save_functions.sh
@@ -251,6 +251,7 @@ function save_function {
         #cp /wbc_tmp/tracker.txt /media/usb/${SAVE_IDENTIFIER}/
         cp /wbc_tmp/debug.txt /media/usb/${SAVE_IDENTIFIER}/debug.txt
 
+        sync
         nice umount /media/usb
 
         #


### PR DESCRIPTION
This PR does the following:

* Uses a unique folder name for each set of files saved to the usb drive, based on the date/time when saving started
    * The date will almost always be wrong until we allow QOpenHD to set it based on correct phone time, and/or let the microservice code set it based on GPS time coming from the flight controller
* Shows a warning on the OSD when recording space is full
* Corrects the log levels of the recording status messages
* Shows a progress message during save
* Restarts the rssi logger when saving to USB finishes
    * Seems like a simple omission, it wasn't be restarted before so it only worked for a single recording until reboot
* Remove the `usbmount` package as a dependency of the openhd package
    * Automounted the USB drive twice and made it difficult to unmount when we needed it to
* Ensure the USB drive actually unmounts by retrying
    * Solves a problem where the drive wasn't unmounted but the video save system wouldn't continue and allow you to save a 2nd flight video unless you removed the drive while it was still mounted, which may have made it look like recordings were being cut off