### PR TITLE
2.2.3 evo consti test

### DIFF
--- a/OpenHD/ohd_interface/inc/validate_settings_helper.h
+++ b/OpenHD/ohd_interface/inc/validate_settings_helper.h
@@ -29,12 +29,13 @@ static std::vector<WifiChannel> get_channels_2G() {
 	  WifiChannel{2452,9},
 	  WifiChannel{2457,10},
 	  WifiChannel{2462,11},
-	  WifiChannel{2467,12},
-	  WifiChannel{2472,13},
+          // Temporary disabled - they won't work unil we patch this shit in the kernel
+	  //WifiChannel{2467,12},
+	  //WifiChannel{2472,13},
 	  // until here it is consistent (5Mhz increments)
 	  // this one is neither allowed in EU nor USA
 	  // (only japan under 11b)
-	  WifiChannel{2484,14},
+	  //WifiChannel{2484,14},
   };
 };
 

--- a/OpenHD/ohd_interface/src/OHDInterface.cpp
+++ b/OpenHD/ohd_interface/src/OHDInterface.cpp
@@ -181,6 +181,9 @@ std::vector<openhd::Setting> OHDInterface::get_all_settings(){
     // we can disable / enable wifi hotspot.
     int enabled=_interface_settings_holder->get_settings().enable_wifi_hotspot;
     auto change_wifi_hotspot=openhd::IntSetting{enabled,[this](std::string,int value){
+                                                    // temporarily disable wifi hotspot (do not allow an user to turn it on)
+                                                    // until we've fixed the OS
+                                                    return false;
                                                     if(value== 0 || value== 1){
                                                       const bool enableX=value;
                                                       if(enableX){


### PR DESCRIPTION
disable things in openhd that are known to NOT WORK due to a incompletely configured image