### PR TITLE
Small fix & new featurs

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_action_handler.hpp
+++ b/OpenHD/ohd_common/inc/openhd_action_handler.hpp
@@ -48,9 +48,9 @@ class ActionHandler{
     auto tmp=m_action_request_bitrate_change;
     if(tmp){
       auto& cb=*tmp;
+      // The cb will update setting the global atomic value for cam1 / cam2 accordingly
       cb(link_bitrate_info);
     }
-    curr_set_raw_video_bitrate_kbits_cam1 =link_bitrate_info.recommended_encoder_bitrate_kbits;
   }
  public:
   // Link statistics - for that the wb link (ohd_interface) needs to talk to ohd_telemetry

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -142,6 +142,9 @@ struct Camera {
   bool supports_rpi_rpicamsrc_metering_mode()const{
     return type==CameraType::RPI_CSI_MMAL;
   }
+  bool supports_force_sw_encode()const{
+      return type==CameraType::UVC || type==CameraType::RPI_CSI_MMAL || type==CameraType::RPI_CSI_LIBCAMERA;
+  }
   // This "hash" needs to be deterministic and unique - otherwise, incompatible settings from
   // a previous camera might be used
   std::string get_unique_settings_filename()const{

--- a/OpenHD/ohd_video/inc/camera_holder.hpp
+++ b/OpenHD/ohd_video/inc/camera_holder.hpp
@@ -61,14 +61,14 @@ class CameraHolder:
       };
       ret.push_back(openhd::Setting{"V_IP_CAM_URL",openhd::StringSetting {get_settings().ip_cam_url,cb_ip_cam_url}});
     }
-    if(m_camera.type==CameraType::UVC || true){
+    if(m_camera.supports_force_sw_encode()){
       auto cb=[this](std::string,int value){
         if(!openhd::validate_yes_or_no(value))return false;
-        unsafe_get_settings().usb_uvc_force_sw_encoding = value;
+        unsafe_get_settings().force_sw_encode = value;
         persist();
         return true;
       };
-      ret.push_back(openhd::Setting{"V_FORCE_SW_ENC",openhd::IntSetting {get_settings().usb_uvc_force_sw_encoding,cb}});
+      ret.push_back(openhd::Setting{"V_FORCE_SW_ENC",openhd::IntSetting {get_settings().force_sw_encode,cb}});
     }
     if(m_camera.supports_bitrate()){
       // NOTE: OpenHD stores the bitrate in kbit/s, but for now we use MBit/s for the setting

--- a/OpenHD/ohd_video/inc/camera_holder.hpp
+++ b/OpenHD/ohd_video/inc/camera_holder.hpp
@@ -61,7 +61,7 @@ class CameraHolder:
       };
       ret.push_back(openhd::Setting{"V_IP_CAM_URL",openhd::StringSetting {get_settings().ip_cam_url,cb_ip_cam_url}});
     }
-    if(m_camera.type==CameraType::UVC){
+    if(m_camera.type==CameraType::UVC || true){
       auto cb=[this](std::string,int value){
         if(!openhd::validate_yes_or_no(value))return false;
         unsafe_get_settings().usb_uvc_force_sw_encoding = value;

--- a/OpenHD/ohd_video/inc/camera_settings.hpp
+++ b/OpenHD/ohd_video/inc/camera_settings.hpp
@@ -101,11 +101,11 @@ struct CameraSettings {
   // Camera exposure metering mode to use
   // Default 0 (average)
   int rpi_rpicamsrc_metering_mode=0;
-  // This is for USB camera(s) (UVC) that can output already encoded data like h264,h265 and mjpeg but also
-  // raw format(s). This forces OpenHD to not use a camera(s) capability to output encoded data, but rather use
-  // raw out & sw encode instead. Can fix bug(s) where a camera(s) encoder is not usable for OpenHD, and SW encoding
-  // (even though being slow) is the better option.
-  bool usb_uvc_force_sw_encoding=false;
+  // Depending on the cam type, openhd uses hw-accelerated encoding whenever possible.
+  // However, in some cases (e.g. when using a USB camera that outputs raw and h264, but the hw encoder of the cam is bad)
+  // or for experimenting (e.g. when using libcamera / rpicamsrc and RPI4) one might prefer to use SW encode.
+  // Enabling this is no guarantee a sw encoded pipeline exists for this camera.
+  bool force_sw_encode=false;
 
   // only used on RK3588, dirty, r.n not persistent
   VideoFormat recordingFormat{VideoCodec::H264, 0, 0, 0}; // 0 means copy
@@ -117,7 +117,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CameraSettings,enable_streaming,
                                    streamed_video_format, h26x_bitrate_kbits,
                                    h26x_keyframe_interval, h26x_intra_refresh_type,mjpeg_quality_percent, ip_cam_url,air_recording,
                                    camera_rotation_degree,horizontal_flip,vertical_flip,
-                                   awb_mode,exposure_mode,brightness_percentage,rpi_rpicamsrc_iso,rpi_rpicamsrc_metering_mode)
+                                   awb_mode,exposure_mode,brightness_percentage,rpi_rpicamsrc_iso,rpi_rpicamsrc_metering_mode,
+                                   force_sw_encode)
 
 
 

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -199,7 +199,7 @@ static std::string createRpicamsrcStream(const int camera_number,
   // but rather zooms in on a specific area (which is not really of use to use)
   ss<<" ! ";
   if(settings.streamed_video_format.videoCodec==VideoCodec::H264){
-    if(settings.usb_uvc_force_sw_encoding){
+    if(settings.force_sw_encode){
       openhd::log::get_default()->warn("Forced SW encode");
       ss<<fmt::format(
           "video/x-raw, width={}, height={}, framerate={}/1 ! ",
@@ -253,7 +253,7 @@ static std::string createLibcamerasrcStream(const std::string& camera_name,
     ss << fmt::format(
         "capsfilter caps=video/x-raw,width={},height={},format=NV12,framerate={}/1,interlace-mode=progressive,colorimetry=bt709 ! ",
         settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
-    if(settings.usb_uvc_force_sw_encoding){
+    if(settings.force_sw_encode){
       openhd::log::get_default()->warn("Forced SW encode");
       ss<< createSwEncoder(extract_common_encoder_params(settings));
     }else{

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -199,16 +199,24 @@ static std::string createRpicamsrcStream(const int camera_number,
   // but rather zooms in on a specific area (which is not really of use to use)
   ss<<" ! ";
   if(settings.streamed_video_format.videoCodec==VideoCodec::H264){
-	ss << fmt::format(
-		"video/x-h264, profile=constrained-baseline, width={}, height={}, "
-		"framerate={}/1, level=4.0 ! ",
-        settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
+    if(settings.usb_uvc_force_sw_encoding){
+      openhd::log::get_default()->debug("Forced SW encode");
+      ss<<fmt::format(
+          "video/x-raw, width={}, height={}, framerate={}/1 ! ",
+          settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
+      ss<<createSwEncoder(extract_common_encoder_params(settings));
+    }else{
+      ss << fmt::format(
+          "video/x-h264, profile=constrained-baseline, width={}, height={}, "
+          "framerate={}/1, level=4.0 ! ",
+          settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
+    }
   }else{
-	openhd::log::get_default()->warn("No h265 / MJPEG encoder on rpi, using SW encode (might result in frame drops/performance issues");
-	ss<<fmt::format(
-		"video/x-raw, width={}, height={}, framerate={}/1 ! ",
-            settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
-	ss<<createSwEncoder(extract_common_encoder_params(settings));
+    openhd::log::get_default()->warn("No h265 / MJPEG encoder on rpi, using SW encode (might result in frame drops/performance issues");
+    ss<<fmt::format(
+        "video/x-raw, width={}, height={}, framerate={}/1 ! ",
+        settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
+    ss<<createSwEncoder(extract_common_encoder_params(settings));
   }
   return ss.str();
 }

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -254,6 +254,7 @@ static std::string createLibcamerasrcStream(const std::string& camera_name,
         "capsfilter caps=video/x-raw,width={},height={},format=NV12,framerate={}/1,interlace-mode=progressive,colorimetry=bt709 ! ",
         settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
     if(settings.usb_uvc_force_sw_encoding){
+      openhd::log::get_default()->warn("Forced SW encode");
       ss<< createSwEncoder(extract_common_encoder_params(settings));
     }else{
       // We got rid of the v4l2convert - see

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -253,10 +253,14 @@ static std::string createLibcamerasrcStream(const std::string& camera_name,
     ss << fmt::format(
         "capsfilter caps=video/x-raw,width={},height={},format=NV12,framerate={}/1,interlace-mode=progressive,colorimetry=bt709 ! ",
         settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);
-    // We got rid of the v4l2convert - see
-    // https://github.com/raspberrypi/libcamera/issues/30
-    // after the libcamerasrc part, we can just append the rpi v4l2 h264 encoder part
-    ss<<create_rpi_v4l2_h264_encoder(settings);
+    if(settings.usb_uvc_force_sw_encoding){
+      ss<< createSwEncoder(extract_common_encoder_params(settings));
+    }else{
+      // We got rid of the v4l2convert - see
+      // https://github.com/raspberrypi/libcamera/issues/30
+      // after the libcamerasrc part, we can just append the rpi v4l2 h264 encoder part
+      ss<<create_rpi_v4l2_h264_encoder(settings);
+    }
   } else if (settings.streamed_video_format.videoCodec == VideoCodec::MJPEG) {
     ss << fmt::format(
         "capsfilter caps=video/x-raw,width={},height={},format=YVYU,framerate={}/1,interlace-mode=progressive,colorimetry=bt709 ! ",

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -200,7 +200,7 @@ static std::string createRpicamsrcStream(const int camera_number,
   ss<<" ! ";
   if(settings.streamed_video_format.videoCodec==VideoCodec::H264){
     if(settings.usb_uvc_force_sw_encoding){
-      openhd::log::get_default()->debug("Forced SW encode");
+      openhd::log::get_default()->warn("Forced SW encode");
       ss<<fmt::format(
           "video/x-raw, width={}, height={}, framerate={}/1 ! ",
           settings.streamed_video_format.width, settings.streamed_video_format.height, settings.streamed_video_format.framerate);

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -217,7 +217,7 @@ void GStreamerStream::setup_usb_uvc() {
   const auto& camera= m_camera_holder->get_camera();
   const auto& setting= m_camera_holder->get_settings();
   m_console->debug("Setting up usb UVC camera Name:{}",camera.name);
-  if(!setting.usb_uvc_force_sw_encoding){
+  if(!setting.force_sw_encode){
     // First we try and start a hw encoded path, (but hw encode by the camera encoder, not a local hw encoder)
     // where v4l2src directly provides encoded video buffers
     // (unless force sw encode is explicitly requested by the user)


### PR DESCRIPTION
1) add option to force sw encode also for rpicamsrc and libcamerasrc
2) fix bug - force_sw_encode not persistent during reboots (usb cam)
3) fix bug - in multi camera mode, the curr recomended bitrate reported by the mavlink message(s) is wrong. Internally, the right one is used though.