### PR TITLE
Small fix

### DIFF
--- a/OpenHD/ohd_telemetry/src/internal/OnboardComputerStatus.hpp
+++ b/OpenHD/ohd_telemetry/src/internal/OnboardComputerStatus.hpp
@@ -89,9 +89,7 @@ static constexpr auto VCGENCMD_CLOCK_V3D="v3d";
 // NOTE: vcgencmd returns values in hertz, use the "mhz" util for more easy to read values.
 static int vcgencmd_measure_clock(const std::string& which){
   int ret = -1;
-  std::stringstream command;
-  command<<"vcgencmd measure_clock "<<which;
-  const auto vcgencmd_result = OHDUtil::run_command_out(command.str().c_str());
+  const auto vcgencmd_result = OHDUtil::run_command_out(fmt::format("vcgencmd measure_clock {}",which));
   if (!vcgencmd_result.has_value()) {
 	return ret;
   }

--- a/OpenHD/ohd_video/inc/camera_holder.hpp
+++ b/OpenHD/ohd_video/inc/camera_holder.hpp
@@ -359,9 +359,14 @@ static void startup_fix_common_issues(std::vector<std::shared_ptr<CameraHolder>>
   }
   // We always enable streaming for camera(s) on startup, to avoid the case where a user disables streaming for a camera,
   // and then forgets about it & reboots and the premise "always an image on startup with a working setup" is suddenly not true anymore.
-  for(int i=0;i<camera_holders.size();i++){
-    camera_holders.at(i)->unsafe_get_settings().enable_streaming= true;
-    camera_holders.at(i)->persist();
+  for(auto & camera_holder : camera_holders){
+    camera_holder->unsafe_get_settings().enable_streaming= true;
+    camera_holder->persist();
+  }
+  // And we disable recording on boot, to not accidentally fill up storage (relates to the new start stop recording widget)
+  for(auto & camera_holder : camera_holders){
+    camera_holder->unsafe_get_settings().air_recording= Recording::DISABLED;
+    camera_holder->persist();
   }
   /*camera_holders.at(0)->unsafe_get_settings().enable_streaming= true;
   camera_holders.at(0)->persist();


### PR DESCRIPTION
disable recording (persistent setting) on boot if enabled - needed for new start stop video recording UI element