### PR TITLE
Enable mavlink tcp server on both air and ground

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_external_device.hpp
+++ b/OpenHD/ohd_common/inc/openhd_external_device.hpp
@@ -87,6 +87,8 @@ class ExternalDeviceManager{
         return;
       }
       // New external device connected
+      // log such that the message is shown in QOpenHD
+      openhd::log::log_via_mavlink(5,"External device connected");
       m_curr_ext_devices[id]=external_device;
       for(auto& cb:m_callbacks){
         cb(external_device, true);
@@ -96,6 +98,8 @@ class ExternalDeviceManager{
         openhd::log::get_default()->warn("Device {} does not exist",external_device.to_string());
         return;
       }
+      // warning in QOpenHD
+      openhd::log::get_default()->warn("External device disconnected");
       // existing external device disconnected
       m_curr_ext_devices.erase(id);
       for(auto& cb:m_callbacks){

--- a/OpenHD/ohd_common/inc/openhd_spdlog.h
+++ b/OpenHD/ohd_common/inc/openhd_spdlog.h
@@ -26,6 +26,10 @@ std::shared_ptr<spdlog::logger> create_or_get(const std::string& logger_name);
 // but sometimes you just don't care about that.
 std::shared_ptr<spdlog::logger> get_default();
 
+// By default, only messages of level warn or higher are forwarded via mavlink (and then shown in QOpenHD).
+// Use this if you want to show a non-warning message in QOpenHD.
+void log_via_mavlink(int level,std::string message);
+
 // Helper to not spam the console with (error) messages, but rather have them sent out with a minimum amount
 // of time in between messages
 /*class LimitedRateLogger{

--- a/OpenHD/ohd_common/src/openhd_spdlog.cpp
+++ b/OpenHD/ohd_common/src/openhd_spdlog.cpp
@@ -67,3 +67,7 @@ std::shared_ptr<spdlog::logger> openhd::log::create_or_get(
 std::shared_ptr<spdlog::logger> openhd::log::get_default() {
   return create_or_get("default");
 }
+
+void openhd::log::log_via_mavlink(int level, std::string message) {
+  openhd::log::udp::ohd_log(static_cast<udp::STATUS_LEVEL>(level),message);
+}

--- a/OpenHD/ohd_interface/inc/wifi_card.h
+++ b/OpenHD/ohd_interface/inc/wifi_card.h
@@ -10,10 +10,7 @@
 #include "validate_settings_helper.h"
 #include "wifi_channel.h"
 
-// R.n (20.08) this class can be summarized as following:
-// 1) WifiCard: Capabilities of a detected wifi card, no persistent settings
-// 2) WifiCardSettings: What to use the wifi card for, !! no frequency settings or similar. !! (note that freq and more are figured out /stored
-// by the different interface types that use wifi, e.g. WBStreams or WifiHotspot
+// After discovery, the capabilities of a WiFi-Card are immutable !
 
 enum class WiFiCardType {
   Unknown = 0,

--- a/OpenHD/ohd_interface/src/usb_tether_listener.cpp
+++ b/OpenHD/ohd_interface/src/usb_tether_listener.cpp
@@ -49,6 +49,12 @@ void USBTetherListener::connectOnce() {
         found_device= true;
         break ;
       }
+      // should never show up as usb1, but whatever, listen for it too
+      if(OHDUtil::str_equal(device,"usb1")){
+        connected_device_name=device;
+        found_device= true;
+        break ;
+      }
       if(OHDUtil::str_equal(device,"enx023b63011a79")){
         connected_device_name=device;
         found_device= true;

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -30,8 +30,8 @@ AirTelemetry::AirTelemetry(OHDPlatform platform,std::shared_ptr<openhd::ActionHa
   m_generic_mavlink_param_provider->add_params(get_all_settings());
   m_components.push_back(m_generic_mavlink_param_provider);
   //TODO should we really enable a mavlink server on air ?
-  //m_tcp_server=std::make_unique<TCPEndpoint>(TCPEndpoint::Config{TCPEndpoint::DEFAULT_PORT});//1445
-  m_tcp_server= nullptr;
+  m_tcp_server=std::make_unique<TCPEndpoint>(TCPEndpoint::Config{TCPEndpoint::DEFAULT_PORT});//1445
+  //m_tcp_server= nullptr;
   if(m_tcp_server){
     m_tcp_server->registerCallback([this](std::vector<MavlinkMessage> messages) {
       // Technically not correct, but works

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -28,8 +28,8 @@ GroundTelemetry::GroundTelemetry(OHDPlatform platform,
   m_gcs_endpoint->registerCallback([this](std::vector<MavlinkMessage> messages) {
     on_messages_ground_station_clients(messages);
   });
-  //m_tcp_server=std::make_unique<TCPEndpoint>(TCPEndpoint::Config{TCPEndpoint::DEFAULT_PORT});//1445
-  m_tcp_server= nullptr;
+  m_tcp_server=std::make_unique<TCPEndpoint>(TCPEndpoint::Config{TCPEndpoint::DEFAULT_PORT});//1445
+  //m_tcp_server= nullptr;
   if(m_tcp_server){
     m_tcp_server->registerCallback([this](std::vector<MavlinkMessage> messages) {
       on_messages_ground_station_clients(messages);


### PR DESCRIPTION
This nicely allows us to run a secondary GCS on the ground station (e.g. x86 users who want QOpenHD and mission planner simultaneously) and also in theory, external devices can connect via TCP if they want to (e.g. wifi hotspot).