### PR TITLE
fix building error with fs not found in debian

### DIFF
--- a/OpenHD/CMakeLists.txt
+++ b/OpenHD/CMakeLists.txt
@@ -3,6 +3,8 @@ project(OpenHD)
 
 set(CMAKE_CXX_STANDARD 17)
 
+link_libraries(stdc++fs)
+
 add_subdirectory(ohd_interface)
 add_subdirectory(ohd_discovery)
 add_subdirectory(ohd_telemetry)


### PR DESCRIPTION
fix building error with fs not found in debian
```shell
[ 94%] Linking CXX executable test_interface
[100%] Linking CXX executable test_common_util
/usr/bin/ld: libOHDInterfaceLib.a(WifiCards.cpp.o): in function `generateSettingsDirectoryIfNonExists()':
WifiCards.cpp:(.text+0x2420): undefined reference to `std::filesystem::create_directory(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: libOHDInterfaceLib.a(WifiCards.cpp.o): in function `findOrCreateSettingsDirectory(bool)':
WifiCards.cpp:(.text+0x2850): undefined reference to `std::filesystem::create_directory(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: libOHDInterfaceLib.a(WifiCards.cpp.o): in function `std::filesystem::exists(std::filesystem::__cxx11::path const&)':
WifiCards.cpp:(.text._ZNSt10filesystem6existsERKNS_7__cxx114pathE[_ZNSt10filesystem6existsERKNS_7__cxx114pathE]+0x10): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: libOHDInterfaceLib.a(WifiCards.cpp.o): in function `std::filesystem::__cxx11::path::path<char const*, std::filesystem::__cxx11::path>(char const* const&, std::filesystem::__cxx11::path::format)':
WifiCards.cpp:(.text._ZNSt10filesystem7__cxx114pathC2IPKcS1_EERKT_NS1_6formatE[_ZNSt10filesystem7__cxx114pathC5IPKcS1_EERKT_NS1_6formatE]+0x64): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/test_interface.dir/build.make:103: test_interface] Error 1
make[1]: *** [CMakeFiles/Makefile2:146: CMakeFiles/test_interface.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[100%] Built target test_common_util
make: *** [Makefile:91: all] Error 2
```