### PR TITLE
Veye V4L2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -107,7 +107,7 @@ steps:
   - git fetch --tags
   - git submodule update --init --recursive --remote
 - name: build
-  image: plugins/docker:linux-arm64
+  image: plugins/docker:linux-arm
   environment:
     CLOUDSMITH_API_KEY:
       from_secret: CLOUDSMITH_API_KEY

--- a/Dockerfile-armhf-raspbian-bullseye
+++ b/Dockerfile-armhf-raspbian-bullseye
@@ -1,4 +1,4 @@
-FROM ghcr.io/openhd/bullseye-lite:v2.3
+FROM ghcr.io/openhd/bullseye-lite:v2.4
 
 RUN apt update
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -83,7 +83,7 @@ max_framebuffers=2
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
-gpu_mem=160
+gpu_mem=400
 
 # force gpu to run in turbo mode for less latency and jitter
 force_turbo=1
@@ -124,11 +124,19 @@ usb_mdio=0x7000
 # uncomment for I2C
 #dtparam=i2c1=on
 dtparam=i2c_arm=on
-#uncomment below if using veye innomaker imx219 cam or HAT
+
+#uncomment below if using veye camera
 #dtparam=i2c_vc=on
-#
+
+#uncomment below for IMX327, IMX462 or IMX385
+dtoverlay=veyecam2m,media-controller=0
+
+#uncomment below for IMX307
+#dtoverlay=csimx307,media-controller=0
 # uncomment for SPI
 #dtparam=spi=on
+
+camera_auto_detect=1
 
 start_x=1
 
@@ -151,6 +159,10 @@ fixup_file=1to3bup_x.dat
 [pi3+]
 start_file=start_x.elf
 fixup_file=fixup_x.dat
+[pi4]
+dtoverlay=vc4-fkms-v3d
+dtoverlay=raspivid-v4l2
+dtoverlay=cma,cma-size=402653184
 
 # uncomment to activate CM4 USB
 #dtoverlay=dwc2,dr_mode=host

--- a/openhd-system/src/cameras.cpp
+++ b/openhd-system/src/cameras.cpp
@@ -197,9 +197,9 @@ void Cameras::detect_raspberrypi_veye() {
 
     std::array<char, 512> buffer;
     std::string veye_detect;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("i2cdetect -y 0 0x3b 0x3b | grep  '3b'", "r"), pclose);
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen("dmesg | grep 'camera id is veyecam2m'", "r"), pclose);
     if (!pipe) {
-        std::cerr << "Cameras::detect_raspberrypi_veye() no pipe from i2cdetect" << std::endl;
+        std::cerr << "Cameras::detect_raspberrypi_veye() no pipe from dmesg" << std::endl;
         return;
     }
     while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
@@ -210,7 +210,7 @@ void Cameras::detect_raspberrypi_veye() {
 
     boost::smatch result;
 
-    boost::regex r{ "30:                                  3b            "};
+    boost::regex r{ "camera id is veyecam2m"};
     
     if (!boost::regex_search(veye_detect, result, r)) {
         std::cerr << "Cameras::detect_raspberrypi_veye() no regex match" << std::endl;

--- a/openhd-video/src/gstreamerstream.cpp
+++ b/openhd-video/src/gstreamerstream.cpp
@@ -274,8 +274,8 @@ void GStreamerStream::setup_raspberrypi_veye() {
     std::string fps;
     parse_user_format(m_camera.format, width, height, fps);
 
-    m_pipeline << fmt::format("rpicamsrc name=bitratectrl camera-number={} bitrate={} preview=0 ! ", m_camera.bus, m_camera.bitrate);
-    m_pipeline << fmt::format("video/x-h264, profile=constrained-baseline, width={}, height={}, framerate={}/1, level=3.0 ! ", width, height, fps);
+    m_pipeline << fmt::format("v4l2src name=picturectrl device=/dev/video0 ! ");
+    m_pipeline << fmt::format("video/x-raw,format=(string)UYVY, width=(int){}, height=(int){},framerate=(fraction){}/1 ! ", width, height, fps);
 }
 
 


### PR DESCRIPTION
Update for veye to use the v4l2 drivers for detection and streaming. 
Update base image to raspbian based. 
Add veye v4l2 lines and camera auto detect into config