### PR TITLE
2.3.2-alpha

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_global_constants.hpp
+++ b/OpenHD/ohd_common/inc/openhd_global_constants.hpp
@@ -30,7 +30,7 @@ static constexpr auto VIDEO_GROUND_VIDEO_STREAM_1_UDP = 5600;
 static constexpr auto VIDEO_GROUND_VIDEO_STREAM_2_UDP = 5601;
 static_assert(VIDEO_GROUND_VIDEO_STREAM_1_UDP != VIDEO_GROUND_VIDEO_STREAM_2_UDP, "Must be different");
 
-static constexpr auto VERSION_NUMBER_STRING="2.3.1-evo-dirty1";
+static constexpr auto VERSION_NUMBER_STRING="2.3.2-alpha";
 
 }
 #endif //OPEN_HD_OPNHD_GLOBAL_CONSTANTS_H


### PR DESCRIPTION
1) FIX: only manage rpi ethernet via mavlink on ground pi, unless expclicitly specified otherwise
2) Update version 2.3.2-alpha