### PR TITLE
Run camera config

### DIFF
--- a/wifibroadcast-scripts/.profile
+++ b/wifibroadcast-scripts/.profile
@@ -59,6 +59,8 @@ if [ "$TTY" == "/dev/tty1" ]; then
         # No pi camera detected, but we still might have a VEYE, and the only way to detect
         # it is to have i2c_vc enabled already, and then probe the i2c-0 bus
         #
+        /usr/local/share/veye-raspberrypi/camera_i2c_config
+
         i2cdetect -y 0 0x3b 0x3b | grep  "30:                                  3b            "
         grepRet=$?
 

--- a/wifibroadcast-scripts/tx_functions.sh
+++ b/wifibroadcast-scripts/tx_functions.sh
@@ -29,7 +29,6 @@ function tx_function {
         # Configure the camera's ISP parameters
         #
         pushd /usr/local/share/veye-raspberrypi
-        /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f videoformat -p1 $IMX290_videoformat > /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f wdrmode -p1 $IMX290_wdrmode > /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f mirrormode -p1 $IMX290_mirrormode >> /tmp/imx290log
         /usr/local/share/veye-raspberrypi/veye_mipi_i2c.sh -w -f denoise -p1 $IMX290_denoise >> /tmp/imx290log


### PR DESCRIPTION
Added in a command run run the camera config for VEYE cams prior to detection.