### PR TITLE
2.2.3 evo consti test

### DIFF
--- a/OpenHD/README.md
+++ b/OpenHD/README.md
@@ -12,8 +12,8 @@ like patched wifi drivers and installed linux utility programs.
 This sounds simple, but it is not. Also, stuff like disabling weird services that would interfer with monitor
 mode or similar falls into this category.
 2) The directory /tmp for writing temporary files exists
-3) The directory /usr/local/share/openhd/ for writing persistent (setting) files exists / can be created 
-4) The directory XXX for writing video recordings to exists TODO which one
+3) The directory /usr/local/share/openhd/ for writing persistent (setting) files can be created by OpenHD
+4) The directory /home/openhd/Videos for storing video recording(s) on the air unit can be created by OpenHD
 5) UART: if the platform has an UART connector (like rpi GPIO), the UART is enabled and has a corresponding linux file handle
 
 

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -11,6 +11,7 @@
 #include "ohd_common/openhd-platform-discover.hpp"
 #include "ohd_common/openhd-global-constants.hpp"
 #include "ohd_common/openhd-spdlog.hpp"
+#include "ohd_common/openhd-temporary-air-or-ground.h"
 #include <DCameras.h>
 #include <OHDInterface.h>
 #include <OHDTelemetry.h>
@@ -116,10 +117,8 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]){
     // The logs/checks here are just to help developer(s) avoid common misconfigurations
     std::cout<<"Using files to detect air or ground\n";
     // We allow users to write the file with a big or small first letter
-    const bool file_run_as_ground_exists= OHDFilesystemUtil::exists("/boot/OpenHD/ground.txt")
-                                        || OHDFilesystemUtil::exists("/boot/OpenHD/Ground.txt");
-    const bool file_run_as_air_exists = OHDFilesystemUtil::exists("/boot/OpenHD/air.txt")
-                                           || OHDFilesystemUtil::exists("/boot/OpenHD/Air.txt");
+    const bool file_run_as_ground_exists= openhd::tmp::any_file_ground_exists();
+    const bool file_run_as_air_exists = openhd::tmp::any_file_air_exists();
     bool error=false;
     if(file_run_as_air_exists && file_run_as_ground_exists){ // both files exist
       std::cerr<<"Both air and ground files exist,unknown what you want - either use the command line param or delete one of them\n";

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -116,8 +116,8 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]){
     // command line parameters not used, use the file(s) for detection (default for normal OpenHD images)
     // The logs/checks here are just to help developer(s) avoid common misconfigurations
     std::cout<<"Using files to detect air or ground\n";
-    const bool file_run_as_ground_exists= openhd::tmp::any_file_ground_exists();
-    const bool file_run_as_air_exists = openhd::tmp::any_file_air_exists();
+    const bool file_run_as_ground_exists= openhd::tmp::file_ground_exists();
+    const bool file_run_as_air_exists = openhd::tmp::file_air_exists();
     bool error=false;
     if(file_run_as_air_exists && file_run_as_ground_exists){ // both files exist
       std::cerr<<"Both air and ground files exist,unknown what you want - either use the command line param or delete one of them\n";

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -116,7 +116,6 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]){
     // command line parameters not used, use the file(s) for detection (default for normal OpenHD images)
     // The logs/checks here are just to help developer(s) avoid common misconfigurations
     std::cout<<"Using files to detect air or ground\n";
-    // We allow users to write the file with a big or small first letter
     const bool file_run_as_ground_exists= openhd::tmp::any_file_ground_exists();
     const bool file_run_as_air_exists = openhd::tmp::any_file_air_exists();
     bool error=false;

--- a/OpenHD/ohd_common/openhd-spdlog.hpp
+++ b/OpenHD/ohd_common/openhd-spdlog.hpp
@@ -17,7 +17,7 @@ namespace spd = spdlog;
 
 namespace openhd::loggers {
 
-// Note: the _mt loggers are threadsafe by design already, but we need to make sure to cretae the instance only once
+// Note: the _mt loggers are threadsafe by design already, but we need to make sure to crete the instance only once
 // For some reason there is no helper for that in spdlog / i haven't found it yet
 
 // Thread-safe but recommended to store result in an intermediate variable

--- a/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
+++ b/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
@@ -10,6 +10,7 @@
 // Dirty, temporary
 namespace openhd::tmp{
 
+// We allow users to write the file with a big or small first letter
 static constexpr auto FILENAME_AIR_1="/boot/OpenHD/air.txt";
 static constexpr auto FILENAME_AIR_2="/boot/OpenHD/Air.txt";
 static constexpr auto FILENAME_GROUND_1="/boot/OpenHD/ground.txt";
@@ -33,6 +34,16 @@ static void delete_any_file_air_or_ground(){
   OHDFilesystemUtil::remove_if_existing(FILENAME_AIR_2);
   OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND_1);
   OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND_2);
+}
+
+static void write_file_air(){
+  OHDFilesystemUtil::create_directories("/boot/OpenHD/");
+  OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_AIR_1," ");
+}
+
+static void write_file_ground(){
+  OHDFilesystemUtil::create_directories("/boot/OpenHD/");
+  OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_GROUND_1," ");
 }
 
 

--- a/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
+++ b/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
@@ -1,0 +1,40 @@
+//
+// Created by consti10 on 28.10.22.
+//
+
+#ifndef OPENHD_OPENHD_OHD_COMMON_OPENHD_TEMPORARY_AIR_OR_GROUND_H_
+#define OPENHD_OPENHD_OHD_COMMON_OPENHD_TEMPORARY_AIR_OR_GROUND_H_
+
+#include "openhd-util-filesystem.hpp"
+
+// Dirty, temporary
+namespace openhd::tmp{
+
+static constexpr auto FILENAME_AIR_1="/boot/OpenHD/air.txt";
+static constexpr auto FILENAME_AIR_2="/boot/OpenHD/Air.txt";
+static constexpr auto FILENAME_GROUND_1="/boot/OpenHD/ground.txt";
+static constexpr auto FILENAME_GROUND_2="/boot/OpenHD/Ground.txt";
+
+static bool any_file_air_exists(){
+  return OHDFilesystemUtil::exists(FILENAME_AIR_1) ||
+         OHDFilesystemUtil::exists(FILENAME_AIR_2);
+}
+static bool any_file_ground_exists(){
+  return OHDFilesystemUtil::exists(FILENAME_GROUND_1) ||
+         OHDFilesystemUtil::exists(FILENAME_GROUND_2);
+}
+
+static bool any_file_air_or_ground_exists(){
+  return any_file_air_exists() || any_file_ground_exists();
+}
+
+static void delete_any_file_air_or_ground(){
+  OHDFilesystemUtil::remove_if_existing(FILENAME_AIR_1);
+  OHDFilesystemUtil::remove_if_existing(FILENAME_AIR_2);
+  OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND_1);
+  OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND_2);
+}
+
+
+}
+#endif  // OPENHD_OPENHD_OHD_COMMON_OPENHD_TEMPORARY_AIR_OR_GROUND_H_

--- a/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
+++ b/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
@@ -10,40 +10,34 @@
 // Dirty, temporary
 namespace openhd::tmp{
 
-// We allow users to write the file with a big or small first letter
-static constexpr auto FILENAME_AIR_1="/boot/OpenHD/air.txt";
-static constexpr auto FILENAME_AIR_2="/boot/OpenHD/Air.txt";
-static constexpr auto FILENAME_GROUND_1="/boot/OpenHD/ground.txt";
-static constexpr auto FILENAME_GROUND_2="/boot/OpenHD/Ground.txt";
+// Note: case sensitive
+static constexpr auto FILENAME_AIR="/boot/OpenHD/air.txt";
+static constexpr auto FILENAME_GROUND="/boot/OpenHD/ground.txt";
 
-static bool any_file_air_exists(){
-  return OHDFilesystemUtil::exists(FILENAME_AIR_1) ||
-         OHDFilesystemUtil::exists(FILENAME_AIR_2);
+static bool file_air_exists(){
+  return OHDFilesystemUtil::exists(FILENAME_AIR);
 }
-static bool any_file_ground_exists(){
-  return OHDFilesystemUtil::exists(FILENAME_GROUND_1) ||
-         OHDFilesystemUtil::exists(FILENAME_GROUND_2);
+static bool file_ground_exists(){
+  return OHDFilesystemUtil::exists(FILENAME_GROUND);
 }
 
-static bool any_file_air_or_ground_exists(){
-  return any_file_air_exists() || any_file_ground_exists();
+static bool file_air_or_ground_exists(){
+  return file_air_exists() || file_ground_exists();
 }
 
 static void delete_any_file_air_or_ground(){
   OHDFilesystemUtil::remove_if_existing(FILENAME_AIR_1);
-  OHDFilesystemUtil::remove_if_existing(FILENAME_AIR_2);
   OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND_1);
-  OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND_2);
 }
 
 static void write_file_air(){
   OHDFilesystemUtil::create_directories("/boot/OpenHD/");
-  OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_AIR_1," ");
+  OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_AIR," ");
 }
 
 static void write_file_ground(){
   OHDFilesystemUtil::create_directories("/boot/OpenHD/");
-  OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_GROUND_1," ");
+  OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_GROUND," ");
 }
 
 

--- a/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
+++ b/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
@@ -26,8 +26,8 @@ static bool file_air_or_ground_exists(){
 }
 
 static void delete_any_file_air_or_ground(){
-  OHDFilesystemUtil::remove_if_existing(FILENAME_AIR_1);
-  OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND_1);
+  OHDFilesystemUtil::remove_if_existing(FILENAME_AIR);
+  OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND);
 }
 
 static void write_file_air(){

--- a/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
+++ b/OpenHD/ohd_common/openhd-temporary-air-or-ground.h
@@ -40,6 +40,21 @@ static void write_file_ground(){
   OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_GROUND," ");
 }
 
+static bool handle_telemetry_change(int value){
+  //0==ground, 1==air, other: undefined (rejected)
+  if(!(value==0 || value==1))return false;
+  if(value==0){
+    // change to ground mode. Remove any existing file(s) if there are any
+    openhd::tmp::delete_any_file_air_or_ground();
+    openhd::tmp::write_file_ground();
+  }else{
+    // change to air mode. Remove any existing file(s) if there are any
+    openhd::tmp::delete_any_file_air_or_ground();
+    openhd::tmp::write_file_air();
+  }
+  return true;
+}
+
 
 }
 #endif  // OPENHD_OPENHD_OHD_COMMON_OPENHD_TEMPORARY_AIR_OR_GROUND_H_

--- a/OpenHD/ohd_common/openhd-util-filesystem.hpp
+++ b/OpenHD/ohd_common/openhd-util-filesystem.hpp
@@ -78,6 +78,12 @@ static std::string read_file(const std::string& path){
   return ret;
 }
 
+static void remove_if_existing(const std::string& filename){
+  if(exists(filename.c_str())){
+    boost::filesystem::remove(filename);
+  }
+}
+
 }
 
 #endif //OPENHD_OPENHD_OHD_COMMON_OPENHD_UTIL_FILESYSTEM_H_

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -208,7 +208,7 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
   }
   // and this allows an advanced user to change its air unit to a ground unit
   // only expose this setting if OpenHD uses the file workaround to figure out air or ground.
-  if(openhd::tmp::any_file_air_or_ground_exists()){
+  if(openhd::tmp::file_air_or_ground_exists()){
     ret.push_back(openhd::Setting{"CONFIG_BOOT_AIR",openhd::IntSetting {1,c_config_boot_as_air}});
   }
   return ret;

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -181,17 +181,7 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
 	return true;
   };
   auto c_config_boot_as_air=[](std::string,int value){
-    if(!(value==0 || value==1))return false;
-    if(value==0){
-      // change to ground mode. Remove any existing file(s) if there are any
-      openhd::tmp::delete_any_file_air_or_ground();
-      openhd::tmp::write_file_ground();
-    }else{
-      // change to air mode. Remove any existing file(s) if there are any
-      openhd::tmp::delete_any_file_air_or_ground();
-      openhd::tmp::write_file_air();
-    }
-    return true;
+    return openhd::tmp::handle_telemetry_change(value);
   };
   auto c_rpi_os_camera_configuration=[this](std::string,int value){
     return m_rpi_os_change_config_handler->change_rpi_os_camera_configuration(value);

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -7,6 +7,7 @@
 #include "mavsdk_temporary/XMavlinkParamProvider.h"
 #include <chrono>
 #include "openhd-util-filesystem.hpp"
+#include "openhd-temporary-air-or-ground.h"
 
 AirTelemetry::AirTelemetry(OHDPlatform platform,std::shared_ptr<openhd::ActionHandler> opt_action_handler): _platform(platform),MavlinkSystem(OHD_SYS_ID_AIR) {
   m_console = spd::stdout_color_mt("ohd_air_tele");
@@ -179,6 +180,19 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
 	setup_uart();
 	return true;
   };
+  auto c_config_boot_as_air=[](std::string,int value){
+    if(!(value==0 || value==1))return false;
+    if(value==0){
+      // change to ground mode. Remove any existing file(s) if there are any
+      openhd::tmp::delete_any_file_air_or_ground();
+      OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_GROUND_1," ");
+    }else{
+      // change to air mode. Remove any existing file(s) if there are any
+      openhd::tmp::delete_any_file_air_or_ground();
+      OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_AIR_1," ");
+    }
+    return true;
+  };
   auto c_rpi_os_camera_configuration=[this](std::string,int value){
     return m_rpi_os_change_config_handler->change_rpi_os_camera_configuration(value);
   };
@@ -191,6 +205,11 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
   if(_platform.platform_type==PlatformType::RaspberryPi && m_rpi_os_change_config_handler!= nullptr){
     ret.push_back(openhd::Setting{"V_OS_CAM_CONFIG",openhd::IntSetting {openhd::rpi::os::cam_config_to_int(openhd::rpi::os::get_current_cam_config_from_file()),
                                                                         c_rpi_os_camera_configuration}});
+  }
+  // and this allows an advanced user to change its air unit to a ground unit
+  // only expose this setting if OpenHD uses the file workaround to figure out air or ground.
+  if(openhd::tmp::any_file_air_or_ground_exists()){
+    ret.push_back(openhd::Setting{"CONFIG_BOOT_AIR",openhd::IntSetting {1,c_config_boot_as_air}});
   }
   return ret;
 }

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -185,11 +185,11 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
     if(value==0){
       // change to ground mode. Remove any existing file(s) if there are any
       openhd::tmp::delete_any_file_air_or_ground();
-      OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_GROUND_1," ");
+      openhd::tmp::write_file_ground();
     }else{
       // change to air mode. Remove any existing file(s) if there are any
       openhd::tmp::delete_any_file_air_or_ground();
-      OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_AIR_1," ");
+      openhd::tmp::write_file_air();
     }
     return true;
   };

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -62,6 +62,7 @@ class GroundTelemetry :public MavlinkSystem{
   //
   //std::unique_ptr<JoystickReader> m_joystick_reader;
   std::shared_ptr<spdlog::logger> m_console;
+  std::vector<openhd::Setting> get_all_settings();
 };
 
 #endif //OPENHD_TELEMETRY_GROUNDTELEMETRY_H

--- a/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
@@ -57,6 +57,7 @@ void OHDTelemetry::add_camera_component(const int camera_index, const std::vecto
   // only 2 cameras suported for now.
   airTelemetry->add_camera_component(camera_index,settings);
 }
+
 void OHDTelemetry::set_link_statistics(openhd::link_statistics::AllStats stats) const {
   if(profile.is_air){
 	airTelemetry->set_link_statistics(stats);
@@ -66,11 +67,13 @@ void OHDTelemetry::set_link_statistics(openhd::link_statistics::AllStats stats) 
 }
 
 void OHDTelemetry::add_external_ground_station_ip(const std::string &ip_openhd, const std::string &ip_dest_device) const {
+  // We only support external ground station(s) connecting to the ground unit
   if(profile.is_air)return;
   groundTelemetry->add_external_ground_station_ip(ip_openhd,ip_dest_device);
 }
-void OHDTelemetry::remove_external_ground_station_ip(const std::string &ip_openhd,
-													 const std::string &ip_dest_device) const {
+
+void OHDTelemetry::remove_external_ground_station_ip(const std::string &ip_openhd,const std::string &ip_dest_device) const {
+  // We only support external ground station(s) connecting to the ground unit
   if(profile.is_air)return;
   groundTelemetry->remove_external_ground_station_ip(ip_openhd,ip_dest_device);
 }

--- a/cloning_with_submodules.md
+++ b/cloning_with_submodules.md
@@ -1,1 +1,1 @@
-git clone --recurse-submodules -b consti-test git@github.com:OpenHD/Open.HD.git
+git clone --recurse-submodules -b 2.2.3-evo git@github.com:OpenHD/Open.HD.git


### PR DESCRIPTION
exposes the air or ground boot as an mavlink settings (NOTE: Whitelisted in QOpenHD by default)

case-sensitivity on files air.txt and ground.txt