### PR TITLE
Optimize telemetry packets per second

### DIFF
--- a/OpenHD/ohd_interface/inc/wb_link_settings.hpp
+++ b/OpenHD/ohd_interface/inc/wb_link_settings.hpp
@@ -53,7 +53,8 @@ struct WBLinkSettings {
   uint32_t wb_video_fec_percentage=DEFAULT_WB_VIDEO_FEC_PERCENTAGE;
   uint32_t wb_tx_power_milli_watt=DEFAULT_WIFI_TX_POWER_MILLI_WATT;
   // rtl8812au driver does not support setting tx power by iw dev, but rather only by setting
-  // this stupid tx power idx override param
+  // a tx power index override param. With the most recent openhd rtl8812au driver,
+  // we can even change this parameter dynamically.
   //uint32_t wb_rtl8812au_tx_pwr_idx_override=0;
   // R.n only possible on RTL8812AU
   // See https://github.com/OpenHD/rtl8812au/blob/v5.2.20/os_dep/linux/ioctl_cfg80211.c#L3667
@@ -160,7 +161,7 @@ static constexpr auto WB_ENABLE_SHORT_GUARD="WB_E_SHORT_GUARD";
 // NOTE: these values are the values that are passed to NL80211_ATTR_WIPHY_TX_POWER_LEVEL
 // this param is normally in mBm, but has been reworked to accept those rtl8812au specific tx power index override values
 // (under this name they were known already in previous openhd releases, but we now support changing them dynamcially at run time)
-static uint32_t tx_power_level_to_mBm_rtl8812au_only(const TxPowerLevel& tx_power_level){
+static uint32_t tx_power_level_to_rtl8812au_tx_power_index_override(const TxPowerLevel& tx_power_level){
   switch (tx_power_level) {
     case TxPowerLevel::LOW:
       return 19;

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -391,7 +391,9 @@ void WBLink::apply_txpower() {
     const auto& card=holder->_wifi_card;
     if(card.type==WiFiCardType::Realtek8812au){
       // corresponding driver workaround for dynamic tx power:
-      const auto tmp=openhd::tx_power_level_to_mBm_rtl8812au_only(settings.wb_tx_power_level);
+      const auto tmp=
+          openhd::tx_power_level_to_rtl8812au_tx_power_index_override(
+              settings.wb_tx_power_level);
       m_console->debug("RTL8812AU power level: %d %d",settings.wb_tx_power_level,tmp);
       WifiCardCommandHelper::iw_set_tx_power_mBm(card,tmp);
     }else{

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -395,7 +395,9 @@ void WBLink::apply_txpower() {
       m_console->debug("RTL8812AU power level: {} {}",settings.wb_tx_power_level,tmp);
       WifiCardCommandHelper::iw_set_tx_power_mBm(card,tmp);
     }else{
-      WifiCardCommandHelper::iwconfig_set_txpower(card,settings.wb_tx_power_milli_watt);
+      const auto tmp=openhd::milli_watt_to_mBm(settings.wb_tx_power_milli_watt);
+      WifiCardCommandHelper::iw_set_tx_power_mBm(tmp);
+      //WifiCardCommandHelper::iwconfig_set_txpower(card,settings.wb_tx_power_milli_watt);
     }
   }
 }

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -396,7 +396,7 @@ void WBLink::apply_txpower() {
       WifiCardCommandHelper::iw_set_tx_power_mBm(card,tmp);
     }else{
       const auto tmp=openhd::milli_watt_to_mBm(settings.wb_tx_power_milli_watt);
-      WifiCardCommandHelper::iw_set_tx_power_mBm(tmp);
+      WifiCardCommandHelper::iw_set_tx_power_mBm(card,tmp);
       //WifiCardCommandHelper::iwconfig_set_txpower(card,settings.wb_tx_power_milli_watt);
     }
   }

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -390,11 +390,9 @@ void WBLink::apply_txpower() {
   for(const auto& holder: m_broadcast_cards){
     const auto& card=holder->_wifi_card;
     if(card.type==WiFiCardType::Realtek8812au){
-      // corresponding driver workaround for dynamic tx power:
-      const auto tmp=
-          openhd::tx_power_level_to_rtl8812au_tx_power_index_override(
-              settings.wb_tx_power_level);
-      m_console->debug("RTL8812AU power level: %d %d",settings.wb_tx_power_level,tmp);
+      // requires corresponding driver workaround for dynamic tx power
+      const auto tmp=openhd::tx_power_level_to_rtl8812au_tx_power_index_override(settings.wb_tx_power_level);
+      m_console->debug("RTL8812AU power level: {} {}",settings.wb_tx_power_level,tmp);
       WifiCardCommandHelper::iw_set_tx_power_mBm(card,tmp);
     }else{
       WifiCardCommandHelper::iwconfig_set_txpower(card,settings.wb_tx_power_milli_watt);

--- a/OpenHD/ohd_telemetry/CMakeLists.txt
+++ b/OpenHD/ohd_telemetry/CMakeLists.txt
@@ -32,7 +32,8 @@ else()
 endif()
 
 SET(sources
-    "src/endpoints/MEndpoint.hpp"
+    "src/endpoints/MEndpoint.cpp"
+    "src/endpoints/MEndpoint.h"
     "src/endpoints/SerialEndpoint.cpp"
     "src/endpoints/SerialEndpoint.h"
     "src/endpoints/UDPEndpoint.cpp"

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -76,10 +76,9 @@ void AirTelemetry::on_messages_ground_unit(const std::vector<MavlinkMessage>& me
   // any data created by an OpenHD component on the air pi only needs to be sent to the ground pi, the FC cannot do anything with it anyways.
   std::lock_guard<std::mutex> guard(components_lock);
   for(auto& component: components){
-    for(const auto message:messages){
-      const auto responses=component->process_mavlink_message(message);
-      send_messages_ground_unit(responses);
-    }
+    std::vector<MavlinkMessage> responses{};
+    MavlinkComponent::vec_append(responses,component->process_mavlink_messages(messages));
+    send_messages_ground_unit(responses);
   }
 }
 

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.h
@@ -47,13 +47,13 @@ class AirTelemetry : public MavlinkSystem{
   const OHDPlatform _platform;
   std::unique_ptr<openhd::telemetry::air::SettingsHolder> _airTelemetrySettings;
   // send a mavlink message to the flight controller connected to the air unit via UART, if connected.
-  void sendMessageFC(const MavlinkMessage &message);
-  // send a mavlink message to the ground pi, system cannot know if this message actually makes it.
-  void sendMessageGroundPi(const MavlinkMessage &message);
-  // called every time a message from the flight controller is received
-  void onMessageFC(MavlinkMessage &message);
-  // called every time a message from the ground pi is received
-  void onMessageGroundPi(MavlinkMessage &message);
+  void send_messages_fc(const std::vector<MavlinkMessage>& messages);
+  // send mavlink messages to the ground unit, lossy
+  void send_messages_ground_unit(const std::vector<MavlinkMessage>& messages);
+  // called every time one or more messages from the flight controller are received
+  void on_messages_fc(const std::vector<MavlinkMessage>& messages);
+  // called every time one or more messages from the ground unit are received
+  void on_messages_ground_unit(const std::vector<MavlinkMessage>& messages);
  private:
   std::mutex _serialEndpointMutex;
   std::unique_ptr<SerialEndpoint> serialEndpoint;

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -88,7 +88,7 @@ void GroundTelemetry::onMessageGroundStationClients(MavlinkMessage &message) {
   // This is not exactly following the mavlink routing standard, but saves a lot of bandwidth.
   std::lock_guard<std::mutex> guard(components_lock);
   for(auto& component:components){
-    const auto responses=component->process_mavlink_message(message);
+    const auto responses=component->process_mavlink_messages({message});
     for(const auto& response:responses){
       // for now, send to the ground station clients only
       sendMessageGroundStationClients(response);

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -44,13 +44,13 @@ class GroundTelemetry :public MavlinkSystem{
  private:
   const OHDPlatform _platform;
   // called every time a message from the air pi is received
-  void onMessageAirPi(MavlinkMessage &message);
+  void on_messages_air_unit(const std::vector<MavlinkMessage>& messages);
   // send a message to the air pi
-  void sendMessageAirPi(const MavlinkMessage &message);
+  void send_messages_air_unit(const std::vector<MavlinkMessage>& messages);
   // called every time a message is received from any of the clients connected to the Ground Station (For Example QOpenHD)
-  void onMessageGroundStationClients(MavlinkMessage &message);
+  void on_messages_ground_station_clients(const std::vector<MavlinkMessage>& messages);
   // send a message to all clients connected to the ground station, for example QOpenHD
-  void sendMessageGroundStationClients(const MavlinkMessage &message);
+  void send_messages_ground_station_clients(const std::vector<MavlinkMessage>& messages);
  private:
   std::unique_ptr<openhd::telemetry::ground::SettingsHolder> m_groundTelemetrySettings;
   std::unique_ptr<UDPEndpoint2> udpGroundClient = nullptr;

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -43,13 +43,13 @@ class GroundTelemetry :public MavlinkSystem{
   void remove_external_ground_station_ip(const std::string& ip_openhd,const std::string& ip_dest_device);
  private:
   const OHDPlatform _platform;
-  // called every time a message from the air pi is received
+  // called every time one or more messages from the air unit are received
   void on_messages_air_unit(const std::vector<MavlinkMessage>& messages);
-  // send a message to the air pi
+  // send messages to the air unit, lossy
   void send_messages_air_unit(const std::vector<MavlinkMessage>& messages);
-  // called every time a message is received from any of the clients connected to the Ground Station (For Example QOpenHD)
+  // called every time one or more messages are received from any of the clients connected to the Ground Station (For Example QOpenHD)
   void on_messages_ground_station_clients(const std::vector<MavlinkMessage>& messages);
-  // send a message to all clients connected to the ground station, for example QOpenHD
+  // send one or more messages to all clients connected to the ground station, for example QOpenHD
   void send_messages_ground_station_clients(const std::vector<MavlinkMessage>& messages);
  private:
   std::unique_ptr<openhd::telemetry::ground::SettingsHolder> m_groundTelemetrySettings;

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -1,0 +1,80 @@
+//
+// Created by consti10 on 05.12.22.
+//
+
+#include "MEndpoint.h"
+
+MEndpoint::MEndpoint(std::string tag)
+    : TAG(std::move(tag)),m_mavlink_channel(checkoutFreeChannel()) {
+  openhd::log::get_default()->debug(TAG+" using channel:{}",m_mavlink_channel);
+}
+
+void MEndpoint::sendMessage(const MavlinkMessage& message) {
+#ifdef OHD_TELEMETRY_TESTING_ENABLE_PACKET_LOSS
+  const auto rand= random_number(0,100);
+    if(rand>50){
+      openhd::loggers::get_default()->debug("Emulate packet loss - dropped packet");
+      return;
+    }
+#endif
+  const auto res=sendMessageImpl(message);
+  m_n_messages_sent++;
+  if(!res)m_n_messages_send_failed++;
+}
+
+void MEndpoint::sendMessages(const std::vector<MavlinkMessage>& messages) {
+  for(const auto& msg:messages){
+    sendMessage(msg);
+  }
+}
+
+void MEndpoint::registerCallback(MAV_MSG_CALLBACK cb) {
+  if (callback != nullptr) {
+    // this might be a common programming mistake - you can only register one callback here
+    openhd::log::get_default()->warn("Overwriting already existing callback");
+  }
+  callback = std::move(cb);
+}
+
+bool MEndpoint::isAlive() const {
+  return (std::chrono::steady_clock::now() - lastMessage) < std::chrono::seconds(5);
+}
+
+std::string MEndpoint::createInfo() const {
+  std::stringstream ss;
+  ss<<TAG<<" {sent:"<<m_n_messages_sent<<" send_failed:"<<m_n_messages_send_failed<<" recv:"<<m_n_messages_received<<" alive:"<<(isAlive() ? "Y" : "N") << "}\n";
+  return ss.str();
+}
+
+void MEndpoint::parseNewData(const uint8_t* data, const int data_len) {
+  //<<TAG<<" received data:"<<data_len<<" "<<MavlinkHelpers::raw_content(data,data_len)<<"\n";
+  int nMessages=0;
+  mavlink_message_t msg;
+  for (int i = 0; i < data_len; i++) {
+    uint8_t res = mavlink_parse_char(m_mavlink_channel, (uint8_t)data[i], &msg, &receiveMavlinkStatus);
+    if (res) {
+      nMessages++;
+      onNewMavlinkMessage(msg);
+    }
+  }
+  //<<TAG<<" N messages:"<<nMessages<<"\n";
+  //<<TAG<<MavlinkHelpers::mavlink_status_to_string(receiveMavlinkStatus)<<"\n";
+}
+
+void MEndpoint::onNewMavlinkMessage(mavlink_message_t msg) {
+#ifdef OHD_TELEMETRY_TESTING_ENABLE_PACKET_LOSS
+  const auto rand= random_number(0,100);
+    if(rand>50){
+      openhd::loggers::get_default()->debug("Emulate packet loss - dropped packet");
+      return;1
+    }
+#endif
+  lastMessage = std::chrono::steady_clock::now();
+  MavlinkMessage message{msg};
+  if (callback != nullptr) {
+    callback(message);
+  } else {
+    openhd::log::get_default()->warn("No callback set,did you forget to add it ?");
+  }
+  m_n_messages_received++;
+}

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -60,8 +60,7 @@ void MEndpoint::parseNewData(const uint8_t* data, const int data_len) {
       onNewMavlinkMessage(msg);
     }
   }
-  //<<TAG<<" N messages:"<<nMessages<<"\n";
-  //<<TAG<<MavlinkHelpers::mavlink_status_to_string(receiveMavlinkStatus)<<"\n";
+  openhd::log::create_or_get(TAG)->debug("N messages:{}",nMessages);
 }
 
 void MEndpoint::onNewMavlinkMessage(mavlink_message_t msg) {

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -12,22 +12,11 @@ MEndpoint::MEndpoint(std::string tag)
   openhd::log::get_default()->debug(TAG+" using channel:{}",m_mavlink_channel);
 }
 
-void MEndpoint::sendMessage(const MavlinkMessage& message) {
-#ifdef OHD_TELEMETRY_TESTING_ENABLE_PACKET_LOSS
-  const auto rand= random_number(0,100);
-    if(rand>50){
-      openhd::loggers::get_default()->debug("Emulate packet loss - dropped packet");
-      return;
-    }
-#endif
-  const auto res=sendMessageImpl(message);
-  m_n_messages_sent++;
-  if(!res)m_n_messages_send_failed++;
-}
-
-void MEndpoint::sendMessages(const std::vector<MavlinkMessage>& messages) {
+void MEndpoint::sendMessages(const std::vector<MavlinkMessage> messages) {
   for(const auto& msg:messages){
-    sendMessage(msg);
+    const auto res=sendMessageImpl(msg);
+    m_n_messages_sent++;
+    if(!res)m_n_messages_send_failed++;
   }
 }
 

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -13,7 +13,9 @@ MEndpoint::MEndpoint(std::string tag)
 }
 
 void MEndpoint::sendMessages(const std::vector<MavlinkMessage> messages) {
-  openhd::log::create_or_get(TAG)->debug("N messages send:{}",messages.size());
+  if(!messages.empty()){
+    openhd::log::create_or_get(TAG)->debug("N messages send:{}",messages.size());
+  }
   const auto res= sendMessagesImpl(messages);
   m_n_messages_sent+=messages.size();
   if(!res){
@@ -50,7 +52,9 @@ void MEndpoint::parseNewData(const uint8_t* data, const int data_len) {
     }
   }
   onNewMavlinkMessages(messages);
-  openhd::log::create_or_get(TAG)->debug("N messages receive:{}",messages.size());
+  if(!messages.empty()){
+    openhd::log::create_or_get(TAG)->debug("N messages receive:{}",messages.size());
+  }
 }
 
 

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -14,10 +14,10 @@ MEndpoint::MEndpoint(std::string tag)
 
 void MEndpoint::sendMessages(const std::vector<MavlinkMessage> messages) {
   openhd::log::create_or_get(TAG)->debug("N messages send:{}",messages.size());
-  for(const auto& msg:messages){
-    const auto res=sendMessageImpl(msg);
-    m_n_messages_sent++;
-    if(!res)m_n_messages_send_failed++;
+  const auto res= sendMessagesImpl(messages);
+  m_n_messages_sent+=messages.size();
+  if(!res){
+    m_n_messages_send_failed++;
   }
 }
 

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -13,6 +13,7 @@ MEndpoint::MEndpoint(std::string tag)
 }
 
 void MEndpoint::sendMessages(const std::vector<MavlinkMessage> messages) {
+  openhd::log::create_or_get(TAG)->debug("N messages send:{}",messages.size());
   for(const auto& msg:messages){
     const auto res=sendMessageImpl(msg);
     m_n_messages_sent++;
@@ -49,7 +50,7 @@ void MEndpoint::parseNewData(const uint8_t* data, const int data_len) {
     }
   }
   onNewMavlinkMessages(messages);
-  openhd::log::create_or_get(TAG)->debug("N messages:{}",messages.size());
+  openhd::log::create_or_get(TAG)->debug("N messages receive:{}",messages.size());
 }
 
 

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -14,7 +14,7 @@ MEndpoint::MEndpoint(std::string tag)
 
 void MEndpoint::sendMessages(const std::vector<MavlinkMessage> messages) {
   if(!messages.empty()){
-    openhd::log::create_or_get(TAG)->debug("N messages send:{}",messages.size());
+    //openhd::log::create_or_get(TAG)->debug("N messages send:{}",messages.size());
   }
   const auto res= sendMessagesImpl(messages);
   m_n_messages_sent+=messages.size();
@@ -53,7 +53,7 @@ void MEndpoint::parseNewData(const uint8_t* data, const int data_len) {
   }
   onNewMavlinkMessages(messages);
   if(!messages.empty()){
-    openhd::log::create_or_get(TAG)->debug("N messages receive:{}",messages.size());
+    //openhd::log::create_or_get(TAG)->debug("N messages receive:{}",messages.size());
   }
 }
 

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.cpp
@@ -4,6 +4,9 @@
 
 #include "MEndpoint.h"
 
+// WARNING BE CAREFULL TO REMOVE ON RELEASE
+//#define OHD_TELEMETRY_TESTING_ENABLE_PACKET_LOSS
+
 MEndpoint::MEndpoint(std::string tag)
     : TAG(std::move(tag)),m_mavlink_channel(checkoutFreeChannel()) {
   openhd::log::get_default()->debug(TAG+" using channel:{}",m_mavlink_channel);

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
@@ -69,9 +69,9 @@ class MEndpoint {
 	onNewMavlinkMessages({MavlinkMessage{msg}});
   }
   // Must be overridden by the implementation
-  // Returns true if the message has been properly sent (e.g. a connection exists on connection-based endpoints)
+  // Returns true if the message(s) have been properly sent (e.g. a connection exists on connection-based endpoints)
   // false otherwise
-  virtual bool sendMessageImpl(const MavlinkMessage &message) = 0;
+  virtual bool sendMessagesImpl(const std::vector<MavlinkMessage>& messages) = 0;
  private:
   MAV_MSG_CALLBACK callback = nullptr;
   // increases message count and forwards the messages via the callback if registered.

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
@@ -67,7 +67,7 @@ class MEndpoint {
   void parseNewData(const uint8_t *data,int data_len);
   // this one is special, since mavsdk in this case has already done the message parsing
   void parseNewDataEmulateForMavsdk(mavlink_message_t msg){
-	onNewMavlinkMessage(msg);
+	onNewMavlinkMessages({MavlinkMessage{msg}});
   }
   // Must be overridden by the implementation
   // Returns true if the message has been properly sent (e.g. a connection exists on connection-based endpoints)
@@ -75,8 +75,8 @@ class MEndpoint {
   virtual bool sendMessageImpl(const MavlinkMessage &message) = 0;
  private:
   MAV_MSG_CALLBACK callback = nullptr;
-  // increases message count and forwards the message via the callback if registered.
-  void onNewMavlinkMessage(mavlink_message_t msg);
+  // increases message count and forwards the messages via the callback if registered.
+  void onNewMavlinkMessages(std::vector<MavlinkMessage> messages);
   mavlink_status_t receiveMavlinkStatus{};
   const uint8_t m_mavlink_channel;
   std::chrono::steady_clock::time_point lastMessage{};

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
@@ -15,9 +15,6 @@
 #include <utility>
 #include <atomic>
 
-// WARNING BE CAREFULL TO REMOVE ON RELEASE
-//#define OHD_TELEMETRY_TESTING_ENABLE_PACKET_LOSS
-
 // Mavlink Endpoint
 // A Mavlink endpoint hides away the underlying connection - e.g. UART, TCP, UDP.
 // It has a (implementation-specific) method to send a message (sendMessage) and (implementation-specific)
@@ -67,7 +64,7 @@ class MEndpoint {
   const std::string TAG;
  protected:
   // parse new data as it comes in, extract mavlink messages and forward them on the registered callback (if it has been registered)
-  void parseNewData(const uint8_t *data,const int data_len);
+  void parseNewData(const uint8_t *data,int data_len);
   // this one is special, since mavsdk in this case has already done the message parsing
   void parseNewDataEmulateForMavsdk(mavlink_message_t msg){
 	onNewMavlinkMessage(msg);

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
@@ -37,9 +37,7 @@ class MEndpoint {
    * @param tag a tag for debugging.
    * @param mavlink_channel the mavlink channel to use for parsing.
    */
-  explicit MEndpoint(std::string tag) : TAG(std::move(tag)),m_mavlink_channel(checkoutFreeChannel()) {
-    openhd::log::get_default()->debug(TAG+" using channel:{}",m_mavlink_channel);
-  };
+  explicit MEndpoint(std::string tag);;
   /**
    * send a message via this endpoint.
    * If the endpoint is silently disconnected, this MUST NOT FAIL/CRASH.
@@ -47,66 +45,29 @@ class MEndpoint {
    * and increases the sent message count
    * @param message the message to send
    */
-  void sendMessage(const MavlinkMessage &message){
-#ifdef OHD_TELEMETRY_TESTING_ENABLE_PACKET_LOSS
-    const auto rand= random_number(0,100);
-    if(rand>50){
-      openhd::loggers::get_default()->debug("Emulate packet loss - dropped packet");
-      return;
-    }
-#endif
-	const auto res=sendMessageImpl(message);
-	m_n_messages_sent++;
-	if(!res)m_n_messages_send_failed++;
-  }
+  void sendMessage(const MavlinkMessage &message);
   // Helper to send multiple messages at once
-  void sendMessages(const std::vector<MavlinkMessage>& messages){
-    for(const auto& msg:messages){
-      sendMessage(msg);
-    }
-  }
+  void sendMessages(const std::vector<MavlinkMessage>& messages);
   /**
    * register a callback that is called every time
    * this endpoint has received a new message
    * @param cb the callback function to register that is then called with a message every time a new full mavlink message has been parsed
    */
-  void registerCallback(MAV_MSG_CALLBACK cb) {
-	if (callback != nullptr) {
-	  // this might be a common programming mistake - you can only register one callback here
-	  openhd::log::get_default()->warn("Overwriting already existing callback");
-	}
-	callback = std::move(cb);
-  }
+  void registerCallback(MAV_MSG_CALLBACK cb);
   /**
    * If (for some reason) you need to reason if this endpoint is alive, just check if it has received any mavlink messages
    * in the last X seconds
    */
-  [[nodiscard]] bool isAlive()const {
-	return (std::chrono::steady_clock::now() - lastMessage) < std::chrono::seconds(5);
-  }
-  [[nodiscard]] std::string createInfo()const{
-	std::stringstream ss;
-	ss<<TAG<<" {sent:"<<m_n_messages_sent<<" send_failed:"<<m_n_messages_send_failed<<" recv:"<<m_n_messages_received<<" alive:"<<(isAlive() ? "Y" : "N") << "}\n";
-	return ss.str();
-  }
+  [[nodiscard]] bool isAlive()const;
+  /**
+   * @return info about this endpoint, for debugging
+   */
+  [[nodiscard]] std::string createInfo()const;
   // can be public since immutable
   const std::string TAG;
  protected:
   // parse new data as it comes in, extract mavlink messages and forward them on the registered callback (if it has been registered)
-  void parseNewData(const uint8_t *data,const int data_len) {
-	//<<TAG<<" received data:"<<data_len<<" "<<MavlinkHelpers::raw_content(data,data_len)<<"\n";
-	int nMessages=0;
-	mavlink_message_t msg;
-	for (int i = 0; i < data_len; i++) {
-	  uint8_t res = mavlink_parse_char(m_mavlink_channel, (uint8_t)data[i], &msg, &receiveMavlinkStatus);
-	  if (res) {
-		nMessages++;
-		onNewMavlinkMessage(msg);
-	  }
-	}
-	//<<TAG<<" N messages:"<<nMessages<<"\n";
-	//<<TAG<<MavlinkHelpers::mavlink_status_to_string(receiveMavlinkStatus)<<"\n";
-  }
+  void parseNewData(const uint8_t *data,const int data_len);
   // this one is special, since mavsdk in this case has already done the message parsing
   void parseNewDataEmulateForMavsdk(mavlink_message_t msg){
 	onNewMavlinkMessage(msg);
@@ -118,23 +79,7 @@ class MEndpoint {
  private:
   MAV_MSG_CALLBACK callback = nullptr;
   // increases message count and forwards the message via the callback if registered.
-  void onNewMavlinkMessage(mavlink_message_t msg){
-#ifdef OHD_TELEMETRY_TESTING_ENABLE_PACKET_LOSS
-    const auto rand= random_number(0,100);
-    if(rand>50){
-      openhd::loggers::get_default()->debug("Emulate packet loss - dropped packet");
-      return;1
-    }
-#endif
-	lastMessage = std::chrono::steady_clock::now();
-	MavlinkMessage message{msg};
-	if (callback != nullptr) {
-	  callback(message);
-	} else {
-	  openhd::log::get_default()->warn("No callback set,did you forget to add it ?");
-	}
-	m_n_messages_received++;
-  }
+  void onNewMavlinkMessage(mavlink_message_t msg);
   mavlink_status_t receiveMavlinkStatus{};
   const uint8_t m_mavlink_channel;
   std::chrono::steady_clock::time_point lastMessage{};

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
@@ -36,15 +36,14 @@ class MEndpoint {
    */
   explicit MEndpoint(std::string tag);;
   /**
-   * send a message via this endpoint.
+   * send one or more messages via this endpoint.
    * If the endpoint is silently disconnected, this MUST NOT FAIL/CRASH.
    * This calls the underlying implementation's sendMessageImpl() function (pure virtual)
    * and increases the sent message count
    * @param message the message to send
+   * TODO make sure we never exceed the wifi MTU
    */
-  void sendMessage(const MavlinkMessage &message);
-  // Helper to send multiple messages at once
-  void sendMessages(const std::vector<MavlinkMessage>& messages);
+  void sendMessages(const std::vector<MavlinkMessage> messages);
   /**
    * register a callback that is called every time
    * this endpoint has received a new message

--- a/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.cpp
@@ -57,10 +57,15 @@ SerialEndpoint::~SerialEndpoint() {
   stop();
 }
 
-bool SerialEndpoint::sendMessageImpl(const MavlinkMessage &message) {
-  const auto data = message.pack();
-  const int ret=write_data_serial(data);
-  return ret;
+bool SerialEndpoint::sendMessagesImpl(const std::vector<MavlinkMessage>& messages) {
+  auto message_buffers= pack_messages(messages);
+  bool success= true;
+  for(const auto& message_buffer:message_buffers){
+    if(!write_data_serial(message_buffer)){
+      success= false;
+    }
+  }
+  return success;
 }
 
 bool SerialEndpoint::write_data_serial(const std::vector<uint8_t> &data){

--- a/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.h
@@ -5,15 +5,15 @@
 #ifndef OPENHD_OPENHD_OHD_TELEMETRY_SRC_ENDPOINTS_SERIALENDPOINT_H_
 #define OPENHD_OPENHD_OHD_TELEMETRY_SRC_ENDPOINTS_SERIALENDPOINT_H_
 
-#include "MEndpoint.hpp"
-#include "openhd-spdlog.hpp"
-#include <utility>
-#include <chrono>
-#include <mutex>
-#include <thread>
+#include <atomic>
 #include <chrono>
 #include <memory>
-#include <atomic>
+#include <mutex>
+#include <thread>
+#include <utility>
+
+#include "MEndpoint.h"
+#include "openhd-spdlog.hpp"
 
 // At some point, I decided there is no way around it than to write our own UART receiver program.
 // Mostly based on MAVSDK. Doesn't use boost.

--- a/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.h
@@ -46,7 +46,7 @@ class SerialEndpoint : public MEndpoint{
   // Does nothing if already stopped.
   void stop();
  private:
-  bool sendMessageImpl(const MavlinkMessage &message) override;
+  bool sendMessagesImpl(const std::vector<MavlinkMessage>& messages) override;
   static int define_from_baudrate(int baudrate);
   static int setup_port(const HWOptions& options,std::shared_ptr<spdlog::logger> m_console);
   void connect_and_read_loop();

--- a/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint.cpp
@@ -35,11 +35,13 @@ UDPEndpoint::~UDPEndpoint() {
   }
 }
 
-bool UDPEndpoint::sendMessageImpl(const MavlinkMessage &message) {
+bool UDPEndpoint::sendMessagesImpl(const std::vector<MavlinkMessage>& messages) {
   //debugMavlinkMessage(message.m,"UDPEndpoint::sendMessage");
   if (transmitter != nullptr) {
-    const auto data = message.pack();
-    transmitter->forwardPacketViaUDP(data.data(), data.size());
+    auto message_buffers= pack_messages(messages);
+    for(const auto& message_buffer:message_buffers){
+      transmitter->forwardPacketViaUDP(message_buffer.data(), message_buffer.size());
+    }
     return true;
   } else {
     m_console->debug("UDPEndpoint::sendMessage with no transmitter");

--- a/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint.h
@@ -5,10 +5,11 @@
 #ifndef XMAVLINKSERVICE_UDPENDPOINT_H
 #define XMAVLINKSERVICE_UDPENDPOINT_H
 
-#include "MEndpoint.hpp"
-#include "HelperSources/SocketHelper.hpp"
-#include "openhd-spdlog.hpp"
 #include <thread>
+
+#include "HelperSources/SocketHelper.hpp"
+#include "MEndpoint.h"
+#include "openhd-spdlog.hpp"
 
 // Wraps two UDP ports, one for sending and one for receiving data
 // (since TCP and UART for example also allow sending and receiving).

--- a/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint.h
@@ -27,7 +27,7 @@ class UDPEndpoint : public MEndpoint {
   // Makes it easy to not mess up the "what is UDP tx port on air unit is UDP rx port on ground unit" paradigm
   static std::unique_ptr<UDPEndpoint> createEndpointForOHDWifibroadcast(bool isAir);
  private:
-  bool sendMessageImpl(const MavlinkMessage &message) override;
+  bool sendMessagesImpl(const std::vector<MavlinkMessage>& messages) override;
   const int SEND_PORT;
   const int RECV_PORT;
   std::unique_ptr<SocketHelper::UDPReceiver> receiver;

--- a/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint2.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint2.h
@@ -29,7 +29,7 @@ class UDPEndpoint2 : public MEndpoint {
   void addAnotherDestIpAddress(std::string ip);
   void removeAnotherDestIpAddress(std::string ip);
  private:
-  bool sendMessageImpl(const MavlinkMessage &message) override;
+  bool sendMessagesImpl(const std::vector<MavlinkMessage>& messages) override;
   const std::string SENDER_IP;
   const int SEND_PORT;
   const std::string RECV_IP;

--- a/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint2.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint2.h
@@ -5,10 +5,11 @@
 #ifndef OPENHD_OPENHD_OHD_TELEMETRY_SRC_ENDPOINTS_UDPENDPOINT2_H_
 #define OPENHD_OPENHD_OHD_TELEMETRY_SRC_ENDPOINTS_UDPENDPOINT2_H_
 
-#include "MEndpoint.hpp"
-#include "HelperSources/SocketHelper.hpp"
-#include <thread>
 #include <map>
+#include <thread>
+
+#include "HelperSources/SocketHelper.hpp"
+#include "MEndpoint.h"
 
 /**
  * Special, for communicating with QGroundControl..

--- a/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.h
+++ b/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.h
@@ -42,7 +42,7 @@ class OHDMainComponent : public MavlinkComponent{
   // override from component
   std::vector<MavlinkMessage> generate_mavlink_messages() override;
   // override from component
-  std::vector<MavlinkMessage> process_mavlink_message(const MavlinkMessage &msg)override;
+  std::vector<MavlinkMessage> process_mavlink_messages(std::vector<MavlinkMessage> messages)override;
   // update stats from ohd_interface
   void set_link_statistics(openhd::link_statistics::StatsAirGround stats);
   openhd::link_statistics::StatsAirGround get_latest_link_statistics();

--- a/OpenHD/ohd_telemetry/src/mav_include.h
+++ b/OpenHD/ohd_telemetry/src/mav_include.h
@@ -36,6 +36,25 @@ struct MavlinkMessage {
   }
 };
 
+static std::vector<std::vector<uint8_t>> pack_messages(const std::vector<MavlinkMessage>& messages,uint32_t max_mtu=1024){
+  std::vector<std::vector<uint8_t>> ret;
+  for(const auto& msg:messages){
+    ret.emplace_back(msg.pack());
+  }
+  return ret;
+  /*std::vector<uint8_t> buff{};
+  buff.reserve(max_mtu);
+  for(const auto& msg:messages){
+    auto data=msg.pack();
+    if(buff.size()+data.size()<=max_mtu){
+      buff.insert(buff.end(), data.begin(), data.end());
+    }else{
+
+    }
+  }*/
+}
+
+
 // For registering a callback that is called every time component X receives one or more mavlink messages
 typedef std::function<void(const std::vector<MavlinkMessage> messages)> MAV_MSG_CALLBACK;
 

--- a/OpenHD/ohd_telemetry/src/mav_include.h
+++ b/OpenHD/ohd_telemetry/src/mav_include.h
@@ -38,20 +38,28 @@ struct MavlinkMessage {
 
 static std::vector<std::vector<uint8_t>> pack_messages(const std::vector<MavlinkMessage>& messages,uint32_t max_mtu=1024){
   std::vector<std::vector<uint8_t>> ret;
-  for(const auto& msg:messages){
+  /*for(const auto& msg:messages){
     ret.emplace_back(msg.pack());
   }
-  return ret;
-  /*std::vector<uint8_t> buff{};
+  return ret;*/
+  std::vector<uint8_t> buff{};
   buff.reserve(max_mtu);
   for(const auto& msg:messages){
     auto data=msg.pack();
     if(buff.size()+data.size()<=max_mtu){
       buff.insert(buff.end(), data.begin(), data.end());
     }else{
-
+      if(!buff.empty()){
+        ret.push_back(buff);
+        buff.resize(0);
+      }
+      buff.insert(buff.end(), data.begin(), data.end());
     }
-  }*/
+  }
+  if(!buff.empty()){
+    ret.push_back(buff);
+  }
+  return ret;
 }
 
 

--- a/OpenHD/ohd_telemetry/src/mav_include.h
+++ b/OpenHD/ohd_telemetry/src/mav_include.h
@@ -36,8 +36,8 @@ struct MavlinkMessage {
   }
 };
 
-// For registering a callback that is called every time component X receives a new Mavlink Message
-typedef std::function<void(MavlinkMessage &mavlinkMessage)> MAV_MSG_CALLBACK;
+// For registering a callback that is called every time component X receives one or more mavlink messages
+typedef std::function<void(const std::vector<MavlinkMessage> messages)> MAV_MSG_CALLBACK;
 
 static int64_t get_time_microseconds(){
   const auto time=std::chrono::steady_clock::now().time_since_epoch();

--- a/OpenHD/ohd_telemetry/src/mavsdk_temporary/XMavlinkParamProvider.cpp
+++ b/OpenHD/ohd_telemetry/src/mavsdk_temporary/XMavlinkParamProvider.cpp
@@ -41,10 +41,11 @@ void XMavlinkParamProvider::set_ready() {
   _mavlink_parameter_receiver->ready_for_communication();
 }
 
-std::vector<MavlinkMessage> XMavlinkParamProvider::process_mavlink_message(
-    const MavlinkMessage& msg) {
+std::vector<MavlinkMessage> XMavlinkParamProvider:: process_mavlink_messages(std::vector<MavlinkMessage> messages){
   std::lock_guard<std::mutex> lock(_mutex);
-  _mavlink_message_handler->process_message(msg.m);
+  for(const auto& msg:messages){
+    _mavlink_message_handler->process_message(msg.m);
+  }
   for(int i=0;i<100;i++){
     _mavlink_parameter_receiver->do_work();
   }

--- a/OpenHD/ohd_telemetry/src/mavsdk_temporary/XMavlinkParamProvider.h
+++ b/OpenHD/ohd_telemetry/src/mavsdk_temporary/XMavlinkParamProvider.h
@@ -25,7 +25,7 @@ class XMavlinkParamProvider :public MavlinkComponent{
   void add_params(const std::vector<openhd::Setting>& settings);
   void set_ready();
   // override from component
-  std::vector<MavlinkMessage> process_mavlink_message(const MavlinkMessage &msg)override;
+  std::vector<MavlinkMessage> process_mavlink_messages(std::vector<MavlinkMessage> messages)override;
   // override from component
   std::vector<MavlinkMessage> generate_mavlink_messages() override;
  private:

--- a/OpenHD/ohd_telemetry/src/routing/MavlinkComponent.hpp
+++ b/OpenHD/ohd_telemetry/src/routing/MavlinkComponent.hpp
@@ -27,7 +27,7 @@ class MavlinkComponent{
    * can use this message or not.
    * @return a list of mavlink messages that were created as a response.Empty unless the given message needs a response.
    */
-  virtual std::vector<MavlinkMessage> process_mavlink_message(const MavlinkMessage& msg)=0;
+  virtual std::vector<MavlinkMessage> process_mavlink_messages(std::vector<MavlinkMessage> messages)=0;
   /**
    * The parent should call this method in regular intervals and send out the generated mavlink messages.
    * This is for fire and forget messages. For example, a component might return the heartbeat(s) here.


### PR DESCRIPTION
wifi / wifibroadcast doesn't perform well with many small packets. By not fragmenting mavlink telemetry messages in the air/ground data callbacks but rather keeping them together in chuncks we decrease the n of packets per second used for mavlink telemetry.
On a typical setup (with pixhawk connected via uart) this decreases the packets per second for telemetry downlink from ~100pps
to ~28pps. 