### PR TITLE
Add support for second udp localhost::port tuple forwarding, primary for openhd web ui

### DIFF
--- a/OpenHD/ohd_common/config/hardware.config
+++ b/OpenHD/ohd_common/config/hardware.config
@@ -56,3 +56,8 @@ NW_ETHERNET_CARD = RPI_ETHERNET_ONLY
 # Note that openhd already can detect externally connected devices, depending on how they are connected and what platform
 # you are on. Only used on ground unit.
 NW_MANUAL_FORWARDING_IPS =
+# OpenHD automatically forwards primary and secondary video localhost UDP 5600 and 5601 on ground.
+# This option additionally also adds forwarding to 5800 (and 5801) of primary / secondary video
+# Primary consumer of these stream(s) is the openhd web ui and its fpv preview (website)
+# This additional forwarding consumes a bit more CPU and is not needed in all scenarios - therefore off by default
+NW_FORWARD_TO_LOCALHOST_58XX = false

--- a/OpenHD/ohd_common/inc/openhd_config.h
+++ b/OpenHD/ohd_common/inc/openhd_config.h
@@ -26,6 +26,7 @@ struct Config{
   // NETWORKING
   std::string NW_ETHERNET_CARD=RPI_ETHERNET_ONLY;
   std::vector<std::string> NW_MANUAL_FORWARDING_IPS;
+  bool NW_FORWARD_TO_LOCALHOST_58XX=false;
 };
 
 Config load_config();

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -35,6 +35,7 @@ openhd::Config openhd::load_config() {
 
 	ret.NW_ETHERNET_CARD = r.Get<std::string>("network", "NW_ETHERNET_CARD");
     ret.NW_MANUAL_FORWARDING_IPS =  r.GetVector<std::string>("network", "NW_MANUAL_FORWARDING_IPS");
+    ret.NW_FORWARD_TO_LOCALHOST_58XX = r.Get<bool>("network","NW_FORWARD_TO_LOCALHOST_58XX");
     return ret;
   }catch (std::exception& exception){
     get_logger()->error("Ill-formatted config file {}",std::string(exception.what()));
@@ -45,10 +46,10 @@ openhd::Config openhd::load_config() {
 void openhd::debug_config(const openhd::Config& config) {
   get_logger()->debug("WIFI_ENABLE_AUTODETECT:{}, WIFI_WB_LINK_CARDS:{}, WIFI_WIFI_HOTSPOT_CARD:{},\n"
       "CAMERA_ENABLE_AUTODETECT:{}, CAMERA_N_CAMERAS:{}, CAMERA_CAMERA0_TYPE:{}, CAMERA_CAMERA1_TYPE:{}\n"
-      "NW_MANUAL_FORWARDING_IPS:{},NW_ETHERNET_CARD:{}",
+      "NW_MANUAL_FORWARDING_IPS:{},NW_ETHERNET_CARD:{},NW_FORWARD_TO_LOCALHOST_58XX:{}",
       config.WIFI_ENABLE_AUTODETECT,OHDUtil::str_vec_as_string(config.WIFI_WB_LINK_CARDS),config.WIFI_WIFI_HOTSPOT_CARD,
       config.CAMERA_ENABLE_AUTODETECT,config.CAMERA_N_CAMERAS,config.CAMERA_CAMERA0_TYPE,config.CAMERA_CAMERA1_TYPE,
-      OHDUtil::str_vec_as_string(config.NW_MANUAL_FORWARDING_IPS),config.NW_ETHERNET_CARD
+      OHDUtil::str_vec_as_string(config.NW_MANUAL_FORWARDING_IPS),config.NW_ETHERNET_CARD,config.NW_FORWARD_TO_LOCALHOST_58XX
       );
 }
 void openhd::debug_config() {

--- a/OpenHD/ohd_video/src/ohd_video_ground.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_ground.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "ohd_video_ground.h"
+#include "openhd_config.h"
 
 #include <utility>
 
@@ -13,10 +14,13 @@ m_link_handle(std::move(link_handle)){
   m_secondary_video_forwarder = std::make_unique<SocketHelper::UDPMultiForwarder>();
   // We always forward video to localhost::5600 (primary) and 5601 (secondary) for the default Ground control application (e.g. QOpenHD) to pick up
   addForwarder("127.0.0.1");
-
-  // Adding forwarder for WebRTC
-  m_primary_video_forwarder->addForwarder("127.0.0.1", 5800);
-
+  // See the description in the .config file for more info
+  if(openhd::load_config().NW_FORWARD_TO_LOCALHOST_58XX){
+    m_console->debug("Forwarding video to 5800/5801 localhost is enabled");
+    // Adding forwarder for WebRTC
+    m_primary_video_forwarder->addForwarder("127.0.0.1", 5800);
+    m_secondary_video_forwarder->addForwarder("127.0.0.1",5801);
+  }
   if(m_link_handle){
     m_link_handle->register_on_receive_video_data_cb([this](int stream_index,const uint8_t * data,int data_len){
       on_video_data(stream_index,data,data_len);

--- a/OpenHD/ohd_video/src/ohd_video_ground.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_ground.cpp
@@ -13,6 +13,10 @@ m_link_handle(std::move(link_handle)){
   m_secondary_video_forwarder = std::make_unique<SocketHelper::UDPMultiForwarder>();
   // We always forward video to localhost::5600 (primary) and 5601 (secondary) for the default Ground control application (e.g. QOpenHD) to pick up
   addForwarder("127.0.0.1");
+
+  // Adding forwarder for WebRTC
+  m_primary_video_forwarder->addForwarder("127.0.0.1", 5800);
+
   if(m_link_handle){
     m_link_handle->register_on_receive_video_data_cb([this](int stream_index,const uint8_t * data,int data_len){
       on_video_data(stream_index,data,data_len);


### PR DESCRIPTION
Needs to be explicitly enabled by the user.
OpenHD/ohd_common/config/hardware.config
https://github.com/OpenHD/OpenHD/pull/853