### PR TITLE
Add ALLWINNER_CSI back into camera check

### DIFF
--- a/OpenHD/ohd_video/src/ohd_video_air.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air.cpp
@@ -75,6 +75,7 @@ void OHDVideoAir::configure(const std::shared_ptr<CameraHolder>& camera_holder) 
     case CameraType::JETSON_CSI:
     case CameraType::IP:
     case CameraType::ROCKCHIP_CSI:
+    case CameraType::ALLWINNER_CSI:
     case CameraType::UVC:
     case CameraType::ROCKCHIP_HDMI:
     case CameraType::CUSTOM_UNMANAGED_CAMERA:


### PR DESCRIPTION
Somehow this got forgotten when I added Allwinner in.