### PR TITLE
fix - re-add dummy camera if no real camera is found after 10seconds

### DIFF
--- a/OpenHD/ohd_video/src/ohd_video_air.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air.cpp
@@ -213,6 +213,10 @@ std::vector<Camera> OHDVideoAir::discover_cameras(const OHDPlatform& platform) {
         cameras = DCameras::discover(platform);
       }
     }
+    if(cameras.empty()){
+      m_console->warn("No camera after 10 seconds, using dummy camera");
+      cameras.emplace_back(createDummyCamera(0));
+    }
     return cameras;
   }
   m_console->info("Camera autodetect off");


### PR DESCRIPTION
Somehow this slipped under my radar. If no camera is found, add dummy camera instead of continouing without camera at all