### PR TITLE
Migrate to boost signal2

### DIFF
--- a/openhd-power/Makefile
+++ b/openhd-power/Makefile
@@ -12,7 +12,7 @@ ifdef $(DESTDIR)
 	$(DESTDIR) := $(DESTDIR)/
 endif
 
-LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lboost_signals -lsystemd `pkg-config --libs gstreamer-base-1.0`
+LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lsystemd `pkg-config --libs gstreamer-base-1.0`
 
 openhd_power: powermicroservice.o main.o
 	g++ -g -pthread -o openhd_power powermicroservice.o main.o  $(LDFLAGS)

--- a/openhd-status/Makefile
+++ b/openhd-status/Makefile
@@ -12,7 +12,7 @@ ifdef $(DESTDIR)
 	$(DESTDIR) := $(DESTDIR)/
 endif
 
-LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lboost_signals -lsystemd `pkg-config --libs gstreamer-base-1.0`
+LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lsystemd `pkg-config --libs gstreamer-base-1.0`
 
 all: qstatus openhd_status
 

--- a/openhd-video/Makefile
+++ b/openhd-video/Makefile
@@ -12,7 +12,7 @@ ifdef $(DESTDIR)
 	$(DESTDIR) := $(DESTDIR)/
 endif
 
-LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lboost_signals -lsystemd `pkg-config --libs gstreamer-base-1.0`
+LDFLAGS = -L$(PWD)/../lib/fmt/build -lfmt -L$(PREFIX)/lib -lboost_filesystem -lboost_regex -lboost_system -lsystemd `pkg-config --libs gstreamer-base-1.0`
 
 openhd_video: cameramicroservice.o control.o hotspot.o camerastream.o gstreamerstream.o main.o
 	g++ -g -pthread -o openhd_video control.o hotspot.o cameramicroservice.o camerastream.o gstreamerstream.o main.o  $(LDFLAGS)

--- a/openhd-video/inc/control.h
+++ b/openhd-video/inc/control.h
@@ -7,7 +7,7 @@
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/regex.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2.hpp>
 
 
 class Control {
@@ -18,7 +18,7 @@ public:
 
     void start_receive();
 
-    boost::signal<void (std::string command_uri)> command_received;
+    boost::signals2::signal<void (std::string command_uri)> command_received;
 
 protected:
     void handle_receive(const boost::system::error_code& error,


### PR DESCRIPTION
Signal2 is a header library and should not require building... This is all caused by pump and boost signal depreciation in ubuntu focal