### PR TITLE
Fixes for 2.2.5 release

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -325,7 +325,7 @@ int main(int argc, char *argv[]) {
     }
     // Now print the actual cameras used by OHD. Of course, this prints nothing on ground (where we have no cameras connected).
     for(const auto& camera:cameras){
-      m_console->info(camera.to_string());
+      m_console->info(camera.to_long_string());
     }
     // And start the blinker (TODO LED output is really dirty right now).
     auto alive_blinker=std::make_unique<openhd::GreenLedAliveBlinker>(*platform,profile->is_air);

--- a/OpenHD/ohd_common/openhd-global-constants.hpp
+++ b/OpenHD/ohd_common/openhd-global-constants.hpp
@@ -30,7 +30,7 @@ static constexpr auto VIDEO_GROUND_VIDEO_STREAM_1_UDP = 5600;
 static constexpr auto VIDEO_GROUND_VIDEO_STREAM_2_UDP = 5601;
 static_assert(VIDEO_GROUND_VIDEO_STREAM_1_UDP != VIDEO_GROUND_VIDEO_STREAM_2_UDP, "Must be different");
 
-static constexpr auto VERSION_NUMBER_STRING="2.2.5-evo";
+static constexpr auto VERSION_NUMBER_STRING="2.2.5.1-evo";
 
 }
 #endif //OPEN_HD_OPNHD_GLOBAL_CONSTANTS_H

--- a/OpenHD/ohd_common/openhd-platform.hpp
+++ b/OpenHD/ohd_common/openhd-platform.hpp
@@ -99,9 +99,7 @@ struct OHDPlatform {
   // The board type we are running on, for example rpi 3B+
   const BoardType board_type;
   [[nodiscard]] std::string to_string()const{
-	std::stringstream ss;
-	ss<<"OHDPlatform{"<<platform_type_to_string(platform_type)<<":"<<board_type_to_string(board_type)<<"}";
-	return ss.str();
+    return fmt::format("[{}:{}]",platform_type_to_string(platform_type),board_type_to_string(board_type));
   }
 };
 

--- a/OpenHD/ohd_common/openhd-util.hpp
+++ b/OpenHD/ohd_common/openhd-util.hpp
@@ -305,6 +305,20 @@ static std::string create_string_from_lines(const std::vector<std::string>& line
   return ss.str();
 }
 
+template<typename T>
+static std::string vec_as_string(const std::vector<T> &v) {
+  std::stringstream ss;
+  ss << "[";
+  for(int i=0;i<v.size();i++){
+    ss << std::to_string(v[i]);
+    if(i!=v.size()-1){
+      ss<<",";
+    }
+  }
+  ss << "]";
+  return ss.str();
+}
+
 }
 
 #endif

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -79,21 +79,16 @@ struct Camera {
   // and the platform encode cap(s) into account).
   std::vector<CameraEndpointV4l2> v4l2_endpoints;
   /**
-   * For logging, create a quick name string that gives developers enough info
-   * such that they can figure out what this camera is.
-   * @return verbose string.
+   * For logging, create a verbose string that gives developers enough info
+   * such that they can figure out what exactly this camera is.
    */
-  [[nodiscard]] std::string debugName() const {
-    std::stringstream ss;
-    ss << name << "|" << camera_type_to_string(type);
-    return ss.str();
+  [[nodiscard]] std::string to_long_string() const {
+    return fmt::format("{}:{}:{}:{}:{}:{}", camera_type_to_string(type),name,vendor,sensor_name,bus,index);
   }
-  [[nodiscard]] std::string to_string() const {
-    std::stringstream ss;
-    ss << "Camera" << index << "{" << camera_type_to_string(type) << ""
-       << "}";
-    return ss.str();
+  [[nodiscard]] std::string to_short_string() const {
+    return fmt::format("{}:{}:{}", camera_type_to_string(type),name,index);
   }
+
   // supported by pretty much any camera type (not supporting bitrate control is only the case for these exotic cases)
   [[nodiscard]] bool supports_bitrate()const{
     const bool not_supported= type==CameraType::CUSTOM_UNMANAGED_CAMERA || type==CameraType::IP;

--- a/OpenHD/ohd_video/inc/camera_enums.hpp
+++ b/OpenHD/ohd_video/inc/camera_enums.hpp
@@ -165,10 +165,7 @@ struct VideoFormat {
    * @return the video format in a readable form.
    */
   [[nodiscard]] std::string toString() const {
-    std::stringstream ss;
-    ss << video_codec_to_string(videoCodec) << "|" << width << "x" << height
-       << "@" << framerate;
-    return ss.str();
+    return fmt::format("{}|{}x{}@{}",video_codec_to_string(videoCodec),width,height,framerate);
   }
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(VideoFormat,videoCodec,width,height,framerate)

--- a/OpenHD/ohd_video/inc/camera_holder.hpp
+++ b/OpenHD/ohd_video/inc/camera_holder.hpp
@@ -301,9 +301,9 @@ class CameraHolder:
   const Camera m_camera;
  private:
   [[nodiscard]] std::string get_unique_filename()const override{
-    // TODO: r.n not unique enough, we need to be unique per model,too - e.g. a user
-    // might connect a different USB camera, where we'd need a different unique ID for
-    return fmt::format("{}_{}.json",m_camera.index, camera_type_to_string(m_camera.type));
+    // TODO: Hopefully "unique enough" now - but there might be issues if the name is
+    // not properly parsed (especially for USB camera(s))
+    return fmt::format("{}_{}_{}.json",m_camera.index, camera_type_to_string(m_camera.type),m_camera.name);
   }
   [[nodiscard]] CameraSettings create_default()const override{
     auto ret=CameraSettings{};

--- a/OpenHD/ohd_video/inc/camera_holder.hpp
+++ b/OpenHD/ohd_video/inc/camera_holder.hpp
@@ -53,7 +53,8 @@ class CameraHolder:
         openhd::Setting{"VIDEO_CODEC",openhd::IntSetting{video_codec_to_int(get_settings().streamed_video_format.videoCodec), c_codec}},
         openhd::Setting{"V_AIR_RECORDING",openhd::IntSetting{recording_to_int(get_settings().air_recording),c_recording}},
         // for debugging
-        openhd::Setting{"V_CAM_TYPE",openhd::StringSetting { get_short_name(),c_read_only_param}},
+        openhd::create_read_only_string("V_CAM_TYPE",camera_type_to_string(m_camera.type)),
+        openhd::create_read_only_string("V_CAM_NAME",get_name_mavlink_safe()),
     };
     if(m_camera.type==CameraType::IP){
       auto cb_ip_cam_url=[this](std::string,std::string value){
@@ -288,6 +289,12 @@ class CameraHolder:
     persist();
     return true;
   }
+  // 15 char mavlink string limit
+  std::string get_name_mavlink_safe()const{
+    auto tmp=m_camera.name;
+    if(tmp.size()>15)tmp.resize(15);
+    return tmp;
+  }
   // Settings hacky end
  private:
   // Camera info is immutable
@@ -338,9 +345,6 @@ class CameraHolder:
       openhd::log::get_default()->warn("Cannot find valid default resolution for USB camera");
     }
     return ret;
-  }
-  [[nodiscard]] std::string get_short_name()const{
-    return camera_type_to_string(m_camera.type);
   }
   // Where the settings (json) for each discovered camera are stored
   static std::string get_video_settings_directory(){

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -279,15 +279,13 @@ std::string GStreamerStream::createDebug(){
     return "GStreamerStream::No debug during restart\n";
   }
   if(!m_camera_holder->get_settings().enable_streaming){
-    std::stringstream ss;
-    ss << "GStreamerStream for camera:"<< m_camera_holder->get_camera().debugName()<<" disabled";
-    return ss.str();
+    return fmt::format("GStreamerStream for camera {} disabled",m_camera_holder->get_camera().to_short_string());
   }
   std::stringstream ss;
   GstState state;
   GstState pending;
   auto returnValue = gst_element_get_state(m_gst_pipeline, &state, &pending, 1000000000);
-  ss << "GStreamerStream for camera:"<< m_camera_holder->get_camera().debugName()<<" State:"<< returnValue << "." << state << "." << pending << ".";
+  ss << "GStreamerStream for camera:"<< m_camera_holder->get_camera().to_short_string()<<" State:"<< returnValue << "." << state << "." << pending << ".";
   return ss.str();
 }
 


### PR DESCRIPTION
fmt / logging 
expose V_CAM_NAME as read-only param for debugging.
fix bug - unique name not unique enough (camera settings)