### PR TITLE
Remove trigger experiment. Break upload to cloudsmith

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,11 +6,6 @@ platform:
   arch: arm
 image_pull_secrets:
 - dockerconfigjson
-trigger:
-  branch:
-  - master
-  event:
-  - pull_request
 steps:
 - name: fetch
   image: arm32v6/alpine:3.12
@@ -42,11 +37,6 @@ platform:
   arch: arm64
 image_pull_secrets:
 - dockerconfigjson
-trigger:
-  branch:
-  - master
-  event:
-  - pull_request
 steps:
 - name: fetch
   image: arm64v8/alpine:3.12
@@ -78,11 +68,6 @@ platform:
   arch: arm64
 image_pull_secrets:
 - dockerconfigjson
-trigger:
-  branch:
-  - master
-  event:
-  - pull_request
 steps:
 - name: fetch
   image: arm64v8/alpine:3.12
@@ -114,11 +99,6 @@ platform:
   arch: arm
 image_pull_secrets:
 - dockerconfigjson
-trigger:
-  branch:
-  - master
-  event:
-  - pull_request
 steps:
 - name: fetch
   image: arm32v6/alpine:3.12


### PR DESCRIPTION
The triggers were workingi n the sense that commits would not trigger a build and only pull requests would. But then it was breaking something in the upload to cloudsmith. 

Checking deb package upload parameters ... ERROR
Failed to validate upload parameters! (status: 401 - Unauthorized)

Detail: Invalid token.