### PR TITLE
Jetson Nano compatibility, bugfixes, power&status microservices

### DIFF
--- a/after-install.sh
+++ b/after-install.sh
@@ -6,6 +6,7 @@ systemctl enable openhd_system
 systemctl enable openhd_security
 systemctl enable openhd_interface
 systemctl enable openhd_video
+systemctl enable openhd_power
 systemctl enable openhd_telemetry@microservice
 systemctl enable openhd_telemetry@telemetry
 

--- a/after-install.sh
+++ b/after-install.sh
@@ -7,6 +7,7 @@ systemctl enable openhd_security
 systemctl enable openhd_interface
 systemctl enable openhd_video
 systemctl enable openhd_power
+systemctl enable openhd_status
 systemctl enable openhd_telemetry@microservice
 systemctl enable openhd_telemetry@telemetry
 

--- a/openhd-common/openhd-wifi.hpp
+++ b/openhd-common/openhd-wifi.hpp
@@ -11,6 +11,7 @@ typedef enum WiFiCardType {
     WiFiCardTypeRealtek8814au,
     WiFiCardTypeRealtek88x2bu,
     WiFiCardTypeRealtek8188eu,
+    WiFiCardTypeAtheros9khtc,
     WiFiCardTypeAtheros9k,
     WiFiCardTypeRalink,
     WiFiCardTypeIntel,
@@ -55,6 +56,9 @@ inline std::string wifi_card_type_to_string(WiFiCardType card_type) {
         case WiFiCardTypeAtheros9k: {
             return "ath9k_htc";
         }
+        case WiFiCardTypeAtheros9khtc: {
+            return "ath9k_htc";
+        }
         case WiFiCardTypeRealtek8812au: {
             return "88xxau";
         }
@@ -82,6 +86,8 @@ inline std::string wifi_card_type_to_string(WiFiCardType card_type) {
 
 inline WiFiCardType string_to_wifi_card_type(std::string driver_name) {
     if (to_uppercase(driver_name).find(to_uppercase("ath9k_htc")) != std::string::npos) {
+        return WiFiCardTypeAtheros9khtc;
+    } else if (to_uppercase(driver_name).find(to_uppercase("ath9k")) != std::string::npos) {
         return WiFiCardTypeAtheros9k;
     } else if (to_uppercase(driver_name).find(to_uppercase("rt2800usb")) != std::string::npos) {
         return WiFiCardTypeRalink;

--- a/openhd-interface/src/streams.cpp
+++ b/openhd-interface/src/streams.cpp
@@ -208,14 +208,6 @@ boost::process::child Streams::start_video_stream(Stream stream) {
         throw std::runtime_error("no wifibroadcast interfaces available");
     }
 
-    std::string interface_names;
-
-    for (auto interface : broadcast_interfaces) {
-        interface_names += interface;
-        interface_names += " ";
-    }
-
-    boost::trim_right(interface_names);
 
 
     if (m_is_air) {    
@@ -230,8 +222,10 @@ boost::process::child Streams::start_video_stream(Stream stream) {
             "-M", std::to_string(stream.mcs), 
             "-k", std::to_string(stream.data_blocks), 
             "-n", std::to_string(stream.total_blocks),
-            interface_names
         };
+
+        tx_args.insert(tx_args.end(), broadcast_interfaces.begin(), broadcast_interfaces.end());
+
 
 
         boost::process::child c_tx(boost::process::search_path("wfb_tx"), tx_args, m_io_service);
@@ -246,8 +240,9 @@ boost::process::child Streams::start_video_stream(Stream stream) {
             "-K", stream.rx_keypair, 
             "-k", std::to_string(stream.data_blocks), 
             "-n", std::to_string(stream.total_blocks),
-            interface_names
         };
+
+        rx_args.insert(rx_args.end(), broadcast_interfaces.begin(), broadcast_interfaces.end());
 
 
         boost::process::child c_rx(boost::process::search_path("wfb_rx"), rx_args, m_io_service);
@@ -272,15 +267,6 @@ stream_pair Streams::start_telemetry_stream(Stream stream) {
     }
 
 
-    std::string interface_names;
-
-    for (auto interface : broadcast_interfaces) {
-        interface_names += interface;
-        interface_names += " ";
-    }
-
-    boost::trim_right(interface_names);
-
 
     std::vector<std::string> rx_args { 
         "-p", std::to_string(m_is_air ? stream.rf_rx_port : stream.rf_tx_port), 
@@ -288,8 +274,8 @@ stream_pair Streams::start_telemetry_stream(Stream stream) {
         "-K", m_is_air ? stream.rx_keypair : stream.tx_keypair,
         "-k", std::to_string(stream.data_blocks), 
         "-n", std::to_string(stream.total_blocks),
-        interface_names
     };
+    rx_args.insert(rx_args.end(), broadcast_interfaces.begin(), broadcast_interfaces.end());
 
 
     std::vector<std::string> tx_args { 
@@ -303,8 +289,8 @@ stream_pair Streams::start_telemetry_stream(Stream stream) {
         "-M", std::to_string(stream.mcs), 
         "-k", std::to_string(stream.data_blocks), 
         "-n", std::to_string(stream.total_blocks),
-        interface_names
     };
+    rx_args.insert(rx_args.end(), broadcast_interfaces.begin(), broadcast_interfaces.end());
 
 
     boost::process::child c_tx(boost::process::search_path("wfb_tx"), tx_args, m_io_service);

--- a/openhd-interface/src/streams.cpp
+++ b/openhd-interface/src/streams.cpp
@@ -290,7 +290,7 @@ stream_pair Streams::start_telemetry_stream(Stream stream) {
         "-k", std::to_string(stream.data_blocks), 
         "-n", std::to_string(stream.total_blocks),
     };
-    rx_args.insert(rx_args.end(), broadcast_interfaces.begin(), broadcast_interfaces.end());
+    tx_args.insert(tx_args.end(), broadcast_interfaces.begin(), broadcast_interfaces.end());
 
 
     boost::process::child c_tx(boost::process::search_path("wfb_tx"), tx_args, m_io_service);

--- a/openhd-interface/src/streams.cpp
+++ b/openhd-interface/src/streams.cpp
@@ -271,7 +271,7 @@ stream_pair Streams::start_telemetry_stream(Stream stream) {
     std::vector<std::string> rx_args { 
         "-p", std::to_string(m_is_air ? stream.rf_rx_port : stream.rf_tx_port), 
         "-u", std::to_string(stream.local_rx_port), 
-        "-K", m_is_air ? stream.rx_keypair : stream.tx_keypair,
+        "-K", stream.rx_keypair,
         "-k", std::to_string(stream.data_blocks), 
         "-n", std::to_string(stream.total_blocks),
     };
@@ -281,7 +281,7 @@ stream_pair Streams::start_telemetry_stream(Stream stream) {
     std::vector<std::string> tx_args { 
         "-p", std::to_string(m_is_air ? stream.rf_tx_port : stream.rf_rx_port),
         "-u", std::to_string(stream.local_tx_port), 
-        "-K", m_is_air ? stream.tx_keypair : stream.rx_keypair,
+        "-K", stream.tx_keypair,
         "-B", std::to_string(stream.bandwidth), 
         "-G", stream.short_gi ? "short" : "long", 
         "-S", stream.stbc ? "1" : "0", 

--- a/openhd-power/Makefile
+++ b/openhd-power/Makefile
@@ -1,0 +1,47 @@
+
+SRC_DIR = $(PWD)/src
+LIB_DIR = $(PWD)/lib
+
+CFLAGS = -I$(PWD)/../lib/fmt/include  -I$(PREFIX)/include -I$(PWD)/inc -I$(PWD)/../openhd-common -I$(PWD)/../lib/mavlink_generated/include/mavlink/v2.0 `pkg-config --cflags gstreamer-base-1.0`
+
+ifeq ($(PREFIX),)
+	PREFIX := /usr/local
+endif
+
+ifdef $(DESTDIR)
+	$(DESTDIR) := $(DESTDIR)/
+endif
+
+LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lboost_signals -lsystemd `pkg-config --libs gstreamer-base-1.0`
+
+openhd_power: powermicroservice.o main.o
+	g++ -g -pthread -o openhd_power powermicroservice.o main.o  $(LDFLAGS)
+
+main.o: $(SRC_DIR)/main.cpp
+	g++ -std=c++17 -Wno-psabi -g -c -pthread $(CFLAGS) $(SRC_DIR)/main.cpp
+
+
+powermicroservice.o: $(SRC_DIR)/powermicroservice.cpp
+	g++ -std=c++17 -Wno-psabi -g -c -pthread $(CFLAGS) $(SRC_DIR)/powermicroservice.cpp
+
+
+
+clean:
+	rm -f *.o openhd_power
+
+
+.PHONY: install
+install: openhd_power
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install -d $(DESTDIR)/etc/systemd/system
+	install -m 755 openhd_power $(DESTDIR)$(PREFIX)/bin/
+	install -m 644 openhd_power.service $(DESTDIR)/etc/systemd/system/
+
+.PHONY: enable
+enable: install
+	systemctl enable openhd_power
+	systemctl start openhd_power
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/bin/openhd_power

--- a/openhd-power/inc/powermicroservice.h
+++ b/openhd-power/inc/powermicroservice.h
@@ -1,0 +1,41 @@
+#ifndef POWERMICROSERVICE_H
+#define POWERMICROSERVICE_H
+
+#include <openhd/mavlink.h>
+
+#include <array>
+#include <stdexcept>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#include "openhd-microservice.hpp"
+#include "openhd-platform.hpp"
+
+
+
+
+class PowerMicroservice: public Microservice {
+public:
+    PowerMicroservice(boost::asio::io_service &io_service, PlatformType platform, bool is_air, std::string unit_id);
+
+    void setup();
+    void process_manifest();
+    void process_settings();
+
+    void save_settings();
+
+    void process_mavlink_message(mavlink_message_t msg);
+
+    void configure();
+
+private:
+
+    std::string m_unit_id;
+
+    bool m_is_air = false;
+
+    int m_base_port = 5620;
+};
+
+#endif

--- a/openhd-power/openhd_power.service
+++ b/openhd-power/openhd_power.service
@@ -8,4 +8,4 @@ ExecStart=/usr/local/bin/openhd_power
 
 [Install]
 WantedBy=multi-user.target
-Alias=openhdvideo.service
+Alias=openhdpower.service

--- a/openhd-power/openhd_power.service
+++ b/openhd-power/openhd_power.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=openhd-power
+After=openhdinterface.service
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/openhd_power
+
+[Install]
+WantedBy=multi-user.target
+Alias=openhdvideo.service

--- a/openhd-power/src/main.cpp
+++ b/openhd-power/src/main.cpp
@@ -1,0 +1,100 @@
+#include <fstream>
+
+#include <iostream>
+#include <iterator>
+#include <exception>
+
+
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+#include <boost/signals2.hpp>
+
+#include <systemd/sd-daemon.h>
+
+#include "../inc/powermicroservice.h"
+#include "openhd-platform.hpp"
+#include "openhd-status.hpp"
+
+
+#include "mavlinkcontrol.h"
+//#include "record.h"
+#include "json.hpp"
+
+
+int main(int argc, char *argv[]) {
+
+    boost::asio::io_service io_service;
+
+    PlatformType platform_type = PlatformTypeUnknown;
+    bool is_air = false;
+    std::string unit_id;
+
+    try {
+        std::ifstream f("/tmp/platform_manifest");
+        nlohmann::json j;
+        f >> j;
+
+        platform_type = string_to_platform_type(j["platform"]);
+    } catch (std::exception &ex) {
+        // don't do anything, but send an error message to the user through the status service
+        status_message(STATUS_LEVEL_EMERGENCY, "Platform manifest processing failed");
+        std::cerr << "Platform manifest error: " << ex.what() << std::endl;
+    }
+
+    try {
+        std::ifstream f("/tmp/profile_manifest");
+        nlohmann::json j;
+        f >> j;
+
+        is_air = j["is-air"];
+
+        unit_id = j["unit-id"];
+    } catch (std::exception &ex) {
+        // don't do anything, but send an error message to the user through the status service
+        status_message(STATUS_LEVEL_EMERGENCY, "Profile manifest processing failed");
+        std::cerr << "EX: " << ex.what() << std::endl;
+    }
+
+    if (!is_air) {
+
+    }
+
+
+//    MavlinkControl mavlink_control(io_service, platform_type);
+    //Record record(io_service);
+
+    //mavlinkcontrol.armed.connect(&record.set_armed);
+    //mavlinkcontrol.rc_channels.connect(&record.set_rc_channels);
+
+
+//    try {
+//        mavlink_control.setup();
+//    } catch (std::exception &exception) {
+//        std::cout << "Microservice connection failed: " << exception.what() << std::endl;
+//        exit(1);
+//    }
+
+    PowerMicroservice * power_microservice;
+
+    try {
+        //record.setup();
+
+//        if (is_air) {
+        	power_microservice = new PowerMicroservice(io_service, platform_type, is_air, unit_id);
+        	power_microservice->setup();
+        	power_microservice->set_sysid(is_air ? 253 : 254);
+//        }
+    } catch (std::exception &ex) {
+        std::cerr << "Error: " << ex.what() << std::endl;
+        exit(1);
+    } catch (...) {
+        std::cerr << "Unknown exception occurred" << std::endl;
+        exit(1);
+    }
+
+    sd_notify(0, "READY=1");
+
+    io_service.run();
+
+    return 0;
+}

--- a/openhd-power/src/main.cpp
+++ b/openhd-power/src/main.cpp
@@ -16,7 +16,6 @@
 #include "openhd-status.hpp"
 
 
-#include "mavlinkcontrol.h"
 //#include "record.h"
 #include "json.hpp"
 

--- a/openhd-power/src/powermicroservice.cpp
+++ b/openhd-power/src/powermicroservice.cpp
@@ -1,0 +1,118 @@
+
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+#include <fstream>
+
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+#include <boost/regex.hpp>
+
+#include <openhd/mavlink.h>
+
+#include "json.hpp"
+#include "inja.hpp"
+using namespace inja;
+using json = nlohmann::json;
+
+#include "openhd-status.hpp"
+#include "openhd-settings.hpp"
+
+#include "../inc/powermicroservice.h"
+
+
+constexpr uint8_t SERVICE_COMPID = MAV_COMP_ID_USER1;
+
+
+PowerMicroservice::PowerMicroservice(boost::asio::io_service &io_service, PlatformType platform, bool is_air, std::string unit_id): Microservice(io_service, platform), m_is_air(is_air), m_unit_id(unit_id) {
+    set_compid(SERVICE_COMPID);
+}
+
+
+void PowerMicroservice::setup() {
+    std::cout << "PowerMicroservice::setup()" << std::endl;
+    Microservice::setup();
+
+    process_manifest();
+    process_settings();
+}
+
+
+void PowerMicroservice::process_manifest() {
+	// No manifest to process for now
+}
+
+void PowerMicroservice::process_settings() {
+	// No settings for now
+}
+
+
+void PowerMicroservice::configure() {
+    std::cerr << "Configuring power uService" << std::endl;
+    // Nothing to do here
+
+}
+
+
+void PowerMicroservice::process_mavlink_message(mavlink_message_t msg) {
+    switch (msg.msgid) {
+        case MAVLINK_MSG_ID_COMMAND_LONG: {
+            mavlink_command_long_t command;
+            mavlink_msg_command_long_decode(&msg, &command);
+
+            std::cerr << "Long command received, target system=" << (uint16_t)command.target_system << "; target comp=" << (uint16_t)command.target_component << "; command=" << command.command << "\n";
+            std::cerr << "My component id=" << (uint16_t) this->m_compid << "\n";
+
+            // only process commands sent to this system or broadcast to all systems
+            if ((command.target_system != this->m_sysid && command.target_system != 0)) {
+                return;
+            }
+
+            // only process commands sent to this component or boadcast to all components on this system
+            if ((command.target_component != this->m_compid && command.target_component != MAV_COMP_ID_ALL)) {
+                return;
+            }
+
+            switch (command.command) {
+            	case OPENHD_CMD_POWER_SHUTDOWN: {
+            		std::cerr << "Shutdown command received!\n";
+            		boost::process::child c_systemctl_shutdown(
+            				boost::process::search_path("systemctl"),
+            				std::vector<std::string>{"start", "poweroff.target"},
+							m_io_service);
+            		c_systemctl_shutdown.detach();
+            	}
+
+            	case OPENHD_CMD_POWER_REBOOT: {
+            		std::cerr << "Reboot command received!\n";
+            		boost::process::child c_systemctl_reboot(
+            				boost::process::search_path("systemctl"),
+							std::vector<std::string>{"start", "reboot.target"},
+							m_io_service);
+            		c_systemctl_reboot.detach();
+            	}
+
+
+                default: {
+                    break;
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+void PowerMicroservice::save_settings() {
+    
+
+}
+

--- a/openhd-status/Makefile
+++ b/openhd-status/Makefile
@@ -1,4 +1,8 @@
-CPPFLAGS = -I$(PWD)/../openhd-common
+
+SRC_DIR = $(PWD)/src
+LIB_DIR = $(PWD)/lib
+
+CFLAGS = -I$(PWD)/../openhd-common -I$(PWD)/../lib/fmt/include  -I$(PREFIX)/include -I$(PWD)/inc -I$(PWD)/../openhd-common -I$(PWD)/../lib/mavlink_generated/include/mavlink/v2.0 `pkg-config --cflags gstreamer-base-1.0`
 
 ifeq ($(PREFIX),)
 	PREFIX := /usr/local
@@ -8,17 +12,41 @@ ifdef $(DESTDIR)
 	$(DESTDIR) := $(DESTDIR)/
 endif
 
+LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lboost_signals -lsystemd `pkg-config --libs gstreamer-base-1.0`
 
-all: qstatus
+all: qstatus openhd_status
 
-%.o: %.c
-	g++ -c -o $@ $< $(CPPFLAGS)
+qstatus: qstatus.c
+	g++ -o $@ $^ $(CFLAGS)
+	
+openhd_status: statusmicroservice.o main.o
+	g++ -g -pthread -o openhd_status statusmicroservice.o main.o  $(LDFLAGS)
 
-qstatus: qstatus.o
-	g++ -o $@ $^
+main.o: $(SRC_DIR)/main.cpp
+	g++ -std=c++17 -Wno-psabi -g -c -pthread $(CFLAGS) $(SRC_DIR)/main.cpp
+
+
+statusmicroservice.o: $(SRC_DIR)/statusmicroservice.cpp
+	g++ -std=c++17 -Wno-psabi -g -c -pthread $(CFLAGS) $(SRC_DIR)/statusmicroservice.cpp
+
+
 
 clean:
-	rm -f qstatus *.o *~
+	rm -f *.o openhd_status qstatus
 
-install:
-	install -m 755 -p qstatus $(DESTDIR)$(PREFIX)/bin/
+
+.PHONY: install
+install: openhd_status
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install -d $(DESTDIR)/etc/systemd/system
+	install -m 755 openhd_status $(DESTDIR)$(PREFIX)/bin/
+	install -m 644 openhd_status.service $(DESTDIR)/etc/systemd/system/
+
+.PHONY: enable
+enable: install
+	systemctl enable openhd_status
+	systemctl start openhd_status
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/bin/openhd_status

--- a/openhd-status/Makefile_old
+++ b/openhd-status/Makefile_old
@@ -1,0 +1,24 @@
+CPPFLAGS = -I$(PWD)/../openhd-common
+
+ifeq ($(PREFIX),)
+	PREFIX := /usr/local
+endif
+
+ifdef $(DESTDIR)
+	$(DESTDIR) := $(DESTDIR)/
+endif
+
+
+all: qstatus
+
+%.o: %.c
+	g++ -c -o $@ $< $(CPPFLAGS)
+
+qstatus: qstatus.o
+	g++ -o $@ $^
+
+clean:
+	rm -f qstatus *.o *~
+
+install:
+	install -m 755 -p qstatus $(DESTDIR)$(PREFIX)/bin/

--- a/openhd-status/inc/statusmicroservice.h
+++ b/openhd-status/inc/statusmicroservice.h
@@ -1,0 +1,53 @@
+#ifndef STATUS_H
+#define STATUS_H
+
+#include <openhd/mavlink.h>
+
+#include <array>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#include "openhd-microservice.hpp"
+#include "openhd-platform.hpp"
+
+struct StatusMessage {
+    std::string message;
+    int sysid;
+    int compid;
+    MAV_SEVERITY severity;
+    uint64_t timestamp;
+};
+
+
+class StatusMicroservice: public Microservice {
+public:
+    StatusMicroservice(boost::asio::io_service &io_service, PlatformType platform, bool is_air, std::string unit_id);
+
+    void setup();
+
+    void start_udp_read();
+
+    void handle_udp_read(const boost::system::error_code& error,
+                         size_t bytes_transferred);
+
+    void send_status_message(MAV_SEVERITY severity, std::string message);
+
+    virtual void process_mavlink_message(mavlink_message_t msg);
+
+ private:
+    std::string m_unit_id;
+
+    bool m_is_air = false;
+
+    enum { max_length = 1024 };
+    char data[max_length];
+
+    std::vector<StatusMessage> m_status_messages;
+
+    boost::asio::ip::udp::socket m_udp_socket;
+
+    std::string m_openhd_version = "unknown";
+};
+
+#endif

--- a/openhd-status/openhd_status.service
+++ b/openhd-status/openhd_status.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=openhd-status
+After=openhdinterface.service
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/openhd_status
+
+[Install]
+WantedBy=multi-user.target
+Alias=openhdstatus.service

--- a/openhd-status/src/main.cpp
+++ b/openhd-status/src/main.cpp
@@ -1,0 +1,82 @@
+#include <fstream>
+
+#include <iostream>
+#include <iterator>
+#include <exception>
+
+
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+#include <boost/signals2.hpp>
+
+#include <systemd/sd-daemon.h>
+
+#include "../inc/statusmicroservice.h"
+#include "openhd-platform.hpp"
+#include "openhd-status.hpp"
+
+
+//#include "record.h"
+#include "json.hpp"
+
+
+int main(int argc, char *argv[]) {
+
+	boost::asio::io_service io_service;
+
+	PlatformType platform_type = PlatformTypeUnknown;
+	bool is_air = false;
+	std::string unit_id;
+
+	try {
+		std::ifstream f("/tmp/platform_manifest");
+		nlohmann::json j;
+		f >> j;
+
+		platform_type = string_to_platform_type(j["platform"]);
+	} catch (std::exception &ex) {
+		// don't do anything, but send an error message to the user through the status service
+		status_message(STATUS_LEVEL_EMERGENCY, "Platform manifest processing failed");
+		std::cerr << "Platform manifest error: " << ex.what() << std::endl;
+	}
+
+	try {
+		std::ifstream f("/tmp/profile_manifest");
+		nlohmann::json j;
+		f >> j;
+
+		is_air = j["is-air"];
+
+		unit_id = j["unit-id"];
+	} catch (std::exception &ex) {
+		// don't do anything, but send an error message to the user through the status service
+		status_message(STATUS_LEVEL_EMERGENCY, "Profile manifest processing failed");
+		std::cerr << "EX: " << ex.what() << std::endl;
+	}
+
+	if (!is_air) {
+
+	}
+
+
+	StatusMicroservice * status_microservice;
+
+	try {
+
+		status_microservice = new StatusMicroservice(io_service, platform_type, is_air, unit_id);
+		status_microservice->setup();
+		status_microservice->set_sysid(is_air ? 253 : 254);
+	} catch (std::exception &ex) {
+		std::cerr << "Error: " << ex.what() << std::endl;
+		exit(1);
+	} catch (...) {
+		std::cerr << "Unknown exception occurred" << std::endl;
+		exit(1);
+	}
+
+	sd_notify(0, "READY=1");
+
+	io_service.run();
+
+	return 0;
+}

--- a/openhd-status/src/statusmicroservice.cpp
+++ b/openhd-status/src/statusmicroservice.cpp
@@ -1,0 +1,288 @@
+#include "../inc/statusmicroservice.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/reboot.h>
+
+#include <iostream>
+#include <fstream>
+#include <streambuf>
+
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+
+#include <openhd/mavlink.h>
+
+#include "openhd-platform.hpp"
+
+#include "../../openhd-common/openhd-status.hpp"
+
+
+
+constexpr uint8_t SERVICE_COMPID = MAV_COMP_ID_USER3;
+
+std::string get_openhd_version() {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("dpkg-query --showformat='${Version}' --show openhd", "r"), pclose);
+    if (!pipe) {
+        throw std::runtime_error("Checking openhd version failed");
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+        result += buffer.data();
+    }
+    return result;
+}
+
+
+StatusMicroservice::StatusMicroservice(boost::asio::io_service &io_service, PlatformType platform, bool is_air, std::string unit_id):
+		Microservice(io_service, platform), m_udp_socket(io_service), m_is_air(is_air), m_unit_id(unit_id) {
+    set_compid(SERVICE_COMPID);
+
+    m_udp_socket.open(boost::asio::ip::udp::v4());
+    m_udp_socket.bind(boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), 50000));
+}
+
+
+void StatusMicroservice::setup() {
+    std::cout << "StatusMicroservice::setup()" << std::endl;
+
+    try {
+        m_openhd_version = get_openhd_version();
+    } catch (std::exception& ex) {
+        // the exception itself doesn't matter, will just mean the m_openhd_version default
+        // gets sent to QOpenHD
+    }
+
+    /*
+     * The timing at early boot is fairly strict, we need OpenHDBoot to quickly
+     * connect to the status service and start displaying messages, which requires
+     * receiving heartbeat and sys_time messages as fast as possible. OpenHDBoot will then
+     * immediately send OPENHD_CMD_GET_STATUS_MESSAGES to this service, and once that happens
+     * we can safely set these intervals back to minimal intervals to reduce air traffic in
+     * normal use.
+     */
+    m_heartbeat_interval = std::chrono::seconds(1);
+    m_sys_time_interval = std::chrono::seconds(1);
+
+    Microservice::setup();
+    start_udp_read();
+
+    /*
+     * Signal to the rest of the early boot system that the status service is now listening,
+     * so it's safe to start sending messages and status events.
+     */
+    FILE *fp = fopen("/tmp/status_service", "ab+");
+    fclose(fp);
+}
+
+
+void StatusMicroservice::start_udp_read() {
+    std::cerr << "StatusMicroservice::start_udp_read()" << std::endl;
+
+    m_udp_socket.async_receive(boost::asio::buffer(data, max_length),
+                               boost::bind(&StatusMicroservice::handle_udp_read,
+                                           this,
+                                           boost::asio::placeholders::error,
+                                           boost::asio::placeholders::bytes_transferred));
+}
+
+
+void StatusMicroservice::handle_udp_read(const boost::system::error_code& error,
+                                         size_t bytes_transferred) {
+    std::cerr << "StatusMicroservice::handle_udp_read()" << std::endl;
+
+    if (!error) {
+        if (bytes_transferred == sizeof(localmessage_t)) {
+            localmessage_t local_message;
+
+            memcpy(&local_message, data, bytes_transferred);
+
+            std::string message = (const char*)local_message.message;
+            MAV_SEVERITY severity = (MAV_SEVERITY)local_message.level;
+
+            send_status_message(severity, message);
+        }
+    }
+    start_udp_read();
+}
+
+
+
+/*
+ * Used to send a status message with a log level to any connected devices, and also store the message locally.
+ *
+ * This makes it possible for the system to "replay" all messages when a new device connects to the system and
+ * needs to see messages that were generated before that point.
+ *
+ * This is primarily done so that early boot messages are preserved and available for review at any time, but is
+ * useful at all times to ensure the user knows what's going on.
+ */
+void StatusMicroservice::send_status_message(MAV_SEVERITY severity, std::string message) {
+    std::cout << "StatusMicroservice::send_status_message: " << message << ", sysid=" << (uint16_t)this->m_sysid << std::endl;
+
+    uint64_t timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+
+    /*
+     * Store the message first, so we can send all local messages to any GCS that requests them later on
+     */
+    StatusMessage m;
+    m.message = message;
+    m.severity = severity;
+    m.timestamp = timestamp;
+    m_status_messages.push_back(m);
+
+    /*
+     * Now send it out
+     */
+    uint8_t raw[MAVLINK_MAX_PACKET_LEN];
+    int len = 0;
+
+    char text[50] = {0};
+    strncpy(text, message.c_str(), sizeof(text));
+    if (text[49] != '\0') {
+        text[49] = '\0';
+    }
+
+
+    mavlink_message_t outgoing_msg;
+    mavlink_msg_openhd_status_message_pack(this->m_sysid, this->m_compid, &outgoing_msg, 0, 0, severity, text, timestamp);
+    len = mavlink_msg_to_send_buffer(raw, &outgoing_msg);
+
+    this->m_socket->async_send(boost::asio::buffer(raw, len),
+                               boost::bind(&Microservice::handle_write,
+                                           this,
+                                           boost::asio::placeholders::error));
+}
+
+
+void StatusMicroservice::process_mavlink_message(mavlink_message_t msg) {
+        switch (msg.msgid) {
+        case MAVLINK_MSG_ID_OPENHD_STATUS_MESSAGE: {
+
+            mavlink_openhd_status_message_t status;
+            mavlink_msg_openhd_status_message_decode(&msg, &status);
+
+            break;
+        }
+        case MAVLINK_MSG_ID_COMMAND_LONG: {
+            mavlink_command_long_t command;
+            mavlink_msg_command_long_decode(&msg, &command);
+
+            // only process commands sent to this system or broadcast to all systems
+            if ((command.target_system != this->m_sysid && command.target_system != 0)) {
+                return;
+            }
+
+            // only process commands sent to this component or boadcast to all components on this system
+            if ((command.target_component != this->m_compid && command.target_component != MAV_COMP_ID_ALL)) {
+                return;
+            }
+
+            switch (command.command) {
+                case OPENHD_CMD_GET_STATUS_MESSAGES: {
+                    std::cout << "OPENHD_CMD_GET_STATUS_MESSAGES" << std::endl;
+                    uint8_t raw[MAVLINK_MAX_PACKET_LEN];
+                    int len = 0;
+
+                    /*
+                     * Now we can safely set these intervals back to minimal intervals to reduce air traffic in
+                     * normal use.
+                     */
+                    m_heartbeat_interval = std::chrono::seconds(5);
+                    m_sys_time_interval = std::chrono::seconds(5);
+
+                    // acknowledge the command, then reply
+                    mavlink_message_t ack;
+                    mavlink_msg_command_ack_pack(this->m_sysid, // mark the message as being from the local system ID
+                                                 this->m_compid,  // and from this component
+                                                 &ack,
+                                                 OPENHD_CMD_GET_STATUS_MESSAGES, // the command we're ack'ing
+                                                 MAV_CMD_ACK_OK,
+                                                 0,
+                                                 0,
+                                                 msg.sysid, // send ack to the senders system ID...
+                                                 msg.compid); // ... and the senders component ID
+                    len = mavlink_msg_to_send_buffer(raw, &ack);
+
+                    this->m_socket->async_send(boost::asio::buffer(raw, len),
+                                               boost::bind(&Microservice::handle_write,
+                                                           this,
+                                                           boost::asio::placeholders::error));
+
+
+                    for (auto & message : m_status_messages) {
+                        uint8_t raw[MAVLINK_MAX_PACKET_LEN];
+                        int len = 0;
+
+                        char text[50] = {0};
+                        strncpy(text, message.message.c_str(), sizeof(text));
+                        if (text[49] != '\0') {
+                            text[49] = '\0';
+                        }
+
+
+                        mavlink_message_t outgoing_msg;
+                        mavlink_msg_openhd_status_message_pack(this->m_sysid, this->m_compid, &outgoing_msg, msg.sysid, msg.compid, message.severity, text, message.timestamp);
+                        len = mavlink_msg_to_send_buffer(raw, &outgoing_msg);
+
+                        this->m_socket->async_send(boost::asio::buffer(raw, len),
+                                                boost::bind(&Microservice::handle_write,
+                                                            this,
+                                                            boost::asio::placeholders::error));
+                    }
+                    break;
+                }
+                case OPENHD_CMD_GET_VERSION: {
+                    std::cout << "OPENHD_CMD_GET_VERSION" << std::endl;
+                    uint8_t raw[MAVLINK_MAX_PACKET_LEN];
+                    int len = 0;
+
+                    // acknowledge the command, then reply
+                    mavlink_message_t ack;
+                    mavlink_msg_command_ack_pack(this->m_sysid, // mark the message as being from the local system ID
+                                                 this->m_compid,  // and from this component
+                                                 &ack,
+                                                 OPENHD_CMD_GET_VERSION, // the command we're ack'ing
+                                                 MAV_CMD_ACK_OK,
+                                                 0,
+                                                 0,
+                                                 msg.sysid, // send ack to the senders system ID...
+                                                 msg.compid); // ... and the senders component ID
+                    len = mavlink_msg_to_send_buffer(raw, &ack);
+
+                    this->m_socket->async_send(boost::asio::buffer(raw, len),
+                                               boost::bind(&Microservice::handle_write,
+                                                           this,
+                                                           boost::asio::placeholders::error));
+
+                    char text[30] = {0};
+
+                    strncpy(text, m_openhd_version.c_str(), sizeof(text));
+                    if (text[29] != '\0') {
+                        text[29] = '\0';
+                    }
+
+                    mavlink_message_t outgoing_msg;
+                    mavlink_msg_openhd_version_message_pack(this->m_sysid, this->m_compid, &outgoing_msg, msg.sysid, msg.compid, text);
+                    len = mavlink_msg_to_send_buffer(raw, &outgoing_msg);
+
+                    this->m_socket->async_send(boost::asio::buffer(raw, len),
+                                               boost::bind(&Microservice::handle_write,
+                                                           this,
+                                                           boost::asio::placeholders::error));
+                    break;
+                }
+                default: {
+                    break;
+                }
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}

--- a/openhd-system/src/wifi.cpp
+++ b/openhd-system/src/wifi.cpp
@@ -134,6 +134,14 @@ void WiFi::process_card(std::string interface_name) {
             card.supports_hotspot = true;
             break;
         }
+        case WiFiCardTypeAtheros9khtc: {
+            card.supports_5ghz = supports_5ghz;
+            card.supports_2ghz = supports_2ghz;
+            card.supports_rts = true;
+            card.supports_injection = true;
+            card.supports_hotspot = true;
+            break;
+        }
         case WiFiCardTypeRalink: {
             card.supports_5ghz = supports_5ghz;
             card.supports_2ghz = supports_2ghz;

--- a/openhd-video/src/gstreamerstream.cpp
+++ b/openhd-video/src/gstreamerstream.cpp
@@ -281,7 +281,7 @@ void GStreamerStream::setup_jetson_csi() {
     parse_user_format(m_camera.format, width, height, fps);
 
 
-    m_pipeline << fmt::format("nvarguscamerasrc maxperf=1 do-timestamp=true sensor-id={} ! ", sensor_id);
+    m_pipeline << fmt::format("nvarguscamerasrc do-timestamp=true sensor-id={} ! ", sensor_id);
     m_pipeline << fmt::format("video/x-raw(memory:NVMM), width={}, height={}, format=NV12, framerate={}/1 ! ", width, height, fps);
     m_pipeline << "queue ! ";
 

--- a/openhd-video/src/gstreamerstream.cpp
+++ b/openhd-video/src/gstreamerstream.cpp
@@ -138,7 +138,7 @@ void GStreamerStream::setup() {
 
 
     // this directs the video stream back to this system for recording in the Record class
-    m_pipeline << fmt::format("udpsink host=127.0.0.1 port={} t. ! ", m_video_port - 10);
+    m_pipeline << fmt::format("udpsink host=127.0.0.1 port={}", m_video_port - 10);
 
 
     std::cerr << "Pipeline: " << m_pipeline.str() << std::endl;

--- a/package.sh
+++ b/package.sh
@@ -125,6 +125,12 @@ build_source() {
     make -j3 || exit 1
     make install DESTDIR=${PKGDIR} || exit 1
     popd
+    
+    pushd openhd-status
+    make clean
+    make -j3 || exit 1
+    make install DESTDIR=${PKGDIR} || exit 1
+    popd
 
     pushd openhd-telemetry
     make clean

--- a/package.sh
+++ b/package.sh
@@ -120,6 +120,12 @@ build_source() {
     make install DESTDIR=${PKGDIR} || exit 1
     popd
 
+    pushd openhd-power
+    make clean
+    make -j3 || exit 1
+    make install DESTDIR=${PKGDIR} || exit 1
+    popd
+
     pushd openhd-telemetry
     make clean
     make -j3 || exit 1


### PR DESCRIPTION
This pull request contains the following fixes:
* Fix invalid gstreamer stream syntax (general)
* Fix invalid parameter for nvarguscamerasrc gStreamer element (jetson Nano)
* Fix bad call to wfb_tx/wfb_rx when multiple injection-capable wifi interfaces are available
* Use proper keys from rx/tx keypair for telemetry streams

And the following feature additions:
* Initial implementation of Power microservice. It acknowledges and executes restart/shutdown commands sent from the UI (QOpenHD)
* Initial implementation of Status microservice (as was prepared by Stephen: https://github.com/OpenHD/OpenHDMicroservice ). Key feature is that it forwards qstatus messages over mavlink so they are now handled by QOpenHD.
* Support for ath9k driver. For non-USB Atheros cards. Testing on different cards is required, I have tested a card with AR9582 chipset which works (2.4GHz band).