### PR TITLE
2.3 evo fix cam path issue

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_settings_imp.hpp
+++ b/OpenHD/ohd_common/inc/openhd_settings_imp.hpp
@@ -78,6 +78,10 @@ static Setting create_read_only_int(const std::string& id,int value){
   };
   return Setting{id, openhd::IntSetting{value, cb}};
 }
+
+// Creates a read - only parameter - we repurpose the mavlink param set for reliably showing more info to
+// the user / developer. Can be quite nice for debugging.
+// Since the n of characters are limited, this might cut away parts of value
 static Setting create_read_only_string(const std::string& id,std::string value){
   if(value.length()>15){
      value.resize(15);

--- a/OpenHD/ohd_common/inc/openhd_settings_persistent.h
+++ b/OpenHD/ohd_common/inc/openhd_settings_persistent.h
@@ -104,11 +104,10 @@ class PersistentSettings{
   void persist_settings()const {
     assert(_settings);
     const auto file_path=get_file_path();
+    // Serialize to json
     const nlohmann::json tmp=*_settings;
     // and write them locally for persistence
-    std::ofstream t(file_path);
-    t << tmp.dump(4);
-    t.close();
+    OHDFilesystemUtil::write_file(file_path,tmp.dump(4));
   }
   /**
    * Try and deserialize the last stored settings (json)

--- a/OpenHD/ohd_common/inc/openhd_util_filesystem.h
+++ b/OpenHD/ohd_common/inc/openhd_util_filesystem.h
@@ -37,7 +37,9 @@ void create_directories(const std::string& directory);
 // delete directory if it exists
 void safe_delete_directory(const std::string& directory);
 
-// Write a text file. If the file already exists, its content is overwritten
+// Write a text file. If the file already exists, its content is overwritten.
+// This does not recursively create directories(s) - use create_directories before if needed.
+// This method intentionally doesn't return an error code, but logs verbose warning(s) when things go wrong.
 void write_file(const std::string& path,const std::string& content);
 
 // Read a file as text and return its content as a string.

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -223,7 +223,5 @@ static constexpr auto PLATFORM_MANIFEST_FILENAME = "/tmp/platform_manifest";
 
 void write_platform_manifest(const OHDPlatform& ohdPlatform) {
   nlohmann::json manifest = ohdPlatform;
-  std::ofstream _t(PLATFORM_MANIFEST_FILENAME);
-  _t << manifest.dump(4);
-  _t.close();
+  OHDFilesystemUtil::write_file(PLATFORM_MANIFEST_FILENAME,manifest.dump(4));
 }

--- a/OpenHD/ohd_common/src/openhd_profile.cpp
+++ b/OpenHD/ohd_common/src/openhd_profile.cpp
@@ -18,9 +18,7 @@ static void to_json(nlohmann::json& j, const OHDProfile& p) {
 
 void write_profile_manifest(const OHDProfile& ohdProfile) {
   nlohmann::json manifest = ohdProfile;
-  std::ofstream _t(PROFILE_MANIFEST_FILENAME);
-  _t << manifest.dump(4);
-  _t.close();
+  OHDFilesystemUtil::write_file(PROFILE_MANIFEST_FILENAME,manifest.dump(4));
 }
 
 std::shared_ptr<OHDProfile> DProfile::discover(bool is_air) {

--- a/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
+++ b/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
@@ -60,12 +60,12 @@ void OHDFilesystemUtil::write_file(const std::string &path,
                                    const std::string &content) {
   try{
     std::ofstream t(path);
-    if(t.bad()){
+    if(!t.good()){
       openhd::log::get_default()->warn("Cannot open file [{}]",path);
     }
     t << content;
     t.close();
-    if(t.bad()){
+    if(!t.good()){
       openhd::log::get_default()->warn("Cannot write file [{}]",path);
     }
   }catch (std::exception& e){

--- a/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
+++ b/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
@@ -60,10 +60,16 @@ void OHDFilesystemUtil::write_file(const std::string &path,
                                    const std::string &content) {
   try{
     std::ofstream t(path);
+    if(t.bad()){
+      openhd::log::get_default()->warn("Cannot open file [{}]",path);
+    }
     t << content;
     t.close();
+    if(t.bad()){
+      openhd::log::get_default()->warn("Cannot write file [{}]",path);
+    }
   }catch (std::exception& e){
-    openhd::log::get_default()->warn("Cannot write file [{}]",path);
+    openhd::log::get_default()->warn("Cannot write file [{}] {}",path,e.what());
   }
 }
 

--- a/OpenHD/ohd_interface/src/wifi_card.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card.cpp
@@ -34,7 +34,5 @@ static constexpr auto WIFI_MANIFEST_FILENAME = "/tmp/wifi_manifest";
 
 void write_wificards_manifest(const std::vector<WiFiCard> &cards) {
   auto manifest = wificards_to_json(cards);
-  std::ofstream _t(WIFI_MANIFEST_FILENAME);
-  _t << manifest.dump(4);
-  _t.close();
+  OHDFilesystemUtil::write_file(WIFI_MANIFEST_FILENAME,manifest.dump(4));
 }

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -142,6 +142,16 @@ struct Camera {
   bool supports_rpi_rpicamsrc_metering_mode()const{
     return type==CameraType::RPI_CSI_MMAL;
   }
+  // This "hash" needs to be deterministic and unique - otherwise, incompatible settings from
+  // a previous camera might be used
+  std::string get_unique_settings_filename()const{
+    auto safe_name=name;
+    // TODO find a better solution
+    if(type==CameraType::RPI_CSI_LIBCAMERA){
+      safe_name=sensor_name;
+    }
+    return fmt::format("{}_{}_{}.json",index, camera_type_to_string(type),safe_name);
+  }
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Camera,type,name,vendor,sensor_name,bus,index,rpi_csi_mmal_is_csi_to_hdmi, v4l2_endpoints)
 

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -7,8 +7,7 @@
 
 #include "camera_enums.hpp"
 #include "include_json.hpp"
-#include <ostream>
-#include <fstream>
+#include "openhd_util_filesystem.h"
 
 
 // Information about a discovered camera and its capabilities.

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -173,7 +173,7 @@ static Camera createDummyCamera(int index=0) {
 static Camera createCustomUnmanagedCamera(int index=0){
   Camera camera;
   camera.name = fmt::format("CustomUnmanagedCamera{}",index);
-  camera.index = 0;
+  camera.index = index;
   camera.vendor = "unknown";
   camera.type = CameraType::CUSTOM_UNMANAGED_CAMERA;
   return camera;

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -159,9 +159,7 @@ static constexpr auto CAMERA_MANIFEST_FILENAME = "/tmp/camera_manifest";
 
 static void write_camera_manifest(const std::vector<Camera> &cameras) {
   auto manifest = cameras_to_json(cameras);
-  std::ofstream _t(CAMERA_MANIFEST_FILENAME);
-  _t << manifest.dump(4);
-  _t.close();
+  OHDFilesystemUtil::write_file(CAMERA_MANIFEST_FILENAME,manifest.dump(4));
 }
 
 static Camera createDummyCamera(int index=0) {

--- a/OpenHD/ohd_video/inc/camera_holder.hpp
+++ b/OpenHD/ohd_video/inc/camera_holder.hpp
@@ -302,9 +302,7 @@ class CameraHolder:
   const Camera m_camera;
  private:
   [[nodiscard]] std::string get_unique_filename()const override{
-    // TODO: Hopefully "unique enough" now - but there might be issues if the name is
-    // not properly parsed (especially for USB camera(s))
-    return fmt::format("{}_{}_{}.json",m_camera.index, camera_type_to_string(m_camera.type),m_camera.name);
+    return m_camera.get_unique_settings_filename();
   }
   [[nodiscard]] CameraSettings create_default()const override{
     auto ret=CameraSettings{};


### PR DESCRIPTION
1) Use OHDFilesystemUtil::write_file() as much as possible - it logs warnings if file write fails
(such that this bug is less likely to happen again in the future)
2) For now, use the libcamera "sensor_name" in the filename "hash"