### PR TITLE
Remove videoformat from VEYE

### DIFF
--- a/config/openhd-settings-1.txt
+++ b/config/openhd-settings-1.txt
@@ -363,6 +363,29 @@ IMX290_wdrtargetbr=0x80
 # Takes effect in WDR mode. range: [0-0xFF]
 IMX290_wdrbtargetbr=0x80
 
+#IR-CUT (Infrared cut-off filter) is a mechanical shutter design. It is placed between the lens and the image sensor, and is controlled by a motor or an electromagnet.
+#IR-CUT has two status: Block or Deliver the infrared.
+#Color Mode - Image is Color Mode and IR_CUT status Block infrared.
+#Black&White Mode - Image is Black&White Mode and IR_CUT status Deliver infrared.
+#Trigger Mode - Trigger pin : J3 pin1.
+#Trigger pin High(3.3~12V),Image is Black&White Mode and IR-CUT status Deliver infrared.
+#Trigger pin Low(GND),Image is Color Mode and IR-CUT status Bolck infrared.
+IMX290_daynightmode=0xFF
+
+#close AE, use manual shutter
+#value is exposure time（seconds）
+#If value is greater than or equal to 0x4B, it will reduce framerate.
+IMX290_mshutter=0x40
+
+#White balance mode setting.
+IMX290_wbmode=0x18
+
+#Rgain and Bgain setting in manual white balance mode.arameter range [0,0xFF].
+IMX290_mwbgain1=0x00
+IMX290_mwbgain2=0x00
+
+#Set yuv seq of camera. Note: only supported on hdver >= 0x4
+#IMX290_yuvseq=YUYV
 
 # Used to flip/mirror the IMX307 camera, separate setting from IMX290 because they don't handle it the same way
 # 0: normal, 1: flip, 2: mirror, 3: flip+mirror. 

--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -29,6 +29,7 @@ function tx_function {
         # Configure the camera's ISP parameters
         #
         pushd /usr/local/share/veye-raspberrypi
+        /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f videoformat -p1 $IMX290_videoformat > /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f wdrmode -p1 $IMX290_wdrmode > /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f mirrormode -p1 $IMX290_mirrormode >> /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f denoise -p1 $IMX290_denoise >> /tmp/imx290log
@@ -70,6 +71,26 @@ function tx_function {
 
         if [ "${IMX290_wdrbtargetbr}" != "" ]; then
             /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f wdrbtargetbr -p1 ${IMX290_wdrbtargetbr} >> /tmp/imx290log
+        fi
+
+        if [ "${IMX290_daynightmode}" != "" ]; then
+            /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f daynightmode -p1 ${IMX290_daynightmode} >> /tmp/imx290log
+        fi
+
+        if [ "${IMX290_mshutter}" != "" ]; then
+            /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f mshutter -p1 ${IMX290_mshutter} >> /tmp/imx290log
+        fi
+
+        if [ "${IMX290_wbmode}" != "" ]; then
+            /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f wbmode -p1 ${IMX290_wbmode} >> /tmp/imx290log
+        fi
+        
+        if [ "${IMX290_mwbgain1}" != "" ]; then
+            /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f mwbgain -p1 ${IMX290_mwbgain1} -p2 ${IMX290_mwbgain2} >> /tmp/imx290log
+        fi
+        
+        if [ "${IMX290_yuvseq}" != "" ]; then
+            /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f yuvseq -p1 ${IMX290_yuvseq} >> /tmp/imx290log
         fi
 
         /usr/local/share/veye-raspberrypi/cs_mipi_i2c.sh -w -f imagedir -p1 $IMX307_imagedir >> /tmp/imx290log

--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -29,7 +29,6 @@ function tx_function {
         # Configure the camera's ISP parameters
         #
         pushd /usr/local/share/veye-raspberrypi
-        /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f videoformat -p1 $IMX290_videoformat > /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f wdrmode -p1 $IMX290_wdrmode > /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f mirrormode -p1 $IMX290_mirrormode >> /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f denoise -p1 $IMX290_denoise >> /tmp/imx290log


### PR DESCRIPTION
This setting was added in with the other lot as it looked to be missing. From reading the documentation it looks like this needs to be set before detection so it is being removed again to see if it fixes issues with startup.