### PR TITLE
2.2.3 evo consti test

### DIFF
--- a/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
@@ -59,6 +59,7 @@ static CamConfig get_current_cam_config_from_file(){
   OHDFilesystemUtil::create_directories("/boot/openhd/");
   if(!OHDFilesystemUtil::exists(CAM_CONFIG_FILENAME)){
     // The OHD image builder defaults to mmal, NOTE this is in contrast to the default rpi os release.
+    openhd::loggers::get_default()->error("EHM");
     OHDFilesystemUtil::write_file(CAM_CONFIG_FILENAME, std::to_string(cam_config_to_int(CamConfig::MMAL)));
     return CamConfig::MMAL;
   }

--- a/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
@@ -118,7 +118,7 @@ static void apply_new_cam_config_and_save(const OHDPlatform& platform,CamConfig 
 class ConfigChangeHandler{
  public:
   explicit ConfigChangeHandler(OHDPlatform platform): m_platform(platform){
-    assert(m_platform.platform_type==PlatformType::PC);
+    assert(m_platform.platform_type==PlatformType::RaspberryPi);
   }
   // Returns true if checks passed, false otherwise (param rejected)
   bool change_rpi_os_camera_configuration(int new_value_as_int){

--- a/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
@@ -126,6 +126,7 @@ class ConfigChangeHandler{
   // Returns true if checks passed, false otherwise (param rejected)
   bool change_rpi_os_camera_configuration(int new_value_as_int){
     std::lock_guard<std::mutex> lock(m_mutex);
+    openhd::loggers::get_default()->debug("Cam config request change to {}",new_value_as_int);
     if(!validate_cam_config_settings_int(new_value_as_int)){
       // reject, not a valid value
       return false;

--- a/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
@@ -59,13 +59,10 @@ static CamConfig get_current_cam_config_from_file(){
   OHDFilesystemUtil::create_directories("/boot/openhd/");
   if(!OHDFilesystemUtil::exists(CAM_CONFIG_FILENAME)){
     // The OHD image builder defaults to mmal, NOTE this is in contrast to the default rpi os release.
-    openhd::loggers::get_default()->error("EHM");
     OHDFilesystemUtil::write_file(CAM_CONFIG_FILENAME, std::to_string(cam_config_to_int(CamConfig::MMAL)));
     return CamConfig::MMAL;
   }
-  openhd::loggers::get_default()->error("hello");
   auto content=OHDFilesystemUtil::read_file(CAM_CONFIG_FILENAME);
-  openhd::loggers::get_default()->error("content:["+content+"]");
   auto content_as_int=std::stoi(content);
   return cam_config_from_int(content_as_int);
 }
@@ -101,7 +98,7 @@ const auto rpi_config_file_path="/boot/config.txt";
 // Applies the new cam config (rewrites the /boot/config.txt file)
 // Then writes the type corresponding to the current configuration into the settings file.
 static void apply_new_cam_config_and_save(const OHDPlatform& platform,CamConfig new_cam_config){
-  openhd::loggers::get_default()->warn("Begin apply cam config"+ cam_config_to_string(new_cam_config));
+  openhd::loggers::get_default()->debug("Begin apply cam config"+ cam_config_to_string(new_cam_config));
   const auto filename= get_file_name_for_cam_config(platform,new_cam_config);
   if(!OHDFilesystemUtil::exists(filename.c_str())){
     openhd::loggers::get_default()->warn("Cannot apply new cam config, corresponding config.txt ["+filename+"] not found");
@@ -112,7 +109,7 @@ static void apply_new_cam_config_and_save(const OHDPlatform& platform,CamConfig 
   // and copy over the new one
   OHDUtil::run_command("cp",{filename,rpi_config_file_path});
   save_cam_config_to_file(new_cam_config);
-  openhd::loggers::get_default()->warn("End apply cam config"+ cam_config_to_string(new_cam_config));
+  openhd::loggers::get_default()->debug("End apply cam config"+ cam_config_to_string(new_cam_config));
 }
 
 // Unfortunately complicated, since we need to perform the action asynchronously and then reboot

--- a/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
@@ -63,7 +63,9 @@ static CamConfig get_current_cam_config_from_file(){
     OHDFilesystemUtil::write_file(CAM_CONFIG_FILENAME, std::to_string(cam_config_to_int(CamConfig::MMAL)));
     return CamConfig::MMAL;
   }
+  openhd::loggers::get_default()->error("hello");
   auto content=OHDFilesystemUtil::read_file(CAM_CONFIG_FILENAME);
+  openhd::loggers::get_default()->error("content:["+content+"]");
   auto content_as_int=std::stoi(content);
   return cam_config_from_int(content_as_int);
 }

--- a/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
@@ -53,7 +53,7 @@ static bool validate_cam_config_settings_int(int val){
   return val>=0 && val<3;
 }
 
-static constexpr auto CAM_CONFIG_FILENAME="/boot/openhd/rpi_cam_config.txt";
+static constexpr auto CAM_CONFIG_FILENAME="/boot/openhd/curr_rpi_cam_config.txt";
 
 static CamConfig get_current_cam_config_from_file(){
   OHDFilesystemUtil::create_directories("/boot/openhd/");

--- a/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_common/openhd-rpi-os-configure-vendor-cam.hpp
@@ -50,7 +50,7 @@ static int cam_config_to_int(CamConfig cam_config){
 }
 
 static bool validate_cam_config_settings_int(int val){
-  return val<=0 && val<3;
+  return val>=0 && val<3;
 }
 
 static constexpr auto CAM_CONFIG_FILENAME="/boot/openhd/rpi_cam_config.txt";
@@ -126,7 +126,6 @@ class ConfigChangeHandler{
   // Returns true if checks passed, false otherwise (param rejected)
   bool change_rpi_os_camera_configuration(int new_value_as_int){
     std::lock_guard<std::mutex> lock(m_mutex);
-    openhd::loggers::get_default()->debug("Cam config request change to {}",new_value_as_int);
     if(!validate_cam_config_settings_int(new_value_as_int)){
       // reject, not a valid value
       return false;

--- a/OpenHD/ohd_common/openhd-util-filesystem.hpp
+++ b/OpenHD/ohd_common/openhd-util-filesystem.hpp
@@ -5,6 +5,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include "openhd-spdlog.hpp"
+
 // boost::filesystem or std::filesystem, what a pain
 // If possible, one should not use boost::filesystem or anything from boost::
 // inside the project, but quickly write a wrapper here.

--- a/OpenHD/ohd_common/openhd-util-filesystem.hpp
+++ b/OpenHD/ohd_common/openhd-util-filesystem.hpp
@@ -67,15 +67,24 @@ static void safe_delete_directory(const char* directory){
 }
 
 static void write_file(const std::string& path,const std::string& content){
-  std::ofstream t(path);
-  t << content;
-  t.close();
+  try{
+    std::ofstream t(path);
+    t << content;
+    t.close();
+  }catch (std::exception& e){
+    openhd::loggers::get_default()->warn("Cannot write file ["+path+"]");
+  }
 }
 static std::string read_file(const std::string& path){
-  std::ifstream f(path);
-  std::string ret;
-  f >> ret;
-  return ret;
+  try{
+    std::ifstream f(path);
+    std::string ret;
+    f >> ret;
+    return ret;
+  }catch (std::exception& e){
+    openhd::loggers::get_default()->warn("Cannot read file ["+path+"]");
+    return "";
+  }
 }
 
 static void remove_if_existing(const std::string& filename){

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -25,7 +25,7 @@ AirTelemetry::AirTelemetry(OHDPlatform platform,std::shared_ptr<openhd::ActionHa
   //
   generic_mavlink_param_provider=std::make_shared<XMavlinkParamProvider>(_sys_id,MAV_COMP_ID_ONBOARD_COMPUTER);
   if(_platform.platform_type==PlatformType::RaspberryPi){
-    m_rpi_os_change_config_handler=std::make_unique<openhd::rpi::os::ConfigChangeHandler>(_platform);
+    //m_rpi_os_change_config_handler=std::make_unique<openhd::rpi::os::ConfigChangeHandler>(_platform);
   }
   // NOTE: We don't call set ready yet, since we have to wait until other modules have provided
   // all their paramters.

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -206,7 +206,7 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
       return false;
     };
     auto tmp=board_type_to_string(_platform.board_type);
-    ret.push_back(openhd::Setting{"BOARD_TYPE",openhd::StringSetting {tmp,c_read_only_param}});
+    ret.push_back(openhd::Setting{"BOARD_TYPE",openhd::StringSetting{tmp,c_read_only_param}});
   }
   return ret;
 }

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -25,7 +25,7 @@ AirTelemetry::AirTelemetry(OHDPlatform platform,std::shared_ptr<openhd::ActionHa
   //
   generic_mavlink_param_provider=std::make_shared<XMavlinkParamProvider>(_sys_id,MAV_COMP_ID_ONBOARD_COMPUTER);
   if(_platform.platform_type==PlatformType::RaspberryPi){
-    //m_rpi_os_change_config_handler=std::make_unique<openhd::rpi::os::ConfigChangeHandler>(_platform);
+    m_rpi_os_change_config_handler=std::make_unique<openhd::rpi::os::ConfigChangeHandler>(_platform);
   }
   // NOTE: We don't call set ready yet, since we have to wait until other modules have provided
   // all their paramters.


### PR DESCRIPTION
Fixed stupid mistakes in previous pull request.

This change is a bit drepressing, but libcamera_ardu breaks compatibility with the "normal" rpi HQ cam on libcamera and / or doesn't work on the rpi 5.15.y kernel.
Also, sed is bugged, so now we just copy over full config.txt files according to the camera config and / or the RPI type (series 4 or not).