### PR TITLE
Migrate to boost signal2 continued

### DIFF
--- a/openhd-video/src/control.cpp
+++ b/openhd-video/src/control.cpp
@@ -2,7 +2,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
-#include <boost/signal.hpp>
+#include <boost/signals2.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 


### PR DESCRIPTION
Signals2 is a header library and should not require building... This is all caused by pump and boost signal depreciation in ubuntu focal