### PR TITLE
Add Timelaps Air function

### DIFF
--- a/openhd-camera/openhdvid
+++ b/openhd-camera/openhdvid
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from time import sleep
 import time
+import threading
 
 import shutil
 
@@ -16,6 +17,28 @@ import picamera
 #mavutil.set_dialect('openhd')
 
 sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
+
+class threadSaveTimelaps(threading.Thread):
+    def __init__(self, myPiCamera, timelapsPath, resize=False, width=0, height=0):
+        threading.Thread.__init__(self)
+        self.timelapsPath = timelapsPath
+        self.picam = myPiCamera
+        self.threadLock = threading.Lock()
+        self.resize=resize
+        self.width=width
+        self.height=height
+    def run(self):
+        self.threadLock.acquire(0)
+        img_file_name = self.timelapsPath + datetime.now().strftime("%y%m%d-%H%M%S-%f") + ".yuv"
+        # don't hook up the resize component in the pipeline if the resolution is the same as the main stream
+        if self.resize:
+            self.picam.capture(img_file_name, format='yuv', use_video_port=True, resize=(self.width, self.height), splitter_port=3)
+        else:
+            #capture_continuous
+            self.picam.capture(img_file_name, format='yuv', use_video_port=True, splitter_port=3)
+        # Free lock to release next thread
+        self.threadLock.release()
+
 
 class OpenHDCamera:
     def __init__(self, option):
@@ -126,17 +149,17 @@ class OpenHDCamera:
         #setting the camera sensor resolution to the biggest one configured
         self.max_width=option.width
         self.max_height=option.height
-        if self.record_local and (option.width_record > self.max_width or option.height_record > self.max_height):
-            self.max_width = option.width_record
-            self.max_height = option.height_record
+        #if self.record_local and (option.width_record > self.max_width or option.height_record > self.max_height):
+        #    self.max_width = option.width_record
+        #    self.max_height = option.height_record
             
-        if self.timelaps_local and (option.width_timelaps > self.max_width or option.height_timelaps > self.max_height):
-            self.max_width = option.width_timelaps
-            self.max_height = option.height_timelaps    
+        #if self.timelaps_local and (option.width_timelaps > self.max_width or option.height_timelaps > self.max_height):
+        #    self.max_width = option.width_timelaps
+        #    self.max_height = option.height_timelaps    
         
         self.camera.resolution=(self.max_width,self.max_height)
 
-        print("Camera initialized", file=sys.stderr)
+        print("Camera initialized with a main resolution of " + str(self.max_width) + "x" + str(self.max_height), file=sys.stderr)
 
     def check_used_space(self, path):
         total, used, free = shutil.disk_usage(path)
@@ -148,9 +171,9 @@ class OpenHDCamera:
     def run(self):
         print("OpenHDCamera.run()", file=sys.stderr)
 
+        #resize=(option.width, option.height),
         self.camera.start_recording(self.output, 
                                     format=self.codec.lower(), 
-                                    resize=(option.width, option.height),
                                     profile=self.profile,
                                     intra_period=self.intra_period,
                                     intra_refresh=self.intra_refresh,
@@ -195,7 +218,7 @@ class OpenHDCamera:
             # this can be replaced with a pymavlink event trigger once pymavlink is available on the image
             now = time.time()
             elapsed = now - start
-            if self.record_local and elapsed > 1:
+            if self.record_local and elapsed > 5:
                 start = time.time()
 
                 percent_used = self.check_used_space(self.record_path)
@@ -215,18 +238,17 @@ class OpenHDCamera:
                     self.timelaps_local = False
                     print("Available space less than 10%, stopping image timelaps recording", file=sys.stderr)
                 else:
-                    img_file_name = self.timelaps_path + datetime.now().strftime("%y%m%d-%H%M%S-%f") + ".yuv"
-                    # don't hook up the resize component in the pipeline if the resolution is the same as the main stream
+                    #Saving timelaps in a thread to avoid latency
+                    resize = True
                     if option.width_timelaps == self.max_width and option.height_timelaps == self.max_height:
-                        self.camera.capture(img_file_name, format='yuv', use_video_port=True, splitter_port=3)
-                        print(str(now) + " Recording image to file with video resolution" + img_file_name, file=sys.stderr)
-                    else:
-                        #capture_continuous
-                        self.camera.capture(img_file_name, format='yuv', use_video_port=True, resize=(option.width_timelaps, option.height_timelaps), splitter_port=3)
-                        print(str(now) + " Recording image to file " + img_file_name + " with specific resolution " + str(option.width_timelaps) + "x" + str(option.height_timelaps), file=sys.stderr)
+                        resize = False
+                    myThreadSaveTimelaps = threadSaveTimelaps(myPiCamera=self.camera, timelapsPath=self.timelaps_path, resize=resize, width=option.width_timelaps, height=option.height_timelaps)
+                    myThreadSaveTimelaps.start()
+            
+            sleep(0.05)
             
             #allow the camera to generate errors 
-            self.camera.wait_recording(self.second_timelaps);
+            #self.camera.wait_recording(0);
             
         self.camera.stop_recording(splitter_port=1)
         self.camera.stop_recording(splitter_port=2)

--- a/openhd-camera/openhdvid
+++ b/openhd-camera/openhdvid
@@ -26,9 +26,8 @@ class OpenHDCamera:
         #                                      robust_parsing=True,
         #                                      source_system=255)
 
-
-        
-        self.camera = picamera.PiCamera(resolution=(option.width, option.height), framerate=option.framerate)
+        #resolution will be set later, with the biggest one between : FPV, recording and timestamp
+        self.camera = picamera.PiCamera(framerate=option.framerate)
 
         if option.iso:
             self.camera.iso = option.iso
@@ -95,10 +94,25 @@ class OpenHDCamera:
 
             f = pathlib.Path(self.record_path)
             f.touch()
-
         else:
             self.record_path = None
             self.record_local = False
+            
+        if option.timelaps:
+            self.timelaps_local = True
+            filename, file_extension = os.path.splitext(option.timelaps)
+            #Not matter about file extension, we are recording in YUV because it doesn't work in JPEG
+            self.timelaps_path = filename
+
+            f = pathlib.Path(self.timelaps_path)
+            f.touch()
+            
+            self.second_timelaps = option.second_timelaps
+            
+        else:
+            self.timelaps_path = None
+            self.timelaps_local = False  
+            self.second_timelaps = 1
 
         self.codec = option.codec
         self.profile = option.profile
@@ -108,6 +122,20 @@ class OpenHDCamera:
         self.sps_timing = option.sps_timing
         self.bitrate = option.bitrate
         self.bitrate_record = option.bitrate_record
+        
+        #setting the camera sensor resolution to the biggest one configured
+        self.max_width=option.width
+        self.max_height=option.height
+        if self.record_local and (option.width_record > self.max_width or option.height_record > self.max_height):
+            self.max_width = option.width_record
+            self.max_height = option.height_record
+            
+        if self.timelaps_local and (option.width_timelaps > self.max_width or option.height_timelaps > self.max_height):
+            self.max_width = option.width_timelaps
+            self.max_height = option.height_timelaps    
+        
+        self.camera.resolution=(self.max_width,self.max_height)
+
         print("Camera initialized", file=sys.stderr)
 
     def check_used_space(self, path):
@@ -122,6 +150,7 @@ class OpenHDCamera:
 
         self.camera.start_recording(self.output, 
                                     format=self.codec.lower(), 
+                                    resize=(option.width, option.height),
                                     profile=self.profile,
                                     intra_period=self.intra_period,
                                     intra_refresh=self.intra_refresh,
@@ -137,17 +166,25 @@ class OpenHDCamera:
                 print("Not enough space available to record locally", file=sys.stderr)
             else:
                 # don't hook up the resize component in the pipeline if the resolution is the same as the main stream
-                if option.width_record == option.width and option.height_record == option.height:
+                if option.width_record == self.max_width and option.height_record == self.max_height:
                     self.camera.start_recording(self.record_path, 'h264', splitter_port=2, bitrate=self.bitrate_record)
                 else:
                     self.camera.start_recording(self.record_path, 'h264', resize=(option.width_record, option.height_record), splitter_port=2, bitrate=self.bitrate_record)
                 print("Recording to file " + self.record_path, file=sys.stderr)
+        
+        
+        if self.timelaps_local:
+            percent_used = self.check_used_space(self.timelaps_path)
+            if percent_used > 90.0:
+                self.timelaps_local = False
+                print("Not enough space available to record timelaps locally", file=sys.stderr)
 
         print("Camera running", file=sys.stderr)
 
         #self.event = mavutil.periodic_event(30)
         
         start = time.time()
+        last_timelaps = 0;
 
         while True:
             #if self.event.trigger():
@@ -167,8 +204,30 @@ class OpenHDCamera:
                     self.record_local = False
                     print("Available space less than 10%, stopping video recording", file=sys.stderr)
                     self.camera.stop_recording(splitter_port=2)
-            sleep(0.05)
-
+            
+            elapsed = now - last_timelaps
+            if self.timelaps_local and elapsed > self.second_timelaps:
+                last_timelaps = now
+                
+                percent_used = self.check_used_space(self.timelaps_path)
+                
+                if percent_used > 90.0:
+                    self.timelaps_local = False
+                    print("Available space less than 10%, stopping image timelaps recording", file=sys.stderr)
+                else:
+                    img_file_name = self.timelaps_path + datetime.now().strftime("%y%m%d-%H%M%S-%f") + ".yuv"
+                    # don't hook up the resize component in the pipeline if the resolution is the same as the main stream
+                    if option.width_timelaps == self.max_width and option.height_timelaps == self.max_height:
+                        self.camera.capture(img_file_name, format='yuv', use_video_port=True, splitter_port=3)
+                        print(str(now) + " Recording image to file with video resolution" + img_file_name, file=sys.stderr)
+                    else:
+                        #capture_continuous
+                        self.camera.capture(img_file_name, format='yuv', use_video_port=True, resize=(option.width_timelaps, option.height_timelaps), splitter_port=3)
+                        print(str(now) + " Recording image to file " + img_file_name + " with specific resolution " + str(option.width_timelaps) + "x" + str(option.height_timelaps), file=sys.stderr)
+            
+            #allow the camera to generate errors 
+            self.camera.wait_recording(self.second_timelaps);
+            
         self.camera.stop_recording(splitter_port=1)
         self.camera.stop_recording(splitter_port=2)
 
@@ -197,6 +256,11 @@ if __name__ == '__main__':
     parser.add_argument('--width_record', '-wr', action="store", dest="width_record", type=int, default=1280)
     parser.add_argument('--height_record', '-hr', action="store", dest="height_record", type=int, default=720)
     parser.add_argument('--bitrate_record', '-brec', action="store", dest="bitrate_record", type=int, default=4000000)
+    
+    parser.add_argument('--timelaps', '-tl', action="store", dest="timelaps", type=str)
+    parser.add_argument('--width_timelaps', '-wtl', action="store", dest="width_timelaps", type=int, default=1280)
+    parser.add_argument('--height_timelaps', '-htl', action="store", dest="height_timelaps", type=int, default=720)
+    parser.add_argument('--second_timelaps', '-stl', action="store", dest="second_timelaps", type=int, default=5)
 
 
     parser.add_argument('--output', '-o', action="store", dest="output", type=str, default="-")


### PR DESCRIPTION
Adding a function to allow timelaps pictures to be recorded on the air side.

Options to put into the EXTRAPARAMS of the openhd-settings-1.txt file are : 

- --timelaps /home/pi/timelaps.jpeg => Path to saved image. Extension of file is not used. We are saving images in YUV format
- -wtl 2028 => Width
- -htl 1080 => Height
- -stl 1 => Time in seconds between each capture