### PR TITLE
Add config line regarding rpi 4's that won't boot

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -1,6 +1,10 @@
 # General note: You can find more info on the options in this file here:
 # https://www.raspberrypi.org/documentation/configuration/config-txt.md
 
+# uncomment if you have a raspberry pi 4 with 4GB of ram or more and it 
+# is not booting
+#total_mem=3072
+
 # uncomment if you get no picture on HDMI for a default "safe" mode
 #hdmi_safe=1
 


### PR DESCRIPTION
Now put against the 2.0 branch as requested.

Many new people hop on onto telegram asking why their RPI 4 isn't booting. Then they are told, add `total_mem=3072` to their config.txt This should make the initial setup less frustrating and user friendly.
