### PR TITLE
Use Extension Counter in RadioTap Header to Select Global RF metrics

### DIFF
--- a/wifibroadcast-base/Makefile
+++ b/wifibroadcast-base/Makefile
@@ -1,5 +1,11 @@
-LDFLAGS=-lrt -lpcap -lwiringPi
-CPPFLAGS=-Wall -O2 -march=armv6zk -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -D _GNU_SOURCE
+CFLAGS=-Wall -D _GNU_SOURCE
+CFLAGS+=-O2 -march=armv6zk -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard
+#CFLAGS+=-DRF_DEBUG=1
+LDFLAGS=-lrt -lpcap
+LDFLAGS+=-lwiringPi
+
+CPPFLAGS=-Wall -g -D _GNU_SOURCE
+CPPFLAGS= $(CFLAGS)
 CFLAGS := $(CFLAGS) -I../lib/mavlink_generated/include/mavlink/v2.0/
 
 all: rx_rc_telemetry_buf rx rx_rc_telemetry rssirx rssitx tx_rawsock tx_telemetry rx_status tracker rssilogger syslogger channelscan check_alive rssi_forward rssi_qgc_forward wifiscan wifibackgroundscan sharedmem_init_rx sharedmem_init_tx

--- a/wifibroadcast-base/radiotap_iter.h
+++ b/wifibroadcast-base/radiotap_iter.h
@@ -123,6 +123,7 @@ struct ieee80211_radiotap_iterator {
     int n_overrides;
     int this_arg_index;
     int this_arg_size;
+    int ext_count;
 
     int is_radiotap_ns;
 

--- a/wifibroadcast-base/radiotap_rc.c
+++ b/wifibroadcast-base/radiotap_rc.c
@@ -206,6 +206,7 @@ int ieee80211_radiotap_iterator_init(struct ieee80211_radiotap_iterator *iterato
     iterator->_vns = vns;
     iterator->current_namespace = &radiotap_ns;
     iterator->is_radiotap_ns = 1;
+    iterator->ext_count = 0;
 
     #ifdef RADIOTAP_SUPPORT_OVERRIDES
     iterator->n_overrides = 0;
@@ -534,6 +535,7 @@ int ieee80211_radiotap_iterator_next(struct ieee80211_radiotap_iterator *iterato
                     iterator->_arg_index++;
                 }
 
+		iterator->ext_count++;
                 iterator->_reset_on_ext = 0;
                 
                 break;


### PR DESCRIPTION
Fix the RSSI Bug with wifi driver having more than 1 antenna with RF metrics reporting in radiotap header.
It has been tested in standlone mode , but not yet with OpenHD air or Ground

Compiling with RF_DEBUG flags enable a verbose mode , only in rssirx at the moment.