### PR TITLE
Fix bug where network manager unmanaged / managed was swapped around,

### DIFF
--- a/OpenHD/ohd_common/mavlink_settings/ISettingsComponent.hpp
+++ b/OpenHD/ohd_common/mavlink_settings/ISettingsComponent.hpp
@@ -74,6 +74,20 @@ static bool validate_yes_or_no(int value){
   return value==0 || value==1;
 }
 
+// Helper for creating read-only params- they can be usefully for debugging
+static Setting create_read_only_int(const std::string& id,int value){
+  auto cb=[](const std::string&,int){
+    return false;
+  };
+  return Setting{id, openhd::IntSetting{value, cb}};
+}
+static Setting create_read_only_string(const std::string& id,const std::string& value){
+  auto cb=[](const std::string&,const std::string&){
+    return false;
+  };
+  return Setting{id, openhd::StringSetting {value, cb}};
+}
+
 namespace testing {
 // For testing
 static std::vector<Setting> create_dummy_camera_settings() {

--- a/OpenHD/ohd_common/openhd-util-filesystem.hpp
+++ b/OpenHD/ohd_common/openhd-util-filesystem.hpp
@@ -2,6 +2,7 @@
 #define OPENHD_OPENHD_OHD_COMMON_OPENHD_UTIL_FILESYSTEM_H_
 
 #include <vector>
+#include <optional>
 
 #include <boost/filesystem.hpp>
 #include <fstream>
@@ -79,17 +80,24 @@ static void write_file(const std::string& path,const std::string& content){
   }
 }
 
-// Read a file as text. If the file doesn't exist, an empty string is returned
-// (NOTE: We could make this std::nullopt on error, but r.n that's not needed.
-static std::string read_file(const std::string& path){
+// Read a file as text and return its content as a string.
+// If the file doesn't exist, return std::nullopt
+static std::optional<std::string> opt_read_file(const std::string& filename){
   try{
-    std::ifstream f(path);
+    std::ifstream f(filename);
     std::string str((std::istreambuf_iterator<char>(f)),std::istreambuf_iterator<char>());
     return str;
   }catch (std::exception& e){
-    openhd::log::get_default()->warn("Cannot read file ["+path+"]");
-    return "";
+    openhd::log::get_default()->warn("Cannot read file [{}]",filename);
+    return std::nullopt;
   }
+}
+
+// Similar to above, but returns empty string if file doesn't exist
+static std::string read_file(const std::string& filename){
+  const auto content= opt_read_file(filename);
+  if(!content.has_value())return "";
+  return content.value();
 }
 
 static void remove_if_existing(const std::string& filename){

--- a/OpenHD/ohd_common/openhd-util-filesystem.hpp
+++ b/OpenHD/ohd_common/openhd-util-filesystem.hpp
@@ -68,6 +68,7 @@ static void safe_delete_directory(const char* directory){
   }
 }
 
+// Write a text file. If the file already exists, its content is overritten
 static void write_file(const std::string& path,const std::string& content){
   try{
     std::ofstream t(path);
@@ -77,6 +78,9 @@ static void write_file(const std::string& path,const std::string& content){
     openhd::log::get_default()->warn("Cannot write file ["+path+"]");
   }
 }
+
+// Read a file as text. If the file doesn't exist, an empty string is returned
+// (NOTE: We could make this std::nullopt on error, but r.n that's not needed.
 static std::string read_file(const std::string& path){
   try{
     std::ifstream f(path);

--- a/OpenHD/ohd_common/openhd-util-filesystem.hpp
+++ b/OpenHD/ohd_common/openhd-util-filesystem.hpp
@@ -68,7 +68,7 @@ static void safe_delete_directory(const char* directory){
   }
 }
 
-// Write a text file. If the file already exists, its content is overritten
+// Write a text file. If the file already exists, its content is overwritten
 static void write_file(const std::string& path,const std::string& content){
   try{
     std::ofstream t(path);

--- a/OpenHD/ohd_common/openhd-util.hpp
+++ b/OpenHD/ohd_common/openhd-util.hpp
@@ -266,6 +266,10 @@ static bool file_exists_and_delete(const char* filename){
   return ret;
 }
 
+template <class T>
+static void vec_append(std::vector<T>& dest, const std::vector<T>& src) {
+  dest.insert(dest.end(), src.begin(), src.end());
+}
 
 }
 

--- a/OpenHD/ohd_interface/inc/validate_settings_helper.h
+++ b/OpenHD/ohd_interface/inc/validate_settings_helper.h
@@ -13,17 +13,16 @@
 
 namespace openhd {
 
-static bool is_valid_frequency_2G(uint32_t frequency,
-                                  bool include_nonstandard_channels = false) {
-  const auto supported = openhd::get_channels_2G(include_nonstandard_channels);
+static bool is_valid_frequency_2G(uint32_t frequency) {
+  const auto supported = openhd::get_channels_2G();
   for (const auto& value : supported) {
     if (value.frequency == frequency) return true;
   }
   return false;
 }
-static bool is_valid_frequency_5G(uint32_t frequency,
-                                  bool include_nonstandard_channels = false) {
-  const auto supported = openhd::get_channels_5G(include_nonstandard_channels);
+
+static bool is_valid_frequency_5G(uint32_t frequency) {
+  const auto supported = openhd::get_channels_5G();
   for (const auto& value : supported) {
     if (value.frequency == frequency) return true;
   }

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -23,7 +23,7 @@
 #include "ohd_link.hpp"
 
 /**
- * This class takes a list of discovered wifi cards (and their settings) and
+ * This class takes a list of cards supporting monitor mode (only 1 card on air) and
  * is responsible for configuring the given cards and then setting up all the Wifi-broadcast streams needed for OpenHD.
  * In the end, we have a link that has some broadcast characteristics for video (video is always broadcast from air to ground)
  * but also a bidirectional link (without re-transmission(s)) for telemetry.

--- a/OpenHD/ohd_interface/inc/wb_link_helper.h
+++ b/OpenHD/ohd_interface/inc/wb_link_helper.h
@@ -25,7 +25,7 @@ bool cards_support_setting_channel_width(const std::vector<WiFiCard>& m_broadcas
 
 // returns true if the given card supports the given frequency, taking into account if the kernel was modifed or not
 bool cards_support_frequency(
-    int frequency,
+    uint32_t frequency,
     const std::vector<WiFiCard>& m_broadcast_cards,
     const OHDPlatform& platform,
     const std::shared_ptr<spdlog::logger>& m_console);

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -145,6 +145,10 @@ static bool wifi_card_supports_frequency(const OHDPlatform& platform,const WiFiC
   return false;
 }
 
+static std::vector<openhd::WifiChannel> get_openhd_channels_from_card(const WiFiCard& card){
+  return openhd::get_all_channels_from_safe_frequencies(card.supported_frequencies);
+}
+
 static std::string debug_cards(const std::vector<WiFiCard>& cards){
   std::stringstream ss;
   ss<<"size:"<<cards.size()<<"{";

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -129,7 +129,7 @@ static bool wifi_card_supports_40Mhz_channel_width(const WiFiCard& wifi_card){
 }
 
 
-static bool wifi_card_supports_frequency(const OHDPlatform& platform,const WiFiCard& wifi_card,const uint32_t frequency){
+static bool wifi_card_supports_frequency(const WiFiCard& wifi_card,const uint32_t frequency){
   const auto channel_opt=openhd::channel_from_frequency(frequency);
   if(!channel_opt.has_value()){
     openhd::log::get_default()->debug("OpenHD doesn't know frequency {}",frequency);

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -187,7 +187,7 @@ static constexpr auto WIFI_MANIFEST_FILENAME = "/tmp/wifi_manifest";
 static void write_wificards_manifest(const std::vector<WiFiCard> &cards) {
   auto manifest = wificards_to_json(cards);
   std::ofstream _t(WIFI_MANIFEST_FILENAME);
-  _t << manifest.dump(-1);
+  _t << manifest.dump(4);
   _t.close();
 }
 

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -105,8 +105,8 @@ struct WiFiCard {
   std::vector<uint32_t> supported_frequencies_5G{};
   [[nodiscard]] std::vector<uint32_t> get_supported_frequencies_2G_5G()const{
     std::vector<uint32_t> ret{};
-    openhd::vec_append(ret,supported_frequencies_2G);
-    openhd::vec_append(ret,supported_frequencies_5G);
+    OHDUtil::vec_append(ret,supported_frequencies_2G);
+    OHDUtil::vec_append(ret,supported_frequencies_5G);
     return ret;
   };
 };

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -93,15 +93,17 @@ struct WiFiCard {
   bool supports_monitor_mode=false;
   bool supports_injection = false;
   bool supports_hotspot = false;
-  bool supports_2GHz()const{
+  [[nodiscard]] bool supports_2GHz()const{
     return !supported_frequencies_2G.empty();
   };
-  bool supports_5GHz()const{
+  [[nodiscard]] bool supports_5GHz()const{
     return !supported_frequencies_5G.empty();
   };
+  // supported 2G frequencies
   std::vector<uint32_t> supported_frequencies_2G{};
+  // supported 5G frequencies
   std::vector<uint32_t> supported_frequencies_5G{};
-  std::vector<uint32_t> get_supported_frequencies_2G_5G()const{
+  [[nodiscard]] std::vector<uint32_t> get_supported_frequencies_2G_5G()const{
     std::vector<uint32_t> ret{};
     openhd::vec_append(ret,supported_frequencies_2G);
     openhd::vec_append(ret,supported_frequencies_5G);

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -149,6 +149,20 @@ static std::vector<openhd::WifiChannel> get_openhd_channels_from_card(const WiFi
   return openhd::get_all_channels_from_safe_frequencies(card.supported_frequencies);
 }
 
+static std::vector<openhd::WifiChannel> get_openhd_channels_from_card(const WiFiCard& card, bool include_2G,bool include_5G){
+  const auto tmp=openhd::get_all_channels_from_safe_frequencies(card.supported_frequencies);
+  std::vector<openhd::WifiChannel> ret{};
+  for(const auto& channel:tmp){
+    if(channel.space==openhd::Space::G2_4){
+      if(include_2G)ret.push_back(channel);
+    }else{
+      assert(channel.space==openhd::Space::G5_8);
+      if(include_5G)ret.push_back(channel);
+    }
+  }
+  return ret;
+}
+
 static std::string debug_cards(const std::vector<WiFiCard>& cards){
   std::stringstream ss;
   ss<<"size:"<<cards.size()<<"{";
@@ -173,7 +187,7 @@ static constexpr auto WIFI_MANIFEST_FILENAME = "/tmp/wifi_manifest";
 static void write_wificards_manifest(const std::vector<WiFiCard> &cards) {
   auto manifest = wificards_to_json(cards);
   std::ofstream _t(WIFI_MANIFEST_FILENAME);
-  _t << manifest.dump(4);
+  _t << manifest.dump(-1);
   _t.close();
 }
 

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -126,12 +126,6 @@ static bool wifi_card_supports_40Mhz_channel_width(const WiFiCard& wifi_card){
   return false;
 }
 
-static bool wifi_card_supports_extra_channels_2G(const WiFiCard& wi_fi_card){
-  if(wi_fi_card.type==WiFiCardType::Atheros9khtc || wi_fi_card.type==WiFiCardType::Atheros9k){
-    return true;
-  }
-  return false;
-}
 
 static bool wifi_card_supports_frequency(const OHDPlatform& platform,const WiFiCard& wifi_card,const uint32_t frequency){
   const auto channel_opt=openhd::channel_from_frequency(frequency);

--- a/OpenHD/ohd_interface/inc/wifi_card.hpp
+++ b/OpenHD/ohd_interface/inc/wifi_card.hpp
@@ -101,11 +101,11 @@ struct WiFiCard {
   bool supports_5GHz()const{
     return xx_supports_5ghz;
   };
-  std::vector<openhd::WifiChannel> supported_channels{};
+  std::vector<uint32_t> supported_frequencies{};
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WiFiCard,device_name,mac,phy80211_index,driver_name,type,
                                    supports_injection,supports_monitor_mode,supports_hotspot,
-                                   xx_supports_2ghz,xx_supports_5ghz)
+                                   xx_supports_2ghz,xx_supports_5ghz,supported_frequencies)
 
 // Only Atheros AR9271 doesn't support setting the mcs index
 static bool wifi_card_supports_variable_mcs(const WiFiCard& wifi_card){
@@ -136,33 +136,13 @@ static bool wifi_card_supports_frequency(const OHDPlatform& platform,const WiFiC
     return false;
   }
   const auto& channel=channel_opt.value();
-  // check if we are running on a modified kernel, in which case we can do those extra frequencies that
-  // are illegal in most countries (otherwise they are disabled)
-  // NOTE: When running on RPI or Jetson we assume we are running on an OpenHD image which has the modified kernel
-  const bool kernel_supports_extra_channels=platform.platform_type==PlatformType::RaspberryPi ||
-                                              platform.platform_type==PlatformType::Jetson;
-  // check if the card generically supports the 2G or 5G space
-  if(channel.space==openhd::Space::G2_4){
-    if(!wifi_card.supports_2GHz()){
-      return false;
-    }
-    if(!channel.is_standard){
-      // special and only AR9271: channels below and above standard wifi
-      const bool include_extra_channels_2G=kernel_supports_extra_channels && wifi_card_supports_extra_channels_2G(wifi_card);
-      if(!include_extra_channels_2G){
-        return false;
-      }
-    }
-  }else{
-    assert(channel.space==openhd::Space::G5_8);
-    if(!wifi_card.supports_5GHz()){
-      return false;
-    }
-    if(!channel.is_standard){
-      return false;
+  for(const auto& freq:wifi_card.supported_frequencies){
+    if(channel.frequency==freq){
+      return true;
     }
   }
-  return true;
+  openhd::log::get_default()->debug("Card {} does not support frequency {}",wifi_card.device_name,frequency);
+  return false;
 }
 
 static std::string debug_cards(const std::vector<WiFiCard>& cards){

--- a/OpenHD/ohd_interface/inc/wifi_channel.h
+++ b/OpenHD/ohd_interface/inc/wifi_channel.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <cstdint>
 
+// NOTE: DO NOT USE CHANNEL NUMBERS ANYWHERE IN CODE - USE FREQUENCIES IN MHZ, SINCE THEY ARE UNIQUE
 namespace openhd {
 
 enum class Space { G2_4, G5_8 };
@@ -34,10 +35,10 @@ struct WifiChannel {
   }
 };
 
-// These are not valid 2.4G wifi channel(s) but some cards aparently can do them, too From https://github.com/OpenHD/linux/blob/092115ae6a980feaa09722690891d99da3afb55c/drivers/net/wireless/ath/ath9k/common-init.c#L39
-// NOTE: In OpenHD we never use the channel number (since it is prone to errors, even in the linux kernel) but rather use the frequency in mhz, which is well-defined. Also read https://yo3iiu.ro/blog/?p=1301
-static std::vector<WifiChannel> get_channels_below_standard_2G_wifi() {
+static std::vector<WifiChannel> get_channels_2G() {
   return std::vector<WifiChannel>{
+      // These are not valid 2.4G wifi channel(s) but some cards aparently can do them, too From https://github.com/OpenHD/linux/blob/092115ae6a980feaa09722690891d99da3afb55c/drivers/net/wireless/ath/ath9k/common-init.c#L39
+      // NOTE: In OpenHD we never use the channel number (since it is prone to errors, even in the linux kernel) but rather use the frequency in mhz, which is well-defined. Also read https://yo3iiu.ro/blog/?p=1301
       WifiChannel{2312, -1, Space::G2_4, false},
       WifiChannel{2317, -1, Space::G2_4, false},
       WifiChannel{2322, -1, Space::G2_4, false},
@@ -58,12 +59,7 @@ static std::vector<WifiChannel> get_channels_below_standard_2G_wifi() {
       WifiChannel{2397, -1, Space::G2_4, false},
       WifiChannel{2402, -1, Space::G2_4, false},
       WifiChannel{2407, -1, Space::G2_4, false},
-  };
-}
-
-// https://en.wikipedia.org/wiki/List_of_WLAN_channels#2.4_GHz_(802.11b/g/n/ax)
-static std::vector<WifiChannel> get_channels_2G_standard() {
-  return std::vector<WifiChannel>{
+      // Now to the standard Wi-Fi channel(s) https://en.wikipedia.org/wiki/List_of_WLAN_channels#2.4_GHz_(802.11b/g/n/ax)
       WifiChannel{2412, 1, Space::G2_4, true},
       WifiChannel{2417, 2, Space::G2_4, true},
       WifiChannel{2422, 3, Space::G2_4, true},
@@ -75,20 +71,13 @@ static std::vector<WifiChannel> get_channels_2G_standard() {
       WifiChannel{2452, 9, Space::G2_4, true},
       WifiChannel{2457, 10, Space::G2_4, true},
       WifiChannel{2462, 11, Space::G2_4, true},
-      // Temporary disabled - they won't work unil we patch this shit in the kernel
       WifiChannel{2467, 12, Space::G2_4, true},
       WifiChannel{2472, 13, Space::G2_4, true},
       // until here it is consistent (5Mhz increments)
       // this one is neither allowed in EU nor USA
       // (only in Japan under 11b)
       WifiChannel{2484, 14, Space::G2_4, true},
-  };
-};
-
-// These are not valid 2.4G wifi channel(s) but some cards apparently can do them, too From https://github.com/OpenHD/linux/blob/092115ae6a980feaa09722690891d99da3afb55c/drivers/net/wireless/ath/ath9k/common-init.c#L39
-// NOTE: channel and frequency seem to be off by one
-static std::vector<WifiChannel> get_channels_above_standard_2G_wifi() {
-  return std::vector<WifiChannel>{
+      // and these are all not valid wlan channels, but the AR9271 can do them anyways
       WifiChannel{2487, -1, Space::G2_4, false},
       WifiChannel{2489, -1, Space::G2_4, false},
       WifiChannel{2492, -1, Space::G2_4, false},
@@ -109,41 +98,10 @@ static std::vector<WifiChannel> get_channels_above_standard_2G_wifi() {
   };
 }
 
-template <class T>
-static void vec_append(std::vector<T>& dest, const std::vector<T>& src) {
-  dest.insert(dest.end(), src.begin(), src.end());
-}
 
-static std::vector<WifiChannel> get_channels_2G(
-    const bool include_nonstandard_channels) {
-  // keep the order of channels
-  std::vector<WifiChannel> ret{};
-  if (include_nonstandard_channels) {
-    vec_append(ret, get_channels_below_standard_2G_wifi());
-  }
-  vec_append(ret, get_channels_2G_standard());
-  if (include_nonstandard_channels) {
-    vec_append(ret, get_channels_above_standard_2G_wifi());
-  }
-  return ret;
-}
-
-// These are not valid 2.4G wifi channel(s) but some cards aparently can do them, too From https://github.com/OpenHD/linux/blob/092115ae6a980feaa09722690891d99da3afb55c/drivers/net/wireless/ath/ath9k/common-init.c#L39
-// NOTE: channel and frequency seem to be off by one
-static std::vector<WifiChannel> get_channels_5G_below() {
+static std::vector<WifiChannel> get_channels_5G(){
   return std::vector<WifiChannel>{
-      WifiChannel{4920, 54, Space::G5_8, false},
-      WifiChannel{4940, 55, Space::G5_8, false},
-      WifiChannel{4960, 56, Space::G5_8, false},
-      WifiChannel{4980, 57, Space::G5_8, false},
-  };
-}
-
-// https://en.wikipedia.org/wiki/List_of_WLAN_channels#5_GHz_(802.11a/h/j/n/ac/ax)
-// These are what iw list lists for rtl8812au
-static std::vector<WifiChannel> get_channels_5G_standard() {
-  return std::vector<WifiChannel>{
-      // TODO {5170,34},
+      // https://en.wikipedia.org/wiki/List_of_WLAN_channels#5_GHz_(802.11a/h/j/n/ac/ax)
       WifiChannel{5180, 36, Space::G5_8, true},
       WifiChannel{5200, 40, Space::G5_8, true},
       WifiChannel{5220, 44, Space::G5_8, true},
@@ -152,6 +110,16 @@ static std::vector<WifiChannel> get_channels_5G_standard() {
       WifiChannel{5280, 56, Space::G5_8, true},
       WifiChannel{5300, 60, Space::G5_8, true},
       WifiChannel{5320, 64, Space::G5_8, true},
+      // this part seems to be disabled quite often -beign
+      WifiChannel{5340, 68, Space::G5_8, true},
+      WifiChannel{5360, 72, Space::G5_8, true},
+      WifiChannel{5380, 76, Space::G5_8, true},
+      WifiChannel{5400, 80, Space::G5_8, true},
+      WifiChannel{5420, 84, Space::G5_8, true},
+      WifiChannel{5440, 88, Space::G5_8, true},
+      WifiChannel{5460, 92, Space::G5_8, true},
+      WifiChannel{5480, 96, Space::G5_8, true},
+      // part often disabled end
       WifiChannel{5500, 100, Space::G5_8, true},
       WifiChannel{5520, 104, Space::G5_8, true},
       WifiChannel{5540, 108, Space::G5_8, true},
@@ -169,31 +137,23 @@ static std::vector<WifiChannel> get_channels_5G_standard() {
       WifiChannel{5785, 157, Space::G5_8, true},
       WifiChannel{5805, 161, Space::G5_8, true},
       WifiChannel{5825, 165, Space::G5_8, true},
+      // starting from here, often disabled territory begins again
       WifiChannel{5845, 169, Space::G5_8, true},
       WifiChannel{5865, 173, Space::G5_8, true},
       WifiChannel{5885, 177, Space::G5_8, true},
+      WifiChannel{5905, 181, Space::G5_8, true},
   };
 };
 
-static std::vector<WifiChannel> get_channels_5G(
-    const bool include_nonstandard_channels) {
-  std::vector<WifiChannel> ret{};
-  if (include_nonstandard_channels) {
-    vec_append(ret, get_channels_5G_below());
-  }
-  vec_append(ret, get_channels_5G_standard());
-  return ret;
-}
 
 static std::vector<WifiChannel> get_all_channels_2G_5G() {
   std::vector<WifiChannel> channels{};
-  vec_append(channels, get_channels_2G(true));
-  vec_append(channels, get_channels_5G(true));
+  OHDUtil::vec_append(channels, get_channels_2G());
+  OHDUtil::vec_append(channels, get_channels_5G());
   return channels;
 }
 
-static std::vector<uint32_t> get_all_channel_frequencies(
-    const std::vector<openhd::WifiChannel>& channels) {
+static std::vector<uint32_t> get_all_channel_frequencies(const std::vector<openhd::WifiChannel>& channels) {
   std::vector<uint32_t> frequencies;
   for (const auto& channel : channels) {
     frequencies.push_back(channel.frequency);

--- a/OpenHD/ohd_interface/inc/wifi_channel.h
+++ b/OpenHD/ohd_interface/inc/wifi_channel.h
@@ -213,6 +213,7 @@ static std::optional<openhd::WifiChannel> channel_from_frequency(uint32_t freque
   return std::nullopt;
 }
 
+// NOTE: Only call this on a list of frequencies that are valid
 static std::vector<openhd::WifiChannel> get_all_channels_from_safe_frequencies(
     const std::vector<uint32_t>& frequencies) {
   std::vector<openhd::WifiChannel> ret;

--- a/OpenHD/ohd_interface/inc/wifi_command_helper.h
+++ b/OpenHD/ohd_interface/inc/wifi_command_helper.h
@@ -50,7 +50,7 @@ bool iw_set_tx_power(const std::string& device,uint32_t tx_power_mBm);
 // blacklist the card from network manager (so we can safely do our own thing, aka wifibroadcast) with it
 // NOTE: this is not permament between restarts - but that is exactly what we want,
 // since on each restart we might do different things with the wifi card(s)
-bool nmcli_set_device_unmanaged(const std::string& device);
+bool nmcli_set_device_managed_status(const std::string& device,bool managed);
 
 // R.n I do not know of a better solution than this one
 // runs iwlist <device> frequencies

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -830,15 +830,7 @@ void WBLink::forward_video_data(int stream_index,const uint8_t * data,int data_l
 
 WBLink::ScanResult WBLink::scan_channels(const ScanChannelsParams& params){
   const WiFiCard& card=m_broadcast_cards.at(0);
-  std::vector<openhd::WifiChannel> channels_to_scan;
-  if(params.check_2g_channels_if_card_support && card.supports_2GHz()){
-    auto tmp=openhd::get_channels_2G(true);
-    channels_to_scan.insert(channels_to_scan.end(),tmp.begin(),tmp.end());
-  }
-  if(params.check_5g_channels_if_card_supports && card.supports_5GHz()){
-    auto tmp=openhd::get_channels_5G(false);
-    channels_to_scan.insert(channels_to_scan.end(),tmp.begin(),tmp.end());
-  }
+  const auto channels_to_scan=get_openhd_channels_from_card(card,params.check_2g_channels_if_card_support,params.check_5g_channels_if_card_supports);
   if(channels_to_scan.empty()){
     m_console->warn("No channels to scan, return early");
     return {};

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -67,6 +67,10 @@ WBLink::~WBLink() {
     m_work_thread_run =false;
     m_work_thread->join();
   }
+  // give the monitor mode cards back to network manager
+  for(const auto& card: m_broadcast_cards){
+    wifi::commandhelper::nmcli_set_device_managed_status(card.device_name, true);
+  }
 }
 
 void WBLink::takeover_cards_monitor_mode() {
@@ -78,7 +82,7 @@ void WBLink::takeover_cards_monitor_mode() {
   // wifibroadcast and therefore making other networking increadibly hard.
   // Tell network manager to ignore the cards we want to do wifibroadcast on
   for(const auto& card: m_broadcast_cards){
-    wifi::commandhelper::nmcli_set_device_unmanaged(card.device_name);
+    wifi::commandhelper::nmcli_set_device_managed_status(card.device_name, false);
   }
   wifi::commandhelper::rfkill_unblock_all();
   // TODO: sometimes this happens:

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -830,7 +830,15 @@ void WBLink::forward_video_data(int stream_index,const uint8_t * data,int data_l
 
 WBLink::ScanResult WBLink::scan_channels(const ScanChannelsParams& params){
   const WiFiCard& card=m_broadcast_cards.at(0);
-  const auto channels_to_scan=get_openhd_channels_from_card(card,params.check_2g_channels_if_card_support,params.check_5g_channels_if_card_supports);
+  std::vector<openhd::WifiChannel> channels_to_scan;
+  if(params.check_2g_channels_if_card_support && card.supports_2GHz()){
+    auto tmp=openhd::get_channels_2G(true);
+    channels_to_scan.insert(channels_to_scan.end(),tmp.begin(),tmp.end());
+  }
+  if(params.check_5g_channels_if_card_supports && card.supports_5GHz()){
+    auto tmp=openhd::get_channels_5G(false);
+    channels_to_scan.insert(channels_to_scan.end(),tmp.begin(),tmp.end());
+  }
   if(channels_to_scan.empty()){
     m_console->warn("No channels to scan, return early");
     return {};

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -681,7 +681,7 @@ void WBLink::perform_rate_adjustment() {
     // m_console->debug("mcs index:{}",settings.wb_mcs_index);
     //  we assume X% of the theoretical link bandwidth is available for the primary video stream 2.4G are almost always completely full of noise, which is why we go with a more conservative perc. value for them. NOTE: It is stupid to reason about the RF environment of the user, but feedback from the beta channel shows that this is kinda needed.
     const bool is_2g_channel =
-        openhd::is_valid_frequency_2G(settings.wb_frequency, true);
+        openhd::is_valid_frequency_2G(settings.wb_frequency);
     const uint32_t kFactorAvailablePerc = is_2g_channel ? 70 : 80;
     const uint32_t max_video_allocated_kbits =
         max_rate_possible_kbits * kFactorAvailablePerc / 100;
@@ -832,11 +832,11 @@ WBLink::ScanResult WBLink::scan_channels(const ScanChannelsParams& params){
   const WiFiCard& card=m_broadcast_cards.at(0);
   std::vector<openhd::WifiChannel> channels_to_scan;
   if(params.check_2g_channels_if_card_support && card.supports_2GHz()){
-    auto tmp=openhd::get_channels_2G(true);
+    auto tmp=openhd::get_channels_2G();
     channels_to_scan.insert(channels_to_scan.end(),tmp.begin(),tmp.end());
   }
   if(params.check_5g_channels_if_card_supports && card.supports_5GHz()){
-    auto tmp=openhd::get_channels_5G(false);
+    auto tmp=openhd::get_channels_5G();
     channels_to_scan.insert(channels_to_scan.end(),tmp.begin(),tmp.end());
   }
   if(channels_to_scan.empty()){

--- a/OpenHD/ohd_interface/src/wb_link_helper.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_helper.cpp
@@ -34,7 +34,7 @@ bool openhd::wb::cards_support_setting_mcs_index(
 
 
 bool openhd::wb::cards_support_frequency(
-    int frequency,
+    uint32_t frequency,
     const std::vector<WiFiCard>& m_broadcast_cards,
     const OHDPlatform& platform,
     const std::shared_ptr<spdlog::logger>& m_console=nullptr) {

--- a/OpenHD/ohd_interface/src/wb_link_helper.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_helper.cpp
@@ -41,7 +41,7 @@ bool openhd::wb::cards_support_frequency(
 
   // and check if all cards support the frequency
   for(const auto& card:m_broadcast_cards){
-    if(!wifi_card_supports_frequency(platform,card,frequency)){
+    if(!wifi_card_supports_frequency(card,frequency)){
       if(m_console){
         m_console->debug("Card {} doesn't support frequency {}",card.device_name,frequency);
       }
@@ -61,9 +61,8 @@ void openhd::wb::fixup_unsupported_settings(
   // For now, we only check whatever the first card can do and assume the rest can do the same
   const WiFiCard first_card= m_broadcast_cards.at(0);
 
-  const auto channel_opt= channel_from_frequency(settings.get_settings().wb_frequency);
-  if(!channel_opt){
-    m_console->warn("Not a valid frequency {}",settings.get_settings().wb_frequency);
+  if(!wifi_card_supports_frequency(first_card,settings.get_settings().wb_frequency)){
+    m_console->warn("Card {} doesn't support {}Mhz, applying defaults",first_card.device_name,settings.get_settings().wb_frequency);
     if(first_card.supports_5GHz()){
       settings.unsafe_get_settings().wb_frequency=DEFAULT_5GHZ_FREQUENCY;
       settings.persist();
@@ -72,25 +71,8 @@ void openhd::wb::fixup_unsupported_settings(
       settings.persist();
     }
   }
-  // guaranteed to succeed,since we fixed a not know frequency already before
-  const auto channel_opt2= channel_from_frequency(settings.get_settings().wb_frequency);
-  assert(channel_opt2.has_value());
-  const auto channel=channel_opt2.value();
-  if(channel.space==Space::G2_4){
-    if(!first_card.supports_2GHz()){
-      m_console->warn("Freq {} but card doesn't support 2.4G",channel.to_string());
-      settings.unsafe_get_settings().wb_frequency=DEFAULT_5GHZ_FREQUENCY;
-      settings.persist();
-    }
-  }else{
-    assert(channel.space==Space::G5_8);
-    if(!first_card.supports_5GHz()){
-      m_console->warn("Freq {} but card doesn't support 5G",channel.to_string());
-      settings.unsafe_get_settings().wb_frequency=DEFAULT_2GHZ_FREQUENCY;
-      settings.persist();
-    }
-  }
   if(!cards_support_setting_mcs_index(m_broadcast_cards)){
+    m_console->warn("Card {} doesn't support setting MCS index, applying defaults",first_card.device_name);
     // cards that do not support changing the mcs index are always fixed to mcs3 on openhd drivers
     settings.unsafe_get_settings().wb_mcs_index=3;
     settings.persist();

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -41,6 +41,13 @@ static std::vector<openhd::WifiChannel> supported_channels(const std::string& de
   auto supported_channels=openhd::get_all_channels_from_safe_frequencies(supported_frequencies);
   return supported_channels;
 }
+static std::vector<uint32_t> supported_frequencies(const std::string& device){
+  const auto channels_to_try=openhd::get_all_channels_2G_5G();
+  const auto tmp=openhd::get_all_channel_frequencies(channels_to_try);
+  auto supported_frequencies=wifi::commandhelper::
+      iw_get_supported_frequencies(device,openhd::get_all_channel_frequencies(channels_to_try));
+  return supported_frequencies;
+}
 
 bool DWifiCards::is_known_for_injection(const WiFiCardType& type) {
   bool supports=false;
@@ -159,7 +166,7 @@ std::optional<WiFiCard> DWifiCards::process_card(const std::string &interface_na
   card.xx_supports_2ghz=supported_freq.supports_any_2G;
   card.xx_supports_5ghz=supported_freq.supports_any_5G;
   // but we now also have a method to figure out all the supported channels
-  card.supported_channels=supported_channels(card.device_name);
+  card.supported_frequencies=supported_frequencies(card.device_name);
 
   // Note that this does not necessarily mean this info is right/complete
   // a card might report a specific channel but then since monitor mode is so hack not support the channel in monitor mode

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -34,7 +34,7 @@ static WiFiCardType driver_to_wifi_card_type(const std::string &driver_name) {
 }
 
 static std::vector<uint32_t> supported_frequencies(const std::string& device,bool check_2g){
-  auto channels_to_try=check_2g ? openhd::get_channels_2G(true) : openhd::get_channels_5G(true);
+  auto channels_to_try=check_2g ? openhd::get_channels_2G() : openhd::get_channels_5G();
   const auto tmp=openhd::get_all_channel_frequencies(channels_to_try);
   auto supported_frequencies=wifi::commandhelper::
       iw_get_supported_frequencies(device,openhd::get_all_channel_frequencies(channels_to_try));

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -33,16 +33,8 @@ static WiFiCardType driver_to_wifi_card_type(const std::string &driver_name) {
   return WiFiCardType::Unknown;
 }
 
-static std::vector<openhd::WifiChannel> supported_channels(const std::string& device){
-  const auto channels_to_try=openhd::get_all_channels_2G_5G();
-  const auto tmp=openhd::get_all_channel_frequencies(channels_to_try);
-  auto supported_frequencies=wifi::commandhelper::
-      iw_get_supported_frequencies(device,openhd::get_all_channel_frequencies(channels_to_try));
-  auto supported_channels=openhd::get_all_channels_from_safe_frequencies(supported_frequencies);
-  return supported_channels;
-}
-static std::vector<uint32_t> supported_frequencies(const std::string& device){
-  const auto channels_to_try=openhd::get_all_channels_2G_5G();
+static std::vector<uint32_t> supported_frequencies(const std::string& device,bool check_2g){
+  auto channels_to_try=check_2g ? openhd::get_channels_2G(true) : openhd::get_channels_5G(true);
   const auto tmp=openhd::get_all_channel_frequencies(channels_to_try);
   auto supported_frequencies=wifi::commandhelper::
       iw_get_supported_frequencies(device,openhd::get_all_channel_frequencies(channels_to_try));
@@ -162,11 +154,12 @@ std::optional<WiFiCard> DWifiCards::process_card(const std::string &interface_na
   WiFiCard card=card_opt.value();
 
   // This reported value is right in most cases
-  const auto supported_freq= wifi::commandhelper::iw_get_supported_frequency_bands(card.device_name);
+  /*const auto supported_freq= wifi::commandhelper::iw_get_supported_frequency_bands(card.device_name);
   card.xx_supports_2ghz=supported_freq.supports_any_2G;
-  card.xx_supports_5ghz=supported_freq.supports_any_5G;
+  card.xx_supports_5ghz=supported_freq.supports_any_5G;*/
   // but we now also have a method to figure out all the supported channels
-  card.supported_frequencies=supported_frequencies(card.device_name);
+  card.supported_frequencies_2G=supported_frequencies(card.device_name, true);
+  card.supported_frequencies_5G=supported_frequencies(card.device_name, false);
 
   // Note that this does not necessarily mean this info is right/complete
   // a card might report a specific channel but then since monitor mode is so hack not support the channel in monitor mode

--- a/OpenHD/ohd_interface/src/wifi_command_helper.cpp
+++ b/OpenHD/ohd_interface/src/wifi_command_helper.cpp
@@ -32,17 +32,17 @@ bool wifi::commandhelper::iw_enable_monitor_mode(const std::string &device) {
 }
 
 static std::string channel_width_as_iw_string(uint32_t channel_width){
-  std::string ret="HT20";
   if(channel_width==5){
-    ret = "5MHz";
-  }else if(channel_width==10){
+    return "5MHz";
+  }else if(channel_width==10) {
     return "10Mhz";
+  }else if(channel_width==20){
+    return "HT20";
   }else if(channel_width==40){
-    ret="HT40+";
-  }else{
-    get_logger()->info("Invalid channel width {}, assuming HT20",channel_width);
+    return "HT40+";
   }
-  return ret;
+  get_logger()->info("Invalid channel width {}, assuming HT20",channel_width);
+  return "HT20";
 }
 
 bool wifi::commandhelper::iw_set_frequency_and_channel_width(const std::string &device, uint32_t freq_mhz,uint32_t channel_width) {

--- a/OpenHD/ohd_interface/src/wifi_command_helper.cpp
+++ b/OpenHD/ohd_interface/src/wifi_command_helper.cpp
@@ -72,9 +72,9 @@ bool wifi::commandhelper::nmcli_set_device_managed_status(const std::string &dev
   get_logger()->info("nmcli_set_device_managed_status {} managed:{}",device,managed);
   std::vector<std::string> arguments{"device","set",device,"managed"};
   if(managed){
-    arguments.emplace_back("no");
-  }else{
     arguments.emplace_back("yes");
+  }else{
+    arguments.emplace_back("no");
   }
   bool success = OHDUtil::run_command("nmcli",arguments);
   return success;

--- a/OpenHD/ohd_interface/src/wifi_command_helper.cpp
+++ b/OpenHD/ohd_interface/src/wifi_command_helper.cpp
@@ -68,11 +68,18 @@ bool wifi::commandhelper::iw_set_tx_power(const std::string &device,uint32_t tx_
   return true;
 }
 
-bool wifi::commandhelper::nmcli_set_device_unmanaged(const std::string &device) {
-  get_logger()->info("nmcli_set_device_unmanaged {}",device);
-  bool success = OHDUtil::run_command("nmcli",{"device","set",device,"managed","no"});
+bool wifi::commandhelper::nmcli_set_device_managed_status(const std::string &device,bool managed){
+  get_logger()->info("nmcli_set_device_managed_status {} managed:{}",device,managed);
+  std::vector<std::string> arguments{"device","set",device,"managed"};
+  if(managed){
+    arguments.emplace_back("no");
+  }else{
+    arguments.emplace_back("yes");
+  }
+  bool success = OHDUtil::run_command("nmcli",arguments);
   return success;
 }
+
 
 static std::string float_without_trailing_zeroes(const float value){
   std::stringstream ss;

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -77,7 +77,7 @@ void AirTelemetry::on_messages_ground_unit(const std::vector<MavlinkMessage>& me
   std::lock_guard<std::mutex> guard(components_lock);
   for(auto& component: components){
     std::vector<MavlinkMessage> responses{};
-    MavlinkComponent::vec_append(responses,component->process_mavlink_messages(messages));
+    OHDUtil::vec_append(responses,component->process_mavlink_messages(messages));
     send_messages_ground_unit(responses);
   }
 }

--- a/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
@@ -13,20 +13,20 @@ OHDTelemetry::OHDTelemetry(OHDPlatform platform1,
 						   bool enableExtendedLogging) :
 	platform(platform1),profile(std::move(profile1)),m_enableExtendedLogging(enableExtendedLogging) {
   if (this->profile.is_air) {
-	airTelemetry = std::make_unique<AirTelemetry>(platform,opt_action_handler);
-	assert(airTelemetry);
-	loopThread = std::make_unique<std::thread>([this] {
-	  assert(airTelemetry);
-          airTelemetry->loop_infinite(terminate, this->m_enableExtendedLogging);
-	});
+    airTelemetry = std::make_unique<AirTelemetry>(platform,opt_action_handler);
+    assert(airTelemetry);
+    loopThread = std::make_unique<std::thread>([this] {
+      assert(airTelemetry);
+      airTelemetry->loop_infinite(terminate, this->m_enableExtendedLogging);
+    });
   } else {
-	groundTelemetry = std::make_unique<GroundTelemetry>(platform,opt_action_handler);
-	assert(groundTelemetry);
-	loopThread = std::make_unique<std::thread>([this] {
-	  assert(groundTelemetry);
-          groundTelemetry->loop_infinite(terminate,
-                                         this->m_enableExtendedLogging);
-	});
+    groundTelemetry = std::make_unique<GroundTelemetry>(platform,opt_action_handler);
+    assert(groundTelemetry);
+    loopThread = std::make_unique<std::thread>([this] {
+      assert(groundTelemetry);
+      groundTelemetry->loop_infinite(terminate,
+                                     this->m_enableExtendedLogging);
+    });
   }
 }
 
@@ -37,24 +37,24 @@ OHDTelemetry::~OHDTelemetry() {
 
 std::string OHDTelemetry::createDebug() const {
   if(profile.is_air){
-	return airTelemetry->create_debug();
+    return airTelemetry->create_debug();
   }else{
-	return groundTelemetry->create_debug();
+    return groundTelemetry->create_debug();
   }
 }
 
 void OHDTelemetry::add_settings_generic(const std::vector<openhd::Setting> &settings) const {
   if(profile.is_air){
-	airTelemetry->add_settings_generic(settings);
+    airTelemetry->add_settings_generic(settings);
   }else{
-	groundTelemetry->add_settings_generic(settings);
+    groundTelemetry->add_settings_generic(settings);
   }
 }
 void OHDTelemetry::settings_generic_ready() const {
   if(profile.is_air){
-	airTelemetry->settings_generic_ready();
+    airTelemetry->settings_generic_ready();
   }else{
-	groundTelemetry->settings_generic_ready();
+    groundTelemetry->settings_generic_ready();
   }
 }
 void OHDTelemetry::add_settings_camera_component(

--- a/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
+++ b/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
@@ -47,14 +47,14 @@ std::vector<MavlinkMessage> OHDMainComponent::generate_mavlink_messages() {
   //m_console->debug("InternalTelemetry::generate_mavlink_messages()");
   std::vector<MavlinkMessage> ret;
   ret.push_back(MavlinkComponent::create_heartbeat());
-  MavlinkComponent::vec_append(ret,m_onboard_computer_status_provider->get_current_status_as_mavlink_message(
+  OHDUtil::vec_append(ret,m_onboard_computer_status_provider->get_current_status_as_mavlink_message(
           m_sys_id, m_comp_id));
-  MavlinkComponent::vec_append(ret, generate_mav_wb_stats());
+  OHDUtil::vec_append(ret, generate_mav_wb_stats());
   //ret.push_back(generateOpenHDVersion());
   //ret.push_back(MExampleMessage::position(mSysId,mCompId));
   //_status_text_accumulator.manually_add_message(RUNS_ON_AIR ? "HelloAir" : "HelloGround");
   const auto logs = generateLogMessages();
-  MavlinkComponent::vec_append(ret,logs);
+  OHDUtil::vec_append(ret,logs);
   return ret;
 }
 

--- a/OpenHD/ohd_telemetry/src/routing/MavlinkComponent.hpp
+++ b/OpenHD/ohd_telemetry/src/routing/MavlinkComponent.hpp
@@ -80,11 +80,6 @@ class MavlinkComponent{
                                MAV_STATE_ACTIVE);
     return heartbeat;
   }
- public:
-  template <class T>
-  static void vec_append(std::vector<T>& dest,const std::vector<T>& src){
-    dest.insert(dest.end(), src.begin(), src.end());
-  }
 };
 
 #endif  // OPENHD_OPENHD_OHD_TELEMETRY_SRC_ROUTING_MAVLINKCOMPONENT_H_

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -95,6 +95,9 @@ struct Camera {
   bool supports_iso()const{
     return type==CameraType::RPI_CSI_MMAL;
   }
+  bool supports_rpi_rpicamsrc_metering_mode()const{
+    return type==CameraType::RPI_CSI_MMAL;
+  }
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Camera,type,name,vendor,sensor_name,vid,pid,bus,index,endpoints)
 

--- a/OpenHD/ohd_video/inc/camera_enums.hpp
+++ b/OpenHD/ohd_video/inc/camera_enums.hpp
@@ -74,8 +74,6 @@ static std::string camera_type_to_string(const CameraType &camera_type) {
       return "DUMMY_SW";
     case CameraType::RPI_CSI_MMAL:
       return "RPI_CSI_MMAL";
-    //case CameraType::RPI_VEYE_CSI_MMAL:
-    //  return "RPI_VEYE_CSI_MMAL";
     case CameraType::RPI_VEYE_CSI_V4l2:
       return "RPI_VEYE_CSI_V4l2";
     case CameraType::JETSON_CSI:

--- a/OpenHD/ohd_video/inc/camera_holder.hpp
+++ b/OpenHD/ohd_video/inc/camera_holder.hpp
@@ -145,6 +145,12 @@ class CameraHolder:
       };
       ret.push_back(openhd::Setting{"V_ISO",openhd::IntSetting{get_settings().rpi_rpicamsrc_iso,c_iso}});
     }
+    if(m_camera.supports_rpi_rpicamsrc_metering_mode()){
+      auto cb=[this](std::string,int value) {
+        return set_rpi_rpicamsrc_metering_mode(value);
+      };
+      ret.push_back(openhd::Setting{"V_METERING_MODE",openhd::IntSetting{get_settings().rpi_rpicamsrc_metering_mode,cb}});
+    }
     return ret;
   }
   bool set_enable_streaming(int enable){
@@ -258,6 +264,12 @@ class CameraHolder:
   bool set_rpi_rpicamsrc_iso(int value){
     if(!openhd::validate_rpi_rpicamsrc_iso(value))return false;
     unsafe_get_settings().rpi_rpicamsrc_iso=value;
+    persist();
+    return true;
+  }
+  bool set_rpi_rpicamsrc_metering_mode(int value){
+    if(!openhd::validate_rpi_rpicamsrc_metering_mode(value)) return false;
+    unsafe_get_settings().rpi_rpicamsrc_metering_mode=value;
     persist();
     return true;
   }

--- a/OpenHD/ohd_video/inc/camera_settings.hpp
+++ b/OpenHD/ohd_video/inc/camera_settings.hpp
@@ -94,6 +94,9 @@ struct CameraSettings {
   // ISO value to use (0 = Auto)
   // Integer. Range: 0 - 3200 Default: 0
   int rpi_rpicamsrc_iso=0;
+  // Camera exposure metering mode to use
+  // Default 0 (average)
+  int rpi_rpicamsrc_metering_mode=0;
 
   // only used on RK3588, dirty, r.n not persistent
   VideoFormat recordingFormat{VideoCodec::H264, 0, 0, 0}; // 0 means copy
@@ -105,7 +108,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CameraSettings,enable_streaming,
                                    streamed_video_format, h26x_bitrate_kbits,
                                    h26x_keyframe_interval, h26x_intra_refresh_type,mjpeg_quality_percent, ip_cam_url,air_recording,
                                    camera_rotation_degree,horizontal_flip,vertical_flip,
-                                   awb_mode,exposure_mode,brightness_percentage,rpi_rpicamsrc_iso)
+                                   awb_mode,exposure_mode,brightness_percentage,rpi_rpicamsrc_iso,rpi_rpicamsrc_metering_mode)
+
 
 
 #endif

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -140,6 +140,9 @@ static std::string createRpicamsrcStream(const int camera_number,
   if(openhd::validate_rpi_rpicamsrc_iso(settings.rpi_rpicamsrc_iso)){
     ss<<"iso="<<settings.rpi_rpicamsrc_iso<<" ";
   }
+  if(openhd::validate_rpi_rpicamsrc_metering_mode(settings.rpi_rpicamsrc_metering_mode)){
+    ss<<"metering-mode="<<settings.rpi_rpicamsrc_metering_mode<<" ";
+  }
   // Note: ROI (Region of interest) on the rpi does not tell the encoder to allocate more bandwidth at a specific area,
   // but rather zooms in on a specific area (which is not really of use to use)
   ss<<" ! ";

--- a/OpenHD/ohd_video/inc/v_validate_settings.h
+++ b/OpenHD/ohd_video/inc/v_validate_settings.h
@@ -82,6 +82,11 @@ static bool validate_rpi_intra_refresh_type(int value){
   return ret;
 }
 
+// see gst-rpicamsrc documentation
+static bool validate_rpi_rpicamsrc_metering_mode(int value){
+  return value>=0 && value<=3;
+}
+
 
 static bool validate_mjpeg_quality_percent(int value){
   const bool ret=value<=100 && value>=1;


### PR DESCRIPTION
migrate to properly using supported frequencies of card for frequency validation.

add rpicamsrc metering mode setting

Quick note: There is no reason to try a frequency if the linux OS doesn't report it, it 100% won't work. 