### PR TITLE
(BUG) Fix rate controll

### DIFF
--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -704,12 +704,12 @@ void WBLink::perform_rate_adjustment() {
     m_console->warn("Got {} tx errors {} times",delta_total_tx_errors,m_n_detected_and_reset_tx_errors);
   }else{
 	if(m_n_detected_and_reset_tx_errors>0){
-	  m_console->warn("No consecutive tx errors - skip reduce");
+	  m_console->warn("No tx errors after {}",m_n_detected_and_reset_tx_errors);
 	}
 	m_n_detected_and_reset_tx_errors=0;
   }
-  if(m_n_detected_and_reset_tx_errors>=2){
-    // We got tx errors N consecutive times, resetting between each - we need to reduce bitrate
+  if(m_n_detected_and_reset_tx_errors>=3){
+    // We got tx errors N consecutive times, (resetting if there are no tx errors) - we need to reduce bitrate
     m_console->debug("Got m_n_detected_and_reset_tx_errors{} with max:{} recommended:{}",
                      m_n_detected_and_reset_tx_errors,
         m_max_video_rate_for_current_wifi_config,m_recommended_video_bitrate);

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -702,6 +702,11 @@ void WBLink::perform_rate_adjustment() {
   if(has_tx_errors){
     m_n_detected_and_reset_tx_errors++;
     m_console->warn("Got {} tx errors {} times",delta_total_tx_errors,m_n_detected_and_reset_tx_errors);
+  }else{
+	if(m_n_detected_and_reset_tx_errors>0){
+	  m_console->warn("No consecutive tx errors - skip reduce");
+	}
+	m_n_detected_and_reset_tx_errors=0;
   }
   if(m_n_detected_and_reset_tx_errors>=2){
     // We got tx errors N consecutive times, resetting between each - we need to reduce bitrate


### PR DESCRIPTION
(Bug) fix - tx errors are not reset if there are no tx errors the n-th  time checking. This can result in openhd constantly reducing the bitrate unnecessarily.
Increase the n of needed consective tx errors for a rate reduction from 2 to 3