### PR TITLE
Docker improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ services:
 - docker
 compiler:
 - gcc
-cache:
-- "$HOME/.openhd_cache"
 jobs:
   include:
   - name: Pi stretch

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
 language: cpp
 os: linux
 dist: bionic
+env:
+  global:
+  - DOCKER_USERNAME=limitlessgreen
+  - secure: XKiksqrRxqTAablNn1mD1f2tAmDHbndhyYvPvhMQPyjPB5F2pZOs/4l+7uMPFCnj+MVWCechItgY2WWBm+xkPARFvPf3bCbito+xVhQvPYzSju4wS5inO2tcOIKhNNmzxaDs0P7Uvzx+rTzhHR3eNwYjTm3JugMHWW0m/CEXKLvcW3+o7Iv8qcqIi2z0buA1Vb96g0Ep4qmomRO9taLWy1SoK9YBzwSkiRG0hVRuoWz8F1aAU6JoNJaUEi2eCsncV2HG9oZsY0afurqksd3Y1TgytL/yysOzgOGPvwzD4MS3uw0zpnWe4Garuhu8xUotqfM8j91hirOccP2VeeCsh5o7dTPUDWp1OD2eGCbZ52Q3zn4mP1AleOjamKYlfxzf6JLcveuy1Gky4iRLsojmQsJHa8Cuaa7PNkyt4OSHcrhoDjc178BbwfpFJQy7beKWVbbpfFqNxSN3F7OGZiWfzeRfn3YNTiBgEVpS5aj35ySdixpUVbov1MbzbMQpBAfX6H353GSjL/tnwsIHJXxqgo68qC9l4kolDJfHs/i1Ja0Jw1RlmscOZgYzpUKzaGPhatct9BxilgNlJPrze4OzPtr9TwxVPDwqrBIpPxfc533MZFIxz03nPWD0BBdzozRoDv/ASlVc9eNhxvtJqTZC9FqVevIqqBDGFZ3/xmMS4w4=
 before_install:
-  - sudo docker run --privileged linuxkit/binfmt:v0.6
-  - sudo dpkg --add-architecture i386
-  - sudo apt -y update
-  - sudo apt -y install qemu-user-static:i386
+- sudo docker run --privileged linuxkit/binfmt:v0.6
+- sudo dpkg --add-architecture i386
+- sudo apt -y update
+- sudo apt -y install qemu-user-static:i386
 services:
-  - docker
+- docker
 compiler:
-  - gcc
+- gcc
 cache:
-  - $HOME/.openhd_cache
+- "$HOME/.openhd_cache"
 jobs:
   include:
-  - name: "Pi stretch"
+  - name: Pi stretch
     env: PLATFORM=pi DISTRO=stretch
-  - name: "Pi buster"
+  - name: Pi buster
     env: PLATFORM=pi DISTRO=buster
 script: bash ./build_docker.sh $PLATFORM $DISTRO

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,11 @@ compiler:
 jobs:
   include:
   - name: "Pi stretch"
-    env: DOCKERFILE=Dockerfile-pi-stretch
+    env: DOCKERFILE=Dockerfile-pi-stretch DISTRO=stretch
   - name: "Pi buster"
-    env: DOCKERFILE=Dockerfile-pi-buster
-script: docker build -f $DOCKERFILE --build-arg CLOUDSMITH_API_KEY=${CLOUDSMITH_API_KEY} .
+    env: DOCKERFILE=Dockerfile-pi-buster DISTRO=buster
+script: |
+
+        docker build -f $DOCKERFILE --build-arg CLOUDSMITH_API_KEY=${CLOUDSMITH_API_KEY} -t=openhd/${DISTRO} .
+        docker create -it -v $PWD:/src --name openhd_${DISTRO}_build openhd/${DISTRO}
+        docker start -i openhd_${DISTRO}_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,12 @@ services:
   - docker
 compiler:
   - gcc
+cache:
+  - $HOME/.openhd_cache
 jobs:
   include:
   - name: "Pi stretch"
-    env: DOCKERFILE=Dockerfile-pi-stretch DISTRO=stretch
+    env: PLATFORM=pi DISTRO=stretch
   - name: "Pi buster"
-    env: DOCKERFILE=Dockerfile-pi-buster DISTRO=buster
-script: |
-
-        docker build -f ${DOCKERFILE} --build-arg CLOUDSMITH_API_KEY=${CLOUDSMITH_API_KEY} -t=openhd/${DISTRO} .
-        docker create -it -v ${TRAVIS_BUILD_DIR}:/src --name openhd_${DISTRO}_build openhd/${DISTRO}
-        docker start -i openhd_${DISTRO}_build
+    env: PLATFORM=pi DISTRO=buster
+script: ./build_docker.sh $PLATFORM $DISTRO

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ jobs:
     env: DOCKERFILE=Dockerfile-pi-buster DISTRO=buster
 script: |
 
-        docker build -f $DOCKERFILE --build-arg CLOUDSMITH_API_KEY=${CLOUDSMITH_API_KEY} -t=openhd/${DISTRO} .
-        docker create -it -v $TRAVIS_BUILD_DIR:/src --name openhd_${DISTRO}_build openhd/${DISTRO}
+        docker build -f ${DOCKERFILE} --build-arg CLOUDSMITH_API_KEY=${CLOUDSMITH_API_KEY} -t=openhd/${DISTRO} .
+        docker create -it -v ${TRAVIS_BUILD_DIR}:/src --name openhd_${DISTRO}_build openhd/${DISTRO}
         docker start -i openhd_${DISTRO}_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ jobs:
 script: |
 
         docker build -f $DOCKERFILE --build-arg CLOUDSMITH_API_KEY=${CLOUDSMITH_API_KEY} -t=openhd/${DISTRO} .
-        docker create -it -v $PWD:/src --name openhd_${DISTRO}_build openhd/${DISTRO}
+        docker create -it -v $TRAVIS_BUILD_DIR:/src --name openhd_${DISTRO}_build openhd/${DISTRO}
         docker start -i openhd_${DISTRO}_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ jobs:
     env: PLATFORM=pi DISTRO=stretch
   - name: "Pi buster"
     env: PLATFORM=pi DISTRO=buster
-script: ./build_docker.sh $PLATFORM $DISTRO
+script: bash ./build_docker.sh $PLATFORM $DISTRO

--- a/Dockerfile-pi-buster
+++ b/Dockerfile-pi-buster
@@ -10,13 +10,6 @@ RUN apt -y install git
 RUN apt -y install ruby-dev
 RUN apt -y install python3-pip
 RUN apt -y purge python-configparser
-RUN apt -y install \
-            build-essential autotools-dev automake libtool autoconf \
-            libpcap-dev libpng-dev libsdl2-dev libsdl1.2-dev libconfig++-dev \
-            libreadline-dev libjpeg8-dev libusb-1.0-0-dev libsodium-dev \
-            libfontconfig1-dev libfreetype6-dev ttf-dejavu-core \
-            libboost-dev libboost-program-options-dev libboost-system-dev libasio-dev libboost-chrono-dev \
-            libboost-regex-dev libboost-filesystem-dev libboost-thread-dev wiringpi indent
 
 RUN gem install --no-document fpm
 RUN pip3 install --upgrade cloudsmith-cli

--- a/Dockerfile-pi-buster
+++ b/Dockerfile-pi-buster
@@ -18,8 +18,8 @@ RUN apt -y install \
             libboost-dev libboost-program-options-dev libboost-system-dev libasio-dev libboost-chrono-dev \
             libboost-regex-dev libboost-filesystem-dev libboost-thread-dev wiringpi indent
 
-RUN gem install fpm
-RUN pip3 install cloudsmith-cli
+RUN gem install --no-document fpm
+RUN pip3 install --upgrade cloudsmith-clii
 
 WORKDIR /src
 

--- a/Dockerfile-pi-buster
+++ b/Dockerfile-pi-buster
@@ -7,23 +7,18 @@ COPY install_dep.sh /data/install_dep.sh
 RUN /data/install_dep.sh
 
 RUN apt -y install git
-
 RUN apt -y install ruby-dev
-
 RUN apt -y install python3-pip
-
 RUN apt -y purge python-configparser
-
 RUN gem install fpm
-
 RUN pip3 install cloudsmith-cli
 
-COPY . /data/
-
-WORKDIR /data
+WORKDIR /src
 
 ARG CLOUDSMITH_API_KEY=000000000000
-
 RUN export CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY
 
-RUN /data/package.sh pi buster docker
+ENTRYPOINT ["./package.sh"]
+CMD ["pi", "buster", "docker"]
+
+VOLUME /src

--- a/Dockerfile-pi-buster
+++ b/Dockerfile-pi-buster
@@ -10,6 +10,14 @@ RUN apt -y install git
 RUN apt -y install ruby-dev
 RUN apt -y install python3-pip
 RUN apt -y purge python-configparser
+RUN apt -y install \
+            build-essential autotools-dev automake libtool autoconf \
+            libpcap-dev libpng-dev libsdl2-dev libsdl1.2-dev libconfig++-dev \
+            libreadline-dev libjpeg8-dev libusb-1.0-0-dev libsodium-dev \
+            libfontconfig1-dev libfreetype6-dev ttf-dejavu-core \
+            libboost-dev libboost-program-options-dev libboost-system-dev libasio-dev libboost-chrono-dev \
+            libboost-regex-dev libboost-filesystem-dev libboost-thread-dev wiringpi indent
+
 RUN gem install fpm
 RUN pip3 install cloudsmith-cli
 

--- a/Dockerfile-pi-buster
+++ b/Dockerfile-pi-buster
@@ -19,7 +19,7 @@ RUN apt -y install \
             libboost-regex-dev libboost-filesystem-dev libboost-thread-dev wiringpi indent
 
 RUN gem install --no-document fpm
-RUN pip3 install --upgrade cloudsmith-clii
+RUN pip3 install --upgrade cloudsmith-cli
 
 WORKDIR /src
 

--- a/Dockerfile-pi-stretch
+++ b/Dockerfile-pi-stretch
@@ -10,13 +10,6 @@ RUN apt -y install git
 RUN apt -y install ruby-dev
 RUN apt -y install python-pip
 RUN apt -y purge python-configparser
-RUN apt -y install \
-            build-essential autotools-dev automake libtool autoconf \
-            libpcap-dev libpng-dev libsdl2-dev libsdl1.2-dev libconfig++-dev \
-            libreadline-dev libjpeg8-dev libusb-1.0-0-dev libsodium-dev \
-            libfontconfig1-dev libfreetype6-dev ttf-dejavu-core \
-            libboost-dev libboost-program-options-dev libboost-system-dev libasio-dev libboost-chrono-dev \
-            libboost-regex-dev libboost-filesystem-dev libboost-thread-dev wiringpi indent
 
 RUN gem install --no-document fpm
 RUN pip install --upgrade cloudsmith-cli

--- a/Dockerfile-pi-stretch
+++ b/Dockerfile-pi-stretch
@@ -7,15 +7,10 @@ COPY install_dep.sh /data/install_dep.sh
 RUN /data/install_dep.sh
 
 RUN apt -y install git
-
 RUN apt -y install ruby-dev
-
 RUN apt -y install python-pip
-
 RUN apt -y purge python-configparser
-
 RUN gem install fpm
-
 RUN pip install cloudsmith-cli
 
 COPY . /data/
@@ -23,7 +18,9 @@ COPY . /data/
 WORKDIR /data
 
 ARG CLOUDSMITH_API_KEY=000000000000
-
 RUN export CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY
 
-RUN /data/package.sh pi stretch docker
+ENTRYPOINT ["./package.sh"]
+CMD ["pi", "buster", "docker"]
+
+VOLUME /src

--- a/Dockerfile-pi-stretch
+++ b/Dockerfile-pi-stretch
@@ -13,9 +13,7 @@ RUN apt -y purge python-configparser
 RUN gem install fpm
 RUN pip install cloudsmith-cli
 
-COPY . /data/
-
-WORKDIR /data
+WORKDIR /src
 
 ARG CLOUDSMITH_API_KEY=000000000000
 RUN export CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY

--- a/Dockerfile-pi-stretch
+++ b/Dockerfile-pi-stretch
@@ -18,8 +18,8 @@ RUN apt -y install \
             libboost-dev libboost-program-options-dev libboost-system-dev libasio-dev libboost-chrono-dev \
             libboost-regex-dev libboost-filesystem-dev libboost-thread-dev wiringpi indent
 
-RUN gem install fpm
-RUN pip install cloudsmith-cli
+RUN gem install --no-document fpm
+RUN pip install --upgrade cloudsmith-cli
 
 WORKDIR /src
 

--- a/Dockerfile-pi-stretch
+++ b/Dockerfile-pi-stretch
@@ -10,6 +10,14 @@ RUN apt -y install git
 RUN apt -y install ruby-dev
 RUN apt -y install python-pip
 RUN apt -y purge python-configparser
+RUN apt -y install \
+            build-essential autotools-dev automake libtool autoconf \
+            libpcap-dev libpng-dev libsdl2-dev libsdl1.2-dev libconfig++-dev \
+            libreadline-dev libjpeg8-dev libusb-1.0-0-dev libsodium-dev \
+            libfontconfig1-dev libfreetype6-dev ttf-dejavu-core \
+            libboost-dev libboost-program-options-dev libboost-system-dev libasio-dev libboost-chrono-dev \
+            libboost-regex-dev libboost-filesystem-dev libboost-thread-dev wiringpi indent
+
 RUN gem install fpm
 RUN pip install cloudsmith-cli
 

--- a/Dockerfile-pi-stretch
+++ b/Dockerfile-pi-stretch
@@ -21,6 +21,6 @@ ARG CLOUDSMITH_API_KEY=000000000000
 RUN export CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY
 
 ENTRYPOINT ["./package.sh"]
-CMD ["pi", "buster", "docker"]
+CMD ["pi", "stretch", "docker"]
 
 VOLUME /src

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -104,6 +104,23 @@ Contribution is always welcome!
 Start helping us by open up an issue or pull request.
 We recommend to get in touch with us via the {telegram} group.
 
+=== Build this repo
+The build system of the OpenHD main package is docker based.
+
+This showcase is for buster and works the same way for stretch:
+```
+docker build -f=./Dockerfile-pi-buster -t=openhd/buster .
+docker create -it -v $PWD:/src --name openhd_buster_build openhd/buster
+```
+And build the package with:
+```
+docker start -i openhd_buster_build
+```
+Steps 1 and 2 only need to be done once.
+After that, only step 3 should be executed (provided that nothing has been changed in the image)
+
+The DEB file should now be in your cloned directory.
+
 == License
 
 OpenHD is licensed under GPLv2, you can find it's contents in this link Raspbian, Linux Kernel, Drivers are licensed under GPLv2 Original code (if found) is licensed as stipulated in respective source files or under the GPLv2 license

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -33,8 +33,8 @@ function build_docker_image() {
 	$DOCKER build -f=./${DOCKERFILE} -t=${IMAGE} .
 
         if [[ -n $TRAVIS ]]; then
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-            $DOCKER push ${IMAGE}
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true
+            $DOCKER push ${IMAGE} || true
         fi
 
         sha256sum ${DOCKERFILE} > $HOME/.openhd_cache/${DOCKERFILE}.sha256

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -26,9 +26,9 @@ set -e
 
 function create_docker_container() {
     if $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY ${IMAGE} ; then
-        return true
+        return 0
     else
-        return false
+        return 1
     fi
 }
 

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -44,6 +44,9 @@ function create_docker_container() {
     elif [[ -n "$($DOCKER images -q ${IMAGE})" ]] ; then
         return 0
 
+    elif [[ $TRAVIS_EVENT_TYPE == "cron" ]] ; then
+        build_docker_image
+        
     else
         if ! $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY ${IMAGE} ; then
             build_docker_image

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -4,7 +4,7 @@ PLATFORM=$1
 DISTRO=$2   
 
 # only if ENV not set
-if [ -z "${DOCKER_USERNAME}" ]; then DOCKER_USERNAME=openhd; fi
+if [ -z "$DOCKER_USERNAME" ]; then DOCKER_USERNAME=openhd; fi
 
 DOCKERFILE=Dockerfile-${PLATFORM}-${DISTRO}
 CONTAINER=openhd_${PLATFORM}_${DISTRO}_build
@@ -24,32 +24,39 @@ if ! $DOCKER ps > /dev/null; then
 fi
 set -e
 
-function create_docker_container() {
-    if $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY ${IMAGE} ; then
-        return 0
-    else
-        return 1
-    fi
-}
 
 # Only (re)build image, if SHA of Dockerfile has changed
 function build_docker_image() {
 
-    if ! create_docker_container ; then
-        $DOCKER rm -v ${CONTAINER} > /dev/null 2>&1 || true
-	    $DOCKER build -f=./${DOCKERFILE} -t=${IMAGE} .
-
-        if [[ -n $TRAVIS ]]; then
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true
-            $DOCKER push ${IMAGE} || true
-        fi
-        create_docker_container
+    $DOCKER build -f=./${DOCKERFILE} -t=${IMAGE} .
+    if [[ -n $TRAVIS ]]; then
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true
+        $DOCKER push ${IMAGE} || true
     fi
 }
+
+
+function create_docker_container() {
+    if [[ (! -n "$($DOCKER images -q ${IMAGE})") && (-n "$($DOCKER images -q $DOCKER_USERNAME/${PLATFORM}_${DISTRO}_openhd_builder)")]] ; then
+        $DOCKER rm -v $DOCKER_USERNAME/${PLATFORM}_${DISTRO}_openhd_builder > /dev/null 2>&1 || true
+        create_docker_container
+
+    elif [[ -n "$($DOCKER images -q ${IMAGE})" ]] ; then
+        return 0
+
+    else
+        if ! $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY ${IMAGE} ; then
+            build_docker_image
+            $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY ${IMAGE}
+        fi
+    fi
+}
+
 
 function run_build() {
     $DOCKER start -i ${CONTAINER}
 }
+
 
 build_docker_image
 run_build

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -24,11 +24,12 @@ set -e
 
 # Only (re)build image, if SHA of Dockerfile has changed
 function build_docker_image() {
-    
-    mkdir -p $HOME/.openhd_cache > /dev/null 2>&1
-    
-    if ! sha256sum -c $HOME/.openhd_cache/${DOCKERFILE}.sha256 > /dev/null 2>&1 ; then
-        $DOCKER build -f=./${DOCKERFILE} -t=$DOCKER_USERNAME/${DISTRO} .
+
+    mkdir -p $HOME/.openhd_cache > /dev/null
+
+    if ! sha256sum -c $HOME/.openhd_cache/${DOCKERFILE}.sha256 > /dev/null ; then
+        $DOCKER rm -v ${CONTAINER} > /dev/null 2>&1 || true
+	$DOCKER build -f=./${DOCKERFILE} -t=$DOCKER_USERNAME/${DISTRO} .
 
         if [[ -n $TRAVIS ]]; then
             echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
@@ -40,8 +41,7 @@ function build_docker_image() {
 }
 
 function create_docker_container() {
-    $DOCKER rm -v ${CONTAINER} > /dev/null 2>&1
-    $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY
+    $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY $DOCKER_USERNAME/${DISTRO} || true
 }
 
 function run_build() {

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+
+PLATFORM=$1
+DISTRO=$2   
+
+# only if ENV not set
+if [ -z "${DOCKER_USERNAME}" ]; then DOCKER_USERNAME=openhd; fi
+
+DOCKERFILE=Dockerfile-${PLATFORM}-${DISTRO}
+CONTAINER=openhd_${PLATFORM}_${DISTRO}_build
+
+DOCKER="docker"
+set +e
+$DOCKER ps > /dev/null 2>&1
+if [ $? != 0 ]; then
+	DOCKER="sudo docker"
+fi
+if ! $DOCKER ps > /dev/null; then
+	echo "error connecting to docker:"
+	$DOCKER ps
+	exit 1
+fi
+set -e
+
+# Only (re)build image, if SHA of Dockerfile has changed
+function build_docker_image() {
+    
+    mkdir -p $HOME/.openhd_cache > /dev/null 2>&1
+    
+    if ! sha256sum -c $HOME/.openhd_cache/${DOCKERFILE}.sha256 > /dev/null 2>&1 ; then
+        $DOCKER build -f=./${DOCKERFILE} -t=$DOCKER_USERNAME/${DISTRO} .
+
+        if [[ -n $TRAVIS ]]; then
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+            $DOCKER push $DOCKER_USERNAME/${DISTRO}
+        fi
+
+        sha256sum ${DOCKERFILE} > $HOME/.openhd_cache/${DOCKERFILE}.sha256
+    fi
+}
+
+function create_docker_container() {
+    $DOCKER rm -v ${CONTAINER} > /dev/null 2>&1
+    $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY
+}
+
+function run_build() {
+    $DOCKER start -i ${CONTAINER}
+}
+
+build_docker_image
+create_docker_container
+run_build

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -38,7 +38,7 @@ function build_docker_image() {
 
 function create_docker_container() {
     if [[ (! -n "$($DOCKER images -q ${IMAGE})") && (-n "$($DOCKER images -q $DOCKER_USERNAME/${PLATFORM}_${DISTRO}_openhd_builder)")]] ; then
-        $DOCKER rm -v $DOCKER_USERNAME/${PLATFORM}_${DISTRO}_openhd_builder > /dev/null 2>&1 || true
+        $DOCKER rm -v ${CONTAINER} > /dev/null 2>&1 || true
         create_docker_container
 
     elif [[ -n "$($DOCKER images -q ${IMAGE})" ]] ; then

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -8,6 +8,7 @@ if [ -z "${DOCKER_USERNAME}" ]; then DOCKER_USERNAME=openhd; fi
 
 DOCKERFILE=Dockerfile-${PLATFORM}-${DISTRO}
 CONTAINER=openhd_${PLATFORM}_${DISTRO}_build
+IMAGE=$DOCKER_USERNAME/${PLATFORM}_${DISTRO}_openhd_builder
 
 DOCKER="docker"
 set +e
@@ -29,11 +30,11 @@ function build_docker_image() {
 
     if ! sha256sum -c $HOME/.openhd_cache/${DOCKERFILE}.sha256 > /dev/null ; then
         $DOCKER rm -v ${CONTAINER} > /dev/null 2>&1 || true
-	$DOCKER build -f=./${DOCKERFILE} -t=$DOCKER_USERNAME/${DISTRO} .
+	$DOCKER build -f=./${DOCKERFILE} -t=${IMAGE} .
 
         if [[ -n $TRAVIS ]]; then
             echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-            $DOCKER push $DOCKER_USERNAME/${DISTRO}
+            $DOCKER push ${IMAGE}
         fi
 
         sha256sum ${DOCKERFILE} > $HOME/.openhd_cache/${DOCKERFILE}.sha256
@@ -41,7 +42,7 @@ function build_docker_image() {
 }
 
 function create_docker_container() {
-    $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY $DOCKER_USERNAME/${DISTRO} || true
+    $DOCKER create -it -v $PWD:/src --name ${CONTAINER} --env CLOUDSMITH_API_KEY=$CLOUDSMITH_API_KEY ${IMAGE} || true
 }
 
 function run_build() {

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -58,5 +58,5 @@ function run_build() {
 }
 
 
-build_docker_image
+create_docker_container
 run_build

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-ba8a2e2e6f88f066eb0f30358fe7902e7fd7760bd4b358841101d344b6653ebd  Dockerfile-pi-buster

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+ba8a2e2e6f88f066eb0f30358fe7902e7fd7760bd4b358841101d344b6653ebd  Dockerfile-pi-buster


### PR DESCRIPTION
This is an other improvement of the build system.

This is how the build procedure changed now (this showcase is for buster ans works the same way with stretch):
```
docker build -f=./Dockerfile-pi-buster -t=openhd/buster .
docker create -it -v $PWD:/src --name openhd_buster_build openhd/buster
docker start -i openhd_buster_build
```
Steps 1 and 2 only need to be done once.
After that, only step 3 should be run (provided that nothing has been changed in the image)

Locally this reduces the build time from >10 minutes to 2, after the build was already done once 

The separation of the docker build step opens also the ability to push the image to docker-hub which would  give the Travis build a boost too.
