### PR TITLE
Fix - illegal instruction on old intel devices due to AVX2

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -195,9 +195,6 @@ int main(int argc, char *argv[]) {
       "continue_without_wb_card:"<<OHDUtil::yes_or_no(options.continue_without_wb_card)<<"\n";
   std::cout<<"Version number:"<<openhd::VERSION_NUMBER_STRING<<"\n";
   std::cout<<"Git info:Branch:"<<git_Branch()<<" SHA:"<<git_CommitSHA1()<<"Dirty:"<<OHDUtil::yes_or_no(git_AnyUncommittedChanges())<<"\n";
-  std::cout<<"X1\n";
-  openhd::log::get_default()->debug("Ex message");
-  std::cout<<"X2\n";
   openhd::debug_config();
   OHDInterface::print_internal_fec_optimization_method();
 

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -195,7 +195,9 @@ int main(int argc, char *argv[]) {
       "continue_without_wb_card:"<<OHDUtil::yes_or_no(options.continue_without_wb_card)<<"\n";
   std::cout<<"Version number:"<<openhd::VERSION_NUMBER_STRING<<"\n";
   std::cout<<"Git info:Branch:"<<git_Branch()<<" SHA:"<<git_CommitSHA1()<<"Dirty:"<<OHDUtil::yes_or_no(git_AnyUncommittedChanges())<<"\n";
+  std::cout<<"X1\n";
   openhd::debug_config();
+  std::cout<<"X2\n";
   OHDInterface::print_internal_fec_optimization_method();
 
   // This is the console we use inside main, in general different openhd modules/classes have their own loggers

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -196,8 +196,9 @@ int main(int argc, char *argv[]) {
   std::cout<<"Version number:"<<openhd::VERSION_NUMBER_STRING<<"\n";
   std::cout<<"Git info:Branch:"<<git_Branch()<<" SHA:"<<git_CommitSHA1()<<"Dirty:"<<OHDUtil::yes_or_no(git_AnyUncommittedChanges())<<"\n";
   std::cout<<"X1\n";
-  openhd::debug_config();
+  openhd::log::get_default()->debug("Ex message");
   std::cout<<"X2\n";
+  openhd::debug_config();
   OHDInterface::print_internal_fec_optimization_method();
 
   // This is the console we use inside main, in general different openhd modules/classes have their own loggers

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -16,15 +16,20 @@ add_library(OHDCommonLib STATIC) # initialized below
 add_library(OHDCommonLib::OHDCommonLib ALIAS OHDCommonLib)
 
 # We use spdlog and json pretty much everywhere in OpenHD. Build it here, then make publicly available
-add_subdirectory(lib/spdlog)
-add_subdirectory(lib/json)
-
+# 1) spdlog
+find_package(spdlog REQUIRED)
+#if(TARGET spdlog)
+#    message(STATUS "Using spdlog from package manager")
+#else()
+#    message(STATUS "Build and link spdlog manually")
+#    add_subdirectory(lib/spdlog)
+#endif()
 # Public since we use it throughout OpenHD
-#find_package(spdlog REQUIRED)
 target_link_libraries(OHDCommonLib PUBLIC spdlog::spdlog)
 
+# 2) nlohmann::json
+add_subdirectory(lib/json)
 # Public since we use it throughout OpenHD
-#find_package(spdlog nlohmann_json)
 target_link_libraries(OHDCommonLib PUBLIC  nlohmann_json::nlohmann_json)
 
 # WARNING: Please do not use boost, without going into too much detail why, it is a pain for multi platform compatibility.

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -29,8 +29,7 @@ target_link_libraries(OHDCommonLib PUBLIC  nlohmann_json::nlohmann_json)
 
 # WARNING: Please do not use boost, without going into too much detail why, it is a pain for multi platform compatibility.
 # We only use it as a temporary solution until all platforms support std::filesystem
-SET(Boost_USE_STATIC_LIBS OFF)
-SET(Boost_USE_MULTITHREAD ON)
+SET(Boost_USE_STATIC_LIBS ON)
 FIND_PACKAGE(Boost REQUIRED COMPONENTS filesystem)
 target_link_libraries(OHDCommonLib PRIVATE Boost::filesystem)
 #----------------------------------------------------------------------------------------------------------------------

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -99,3 +99,6 @@ target_link_libraries(test_ohd_reboot OHDCommonLib)
 
 add_executable(test_config test/test_config.cpp)
 target_link_libraries(test_config OHDCommonLib)
+
+add_executable(test_logging test/test_logging.cpp)
+target_link_libraries(test_logging OHDCommonLib)

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -17,13 +17,8 @@ add_library(OHDCommonLib::OHDCommonLib ALIAS OHDCommonLib)
 
 # We use spdlog and json pretty much everywhere in OpenHD. Build it here, then make publicly available
 # 1) spdlog
-find_package(spdlog REQUIRED)
-#if(TARGET spdlog)
-#    message(STATUS "Using spdlog from package manager")
-#else()
-#    message(STATUS "Build and link spdlog manually")
-#    add_subdirectory(lib/spdlog)
-#endif()
+#find_package(spdlog REQUIRED)
+add_subdirectory(lib/spdlog)
 # Public since we use it throughout OpenHD
 target_link_libraries(OHDCommonLib PUBLIC spdlog::spdlog)
 

--- a/OpenHD/ohd_common/config/hardware.config
+++ b/OpenHD/ohd_common/config/hardware.config
@@ -56,7 +56,7 @@ NW_ETHERNET_CARD = RPI_ETHERNET_ONLY
 # Note that openhd already can detect externally connected devices, depending on how they are connected and what platform
 # you are on. Only used on ground unit.
 NW_MANUAL_FORWARDING_IPS =
-# OpenHD automatically forwards primary and secondary video localhost UDP 5600 and 5601 on ground.
+# OpenHD automatically forwards primary and secondary video to localhost UDP 5600 and 5601 on ground.
 # This option additionally also adds forwarding to 5800 (and 5801) of primary / secondary video
 # Primary consumer of these stream(s) is the openhd web ui and its fpv preview (website)
 # This additional forwarding consumes a bit more CPU and is not needed in all scenarios - therefore off by default

--- a/OpenHD/ohd_common/inc/openhd_global_constants.hpp
+++ b/OpenHD/ohd_common/inc/openhd_global_constants.hpp
@@ -30,7 +30,7 @@ static constexpr auto VIDEO_GROUND_VIDEO_STREAM_1_UDP = 5600;
 static constexpr auto VIDEO_GROUND_VIDEO_STREAM_2_UDP = 5601;
 static_assert(VIDEO_GROUND_VIDEO_STREAM_1_UDP != VIDEO_GROUND_VIDEO_STREAM_2_UDP, "Must be different");
 
-static constexpr auto VERSION_NUMBER_STRING="2.3.3-beta";
+static constexpr auto VERSION_NUMBER_STRING="2.3.3-beta-dirty";
 
 }
 #endif //OPEN_HD_OPNHD_GLOBAL_CONSTANTS_H

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -39,7 +39,7 @@ openhd::Config openhd::load_config() {
     return ret;
   }catch (std::exception& exception){
     std::cout<<"Y1\n";
-    openhd::log::get_default()->debug("Ex message2");
+    openhd::log::get_default()->debug("Ex message2 {}",std::string("hallo"));
     get_logger()->error("Ill-formatted config file {}",std::string(exception.what()));
     std::cout<<"Y2\n";
   }

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -39,6 +39,7 @@ openhd::Config openhd::load_config() {
     return ret;
   }catch (std::exception& exception){
     std::cout<<"Y1\n";
+    openhd::log::get_default()->debug("Ex message2");
     get_logger()->error("Ill-formatted config file {}",std::string(exception.what()));
     std::cout<<"Y2\n";
   }

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -56,6 +56,7 @@ void openhd::debug_config(const openhd::Config& config) {
 
 void openhd::debug_config() {
   auto config=load_config();
+  std::cout<<"Y2\n";
   debug_config(config);
 }
 

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -38,10 +38,7 @@ openhd::Config openhd::load_config() {
     ret.NW_FORWARD_TO_LOCALHOST_58XX = r.Get<bool>("network","NW_FORWARD_TO_LOCALHOST_58XX");
     return ret;
   }catch (std::exception& exception){
-    std::cout<<"Y1\n";
-    openhd::log::get_default()->debug("Ex message2 {}",std::string("hallo"));
     get_logger()->error("Ill-formatted config file {}",std::string(exception.what()));
-    std::cout<<"Y2\n";
   }
   return {};
 }

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -44,7 +44,6 @@ openhd::Config openhd::load_config() {
 }
 
 void openhd::debug_config(const openhd::Config& config) {
-  std::cout<<"Ehm\n";
   get_logger()->debug("WIFI_ENABLE_AUTODETECT:{}, WIFI_WB_LINK_CARDS:{}, WIFI_WIFI_HOTSPOT_CARD:{},\n"
       "CAMERA_ENABLE_AUTODETECT:{}, CAMERA_N_CAMERAS:{}, CAMERA_CAMERA0_TYPE:{}, CAMERA_CAMERA1_TYPE:{}\n"
       "NW_MANUAL_FORWARDING_IPS:{},NW_ETHERNET_CARD:{},NW_FORWARD_TO_LOCALHOST_58XX:{}",
@@ -56,7 +55,6 @@ void openhd::debug_config(const openhd::Config& config) {
 
 void openhd::debug_config() {
   auto config=load_config();
-  std::cout<<"Y2\n";
   debug_config(config);
 }
 

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -38,7 +38,9 @@ openhd::Config openhd::load_config() {
     ret.NW_FORWARD_TO_LOCALHOST_58XX = r.Get<bool>("network","NW_FORWARD_TO_LOCALHOST_58XX");
     return ret;
   }catch (std::exception& exception){
+    std::cout<<"Y1\n";
     get_logger()->error("Ill-formatted config file {}",std::string(exception.what()));
+    std::cout<<"Y2\n";
   }
   return {};
 }

--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -44,6 +44,7 @@ openhd::Config openhd::load_config() {
 }
 
 void openhd::debug_config(const openhd::Config& config) {
+  std::cout<<"Ehm\n";
   get_logger()->debug("WIFI_ENABLE_AUTODETECT:{}, WIFI_WB_LINK_CARDS:{}, WIFI_WIFI_HOTSPOT_CARD:{},\n"
       "CAMERA_ENABLE_AUTODETECT:{}, CAMERA_N_CAMERAS:{}, CAMERA_CAMERA0_TYPE:{}, CAMERA_CAMERA1_TYPE:{}\n"
       "NW_MANUAL_FORWARDING_IPS:{},NW_ETHERNET_CARD:{},NW_FORWARD_TO_LOCALHOST_58XX:{}",
@@ -52,6 +53,7 @@ void openhd::debug_config(const openhd::Config& config) {
       OHDUtil::str_vec_as_string(config.NW_MANUAL_FORWARDING_IPS),config.NW_ETHERNET_CARD,config.NW_FORWARD_TO_LOCALHOST_58XX
       );
 }
+
 void openhd::debug_config() {
   auto config=load_config();
   debug_config(config);

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -92,7 +92,7 @@ static std::optional<std::pair<PlatformType,BoardType>> detect_raspberrypi(){
   const std::string raspberry_identifier = result[1];
   if(raspberry_identifier == "0000")
   {
-    std::cout<<"identifier:{"<<raspberry_identifier<<"} is not raspberry pi\n";
+    openhd::log::get_default()->debug("Pi identifier:[{}] is not raspberry pi",raspberry_identifier);
     return {};
   }
   openhd::log::get_default()->debug("Pi identifier:[{}]",raspberry_identifier);

--- a/OpenHD/ohd_common/test/test_logging.cpp
+++ b/OpenHD/ohd_common/test/test_logging.cpp
@@ -1,0 +1,11 @@
+//
+// Created by consti10 on 19.03.23.
+//
+
+#include "openhd_spdlog.h"
+
+int main(int argc, char *argv[]) {
+  openhd::log::get_default()->debug("Example debug");
+  openhd::log::get_default()->warn("Example warn");
+  return 0;
+}

--- a/OpenHD/ohd_interface/CMakeLists.txt
+++ b/OpenHD/ohd_interface/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_subdirectory(../ohd_common commonlib EXCLUDE_FROM_ALL)
 
 # Build and include wifibroadcast
+set(WB_ENABLE_SIMD_OPTIMIZATIONS OFF)
 include(../lib/wifibroadcast/WBLib.cmake)
 
 add_library(OHDInterfaceLib STATIC) # initialized below

--- a/OpenHD/ohd_interface/inc/ethernet_hotspot.h
+++ b/OpenHD/ohd_interface/inc/ethernet_hotspot.h
@@ -8,6 +8,7 @@
 #include <openhd_external_device.hpp>
 #include <openhd_settings_imp.hpp>
 #include <string>
+#include <thread>
 
 #include "ethernet_hotspot_settings.h"
 

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -68,6 +68,7 @@ WBLink::WBLink(OHDProfile profile,OHDPlatform platform,std::vector<WiFiCard> bro
 }
 
 WBLink::~WBLink() {
+  m_console->debug("WBLink::~WBLink() begin");
   if(m_opt_action_handler){
     m_opt_action_handler->action_wb_link_scan_channels_register(nullptr);
   }
@@ -84,6 +85,7 @@ WBLink::~WBLink() {
   for(const auto& card: m_broadcast_cards){
     wifi::commandhelper::nmcli_set_device_managed_status(card.device_name, true);
   }
+  m_console->debug("WBLink::~WBLink() end");
 }
 
 void WBLink::takeover_cards_monitor_mode() {

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -1,6 +1,7 @@
 #include "wifi_card_discovery.h"
 
 #include <regex>
+#include <thread>
 
 #include "openhd_spdlog.h"
 #include "openhd_util.h"

--- a/OpenHD/ohd_telemetry/CMakeLists.txt
+++ b/OpenHD/ohd_telemetry/CMakeLists.txt
@@ -9,14 +9,6 @@ add_library(OHDTelemetryLib::OHDTelemetryLib ALIAS OHDTelemetryLib)
 # Only needed when building this submodule manually
 add_subdirectory(../ohd_common commonlib EXCLUDE_FROM_ALL)
 
-# from https://github.com/alexott/boost-asio-examples/blob/master/CMakeLists.txt
-# Find and include boost
-# Changed according to https://cliutils.gitlab.io/modern-cmake/chapters/packages/Boost.html
-SET(Boost_USE_STATIC_LIBS ON)
-find_package(Boost REQUIRED COMPONENTS filesystem)
-message(STATUS "Boost version: ${Boost_VERSION}")
-target_link_libraries(OHDTelemetryLib PRIVATE Boost::filesystem)
-
 find_package(Threads REQUIRED)
 target_link_libraries(OHDTelemetryLib PUBLIC Threads::Threads)
 

--- a/OpenHD/ohd_telemetry/CMakeLists.txt
+++ b/OpenHD/ohd_telemetry/CMakeLists.txt
@@ -12,7 +12,7 @@ add_subdirectory(../ohd_common commonlib EXCLUDE_FROM_ALL)
 # from https://github.com/alexott/boost-asio-examples/blob/master/CMakeLists.txt
 # Find and include boost
 # Changed according to https://cliutils.gitlab.io/modern-cmake/chapters/packages/Boost.html
-SET(Boost_USE_STATIC_LIBS OFF)
+SET(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS filesystem)
 message(STATUS "Boost version: ${Boost_VERSION}")
 target_link_libraries(OHDTelemetryLib PRIVATE Boost::filesystem)

--- a/OpenHD/ohd_telemetry/CMakeLists.txt
+++ b/OpenHD/ohd_telemetry/CMakeLists.txt
@@ -116,9 +116,6 @@ target_compile_options(mavlink INTERFACE -Wno-address-of-packed-member -Wno-cast
 target_include_directories(mavlink INTERFACE ../lib/mavlink-headers/mavlink/v2.0)
 target_link_libraries(OHDTelemetryLib PUBLIC mavlink)
 
-# Note: We do not need wifibroadcast as a whole here, we can get the header-only files.
-target_include_directories(OHDTelemetryLib PUBLIC ../lib/wifibroadcast/src)
-
 # All the test files for development
 add_executable(test_serial_endpoint tests/test_serial_endpoint.cpp)
 target_link_libraries(test_serial_endpoint OHDTelemetryLib)

--- a/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/MEndpoint.h
@@ -14,7 +14,8 @@
 
 #include "../mav_helper.h"
 #include "../mav_include.h"
-#include "HelperSources/TimeHelper.hpp"
+// dirty, pull in header only
+#include "../../../lib/wifibroadcast/src/HelperSources/TimeHelper.hpp"
 #include "openhd_spdlog.h"
 
 // Mavlink Endpoint

--- a/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint2.h
+++ b/OpenHD/ohd_telemetry/src/endpoints/UDPEndpoint2.h
@@ -7,8 +7,8 @@
 
 #include <map>
 #include <thread>
-
-#include "HelperSources/SocketHelper.hpp"
+// dirty, pull in header only
+#include "../../../lib/wifibroadcast/src/HelperSources/SocketHelper.hpp"
 #include "MEndpoint.h"
 
 /**

--- a/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.h
+++ b/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.h
@@ -12,10 +12,10 @@
 #include <vector>
 
 #include "../mav_helper.h"
-#include "HelperSources/SocketHelper.hpp"
+// dirty, pull in header only
+#include "../../../lib/wifibroadcast/src/HelperSources/SocketHelper.hpp"
 #include "OnboardComputerStatusProvider.h"
 #include "StatusTextAccumulator.h"
-#include "WBReceiverStats.hpp"
 #include "openhd_action_handler.hpp"
 #include "openhd_link_statistics.hpp"
 #include "openhd_platform.h"

--- a/OpenHD/ohd_telemetry/src/internal/StatusTextAccumulator.h
+++ b/OpenHD/ohd_telemetry/src/internal/StatusTextAccumulator.h
@@ -6,8 +6,8 @@
 #define OPENHD_OPENHD_OHD_TELEMETRY_SRC_INTERNAL_STATUSTEXT_H_
 
 #include <queue>
-
-#include "HelperSources/SocketHelper.hpp"
+// dirty, pull in header only
+#include "../../../lib/wifibroadcast/src/HelperSources/SocketHelper.hpp"
 #include "mav_include.h"
 #include "openhd_spdlog.h"
 #include "openhd_udp_log.h"

--- a/OpenHD/ohd_video/inc/openhd-rpi-os-configure-vendor-cam.hpp
+++ b/OpenHD/ohd_video/inc/openhd-rpi-os-configure-vendor-cam.hpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <thread>
 
 #include "openhd_platform.h"
 #include "openhd_spdlog.h"


### PR DESCRIPTION
1) Reduced wifibroadcast SIMD requirements from AVX2 to SSSE3 to support more "old" intel hardware.
2) boost - link statically
3) refactor cmake a bit