### PR TITLE
default to MCS index 1 for the uplink (e.g. when injecting from the gnd) & hw supports it.

### DIFF
--- a/OpenHD/ohd_interface/inc/wb_link_helper.h
+++ b/OpenHD/ohd_interface/inc/wb_link_helper.h
@@ -21,12 +21,6 @@ bool disable_all_frequency_checks();
 
 /**
  * @param m_broadcast_cards the cards to check capabilities from
- * @return true if all cards support setting an MCS index,
- */
-bool cards_support_setting_mcs_index(const std::vector<WiFiCard>& m_broadcast_cards);
-
-/**
- * @param m_broadcast_cards the cards to check capabilities from
  * @return  true if all cards support setting the channel width (otherwise 20Mhz default is fixed (most likely))
  */
 bool cards_support_setting_channel_width(const std::vector<WiFiCard>& m_broadcast_cards);

--- a/OpenHD/ohd_interface/inc/wifi_card.h
+++ b/OpenHD/ohd_interface/inc/wifi_card.h
@@ -80,13 +80,24 @@ static bool wifi_card_supports_variable_mcs(const WiFiCard& wifi_card){
   if(wifi_card.type==WiFiCardType::Realtek8812au)return true;
   return false;
 }
+/**
+ * @param m_broadcast_cards the cards to check capabilities from
+ * @return true if all cards support setting an MCS index,
+ */
+static bool all_cards_support_setting_mcs_index(const std::vector<WiFiCard>& m_broadcast_cards){
+  for(const auto& card: m_broadcast_cards){
+	if(!wifi_card_supports_variable_mcs(card)){
+	  return false;
+	}
+  }
+  return true;
+}
 
 // Only RTL8812au so far supports a 40Mhz channel width (and there it is also discouraged to use it)
 static bool wifi_card_supports_40Mhz_channel_width(const WiFiCard& wifi_card){
   if(wifi_card.type==WiFiCardType::Realtek8812au)return true;
   return false;
 }
-
 
 static bool wifi_card_supports_frequency(const WiFiCard& wifi_card,const uint32_t frequency){
   const auto channel_opt=openhd::channel_from_frequency(frequency);

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -40,9 +40,19 @@ WBLink::WBLink(OHDProfile profile,OHDPlatform platform,std::vector<WiFiCard> bro
     exit(1);
   }
   // this fetches the last settings, otherwise creates default ones
-  m_settings =std::make_unique<openhd::WBStreamsSettingsHolder>(platform,m_broadcast_cards);
+  m_settings =std::make_unique<openhd::WBStreamsSettingsHolder>(m_platform,m_profile,m_broadcast_cards);
   // fixup any settings coming from a previous use with a different wifi card (e.g. if user swaps around cards)
   openhd::wb::fixup_unsupported_settings(*m_settings,m_broadcast_cards,m_console);
+  if(m_profile.is_ground()){
+	if(all_cards_support_setting_mcs_index(m_broadcast_cards) &&
+	m_settings->unsafe_get_settings().wb_mcs_index!=openhd::DEFAULT_GND_UPLINK_MCS_INDEX){
+	  // We always use a MCS index of X for the uplink, since (compared to the down / video link) it requires a negligible amount of bandwidth
+	  // and for those using RC over OpenHD, we have the benefit that the range of RC is "more" than the range for video
+	  m_console->warn("GND-fixing MCS to {}",openhd::DEFAULT_GND_UPLINK_MCS_INDEX);
+	  m_settings->unsafe_get_settings().wb_mcs_index=openhd::DEFAULT_GND_UPLINK_MCS_INDEX;
+	  m_settings->persist();
+	}
+  }
   takeover_cards_monitor_mode();
   configure_cards();
   configure_telemetry();
@@ -319,7 +329,7 @@ bool WBLink::set_mcs_index(int mcs_index) {
     m_console->warn("Invalid mcs index{}",mcs_index);
     return false;
   }
-  if(!openhd::wb::cards_support_setting_mcs_index(m_broadcast_cards)){
+  if(!all_cards_support_setting_mcs_index(m_broadcast_cards)){
     m_console->warn("Cannot change mcs index, it is fixed for at least one of the used cards");
     return false;
   }

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -43,14 +43,15 @@ WBLink::WBLink(OHDProfile profile,OHDPlatform platform,std::vector<WiFiCard> bro
   m_settings =std::make_unique<openhd::WBStreamsSettingsHolder>(m_platform,m_profile,m_broadcast_cards);
   // fixup any settings coming from a previous use with a different wifi card (e.g. if user swaps around cards)
   openhd::wb::fixup_unsupported_settings(*m_settings,m_broadcast_cards,m_console);
+  // We default to the right setting (clean install) but only print a warning, don't actively fix it.
   if(m_profile.is_ground()){
 	if(all_cards_support_setting_mcs_index(m_broadcast_cards) &&
 	m_settings->unsafe_get_settings().wb_mcs_index!=openhd::DEFAULT_GND_UPLINK_MCS_INDEX){
 	  // We always use a MCS index of X for the uplink, since (compared to the down / video link) it requires a negligible amount of bandwidth
 	  // and for those using RC over OpenHD, we have the benefit that the range of RC is "more" than the range for video
-	  m_console->warn("GND-fixing MCS to {}",openhd::DEFAULT_GND_UPLINK_MCS_INDEX);
-	  m_settings->unsafe_get_settings().wb_mcs_index=openhd::DEFAULT_GND_UPLINK_MCS_INDEX;
-	  m_settings->persist();
+	  m_console->warn("GND recommended MCS{}",openhd::DEFAULT_GND_UPLINK_MCS_INDEX);
+	  //m_settings->unsafe_get_settings().wb_mcs_index=openhd::DEFAULT_GND_UPLINK_MCS_INDEX;
+	  //m_settings->persist();
 	}
   }
   takeover_cards_monitor_mode();

--- a/OpenHD/ohd_interface/src/wb_link_helper.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_helper.cpp
@@ -22,17 +22,6 @@ bool openhd::wb::cards_support_setting_channel_width(
   return true;
 }
 
-bool openhd::wb::cards_support_setting_mcs_index(
-    const std::vector<WiFiCard>& m_broadcast_cards) {
-  for(const auto& card: m_broadcast_cards){
-    if(!wifi_card_supports_variable_mcs(card)){
-      return false;
-    }
-  }
-  return true;
-}
-
-
 bool openhd::wb::cards_support_frequency(
     uint32_t frequency,
     const std::vector<WiFiCard>& m_broadcast_cards,
@@ -71,7 +60,7 @@ void openhd::wb::fixup_unsupported_settings(
       settings.persist();
     }
   }
-  if(!cards_support_setting_mcs_index(m_broadcast_cards)){
+  if(!all_cards_support_setting_mcs_index(m_broadcast_cards)){
     m_console->warn("Card {} doesn't support setting MCS index, applying defaults",first_card.device_name);
     // cards that do not support changing the mcs index are always fixed to mcs3 on openhd drivers
     settings.unsafe_get_settings().wb_mcs_index=3;


### PR DESCRIPTION
also, print warning to the user when gnd doesn't do 1