### PR TITLE
RC Stuff

### DIFF
--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -218,12 +218,12 @@ void GroundTelemetry::remove_external_ground_station_ip(const openhd::ExternalDe
 
 std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
   std::vector<openhd::Setting> ret{};
-  auto c_config_boot_as_air=[](std::string,int value){
-    return openhd::tmp::handle_telemetry_change(value);
-  };
   // and this allows an advanced user to change its air unit to a ground unit
   // only expose this setting if OpenHD uses the file workaround to figure out air or ground.
   if(openhd::tmp::file_air_or_ground_exists()){
+    auto c_config_boot_as_air=[](std::string,int value){
+      return openhd::tmp::handle_telemetry_change(value);
+    };
     ret.push_back(openhd::Setting{"CONFIG_BOOT_AIR",openhd::IntSetting {0,c_config_boot_as_air}});
   }
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -51,8 +51,8 @@ GroundTelemetry::GroundTelemetry(OHDPlatform platform,
           auto msg_for_gcs=rc_channels_override_from_array(OHD_SYS_ID_GROUND,0,channels,0,0);
           send_messages_ground_station_clients({msg_for_gcs});
     },
-        m_gnd_settings->get_settings().rc_over_joystick_update_rate_hz,JoystickReader::get_default_channel_mapping());
-    const auto parsed=JoystickReader::convert_string_to_channel_mapping(
+        m_gnd_settings->get_settings().rc_over_joystick_update_rate_hz,openhd::get_default_channel_mapping());
+    const auto parsed=openhd::convert_string_to_channel_mapping(
         m_gnd_settings->get_settings().rc_channel_mapping);
     if(parsed==std::nullopt){
       m_console->warn("Not a valid channel mapping,using default");
@@ -256,7 +256,7 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
                                                                      c_rc_over_joystick_update_rate_hz}});
     auto c_rc_over_joystick_channel_mapping=[this](std::string,std::string value){
       m_console->debug("Change channel mapping {}",value);
-      const auto parsed=JoystickReader::convert_string_to_channel_mapping(value);
+      const auto parsed=openhd::convert_string_to_channel_mapping(value);
       if(parsed==std::nullopt){
         m_console->warn("Not a valid channel mapping");
         return false;

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -57,7 +57,7 @@ GroundTelemetry::GroundTelemetry(OHDPlatform platform,
     if(parsed==std::nullopt){
       m_console->warn("Not a valid channel mapping,using default");
     }else{
-      m_rc_joystick_sender->update_channel_maping(parsed.value());
+      m_rc_joystick_sender->update_channel_mapping(parsed.value());
     }
     m_console->info("Joystick enabled");
   }else{
@@ -261,7 +261,7 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
         m_console->warn("Not a valid channel mapping");
         return false;
       }
-      m_rc_joystick_sender->update_channel_maping(parsed.value());
+      m_rc_joystick_sender->update_channel_mapping(parsed.value());
       m_gnd_settings->unsafe_get_settings().rc_channel_mapping=value;
       m_gnd_settings->persist();
       return true;

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -232,8 +232,9 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
       if(!openhd::telemetry::ground::valid_joystick_update_rate(value))return false;
       m_gnd_settings->unsafe_get_settings().rc_over_joystick_update_rate_hz=value;
       m_gnd_settings->persist();
-      assert(m_rc_joystick_sender);
-      m_rc_joystick_sender->change_update_rate(value);
+      if(m_rc_joystick_sender){
+        m_rc_joystick_sender->change_update_rate(value);
+      }
       return true;
     };
     ret.push_back(openhd::Setting{"RC_UPDATE_HZ",openhd::IntSetting{static_cast<int>(
@@ -246,9 +247,11 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
         m_console->warn("Not a valid channel mapping");
         return false;
       }
-      m_rc_joystick_sender->update_channel_mapping(parsed.value());
       m_gnd_settings->unsafe_get_settings().rc_channel_mapping=value;
       m_gnd_settings->persist();
+      if(m_rc_joystick_sender){
+        m_rc_joystick_sender->update_channel_mapping(parsed.value());
+      }
       return true;
     };
     ret.push_back(openhd::Setting{"RC_CHAN_MAP",openhd::StringSetting {m_gnd_settings->get_settings().rc_channel_mapping,

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -51,15 +51,9 @@ GroundTelemetry::GroundTelemetry(OHDPlatform platform,
       auto msg_for_gcs=rc_channels_override_from_array(OHD_SYS_ID_GROUND,0,channels,0,0);
       send_messages_ground_station_clients({msg_for_gcs});
     };
+    auto mapping_parsed=openhd::convert_string_to_channel_mapping_or_default(m_gnd_settings->get_settings().rc_channel_mapping);
     m_rc_joystick_sender=std::make_unique<RcJoystickSender>(cb,
-        m_gnd_settings->get_settings().rc_over_joystick_update_rate_hz,openhd::get_default_channel_mapping());
-    const auto parsed=openhd::convert_string_to_channel_mapping(
-        m_gnd_settings->get_settings().rc_channel_mapping);
-    if(parsed==std::nullopt){
-      m_console->warn("Not a valid channel mapping,using default");
-    }else{
-      m_rc_joystick_sender->update_channel_mapping(parsed.value());
-    }
+        m_gnd_settings->get_settings().rc_over_joystick_update_rate_hz,mapping_parsed);
     m_console->info("Joystick enabled");
   }else{
     m_console->info("Joystick disabled");

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -74,6 +74,10 @@ class GroundTelemetry :public MavlinkSystem{
   void send_messages_ground_station_clients(const std::vector<MavlinkMessage>& messages);
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
+#ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
+  void enable_joystick();
+  void disable_joystick();
+#endif //OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
  private:
   std::shared_ptr<spdlog::logger> m_console;
   std::unique_ptr<openhd::telemetry::ground::SettingsHolder> m_gnd_settings;
@@ -92,8 +96,7 @@ class GroundTelemetry :public MavlinkSystem{
   std::shared_ptr<openhd::ExternalDeviceManager> m_ext_device_manager;
   //
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
-  //std::unique_ptr<JoystickReader> m_joystick_reader;
-  std::unique_ptr<RcJoystickSender> m_rc_joystick_sender;
+  std::unique_ptr<RcJoystickSender> m_rc_joystick_sender= nullptr;
 #endif
 };
 

--- a/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.h
@@ -18,7 +18,7 @@ static constexpr auto UART_CONNECTION_TYPE_DISABLE="";
 struct Settings{
   bool enable_rc_over_joystick=false;
   int rc_over_joystick_update_rate_hz=30;
-  std::string rc_channel_mapping="0,1,2,3,4,5,6,7";
+  std::string rc_channel_mapping="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18";
   // This is for outputting FC mavlink data via serial on the ground station
   std::string gnd_uart_connection_type=UART_CONNECTION_TYPE_DISABLE;
   int gnd_uart_baudrate=115200;

--- a/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
+++ b/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
@@ -57,7 +57,7 @@ static CHAN_MAP convert_string_to_channel_mapping_or_default(const std::string& 
   if(ret.has_value()){
     return ret.value();
   }
-  openhd::log::get_default()->warn("Invalid channel mapping {}",input);
+  openhd::log::get_default()->warn("Invalid channel mapping [{}],using default",input);
   return get_default_channel_mapping();
 }
 

--- a/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
+++ b/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
@@ -57,6 +57,7 @@ static CHAN_MAP convert_string_to_channel_mapping_or_default(const std::string& 
   if(ret.has_value()){
     return ret.value();
   }
+  openhd::log::get_default()->warn("Invalid channel mapping {}",input);
   return get_default_channel_mapping();
 }
 

--- a/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
+++ b/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
@@ -57,7 +57,9 @@ static std::array<uint16_t,18> remap_channels(const std::array<uint16_t,18>& cha
   for(int i=0;i<18;i++){
     if(i<8){
       const auto channel_to_use=chan_map[i];
-      ret[i]=channels[channel_to_use];
+      if(i>=0 && i < channels.size()){
+        ret[i]=channels[channel_to_use];
+      }
     }else{
       ret[i]=channels[i];
     }

--- a/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
+++ b/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
@@ -55,9 +55,10 @@ static CHAN_MAP get_default_channel_mapping() {
 static std::array<uint16_t,18> remap_channels(const std::array<uint16_t,18>& channels,const CHAN_MAP& chan_map){
   std::array<uint16_t,18> ret{};
   for(int i=0;i<18;i++){
-    if(i<8){
+    // Better be safe than sorry regarding bounds checking (even though we shouldn't ever be out of bounds)
+    if(i<chan_map.size()){
       const auto channel_to_use=chan_map[i];
-      if(i>=0 && i < channels.size()){
+      if(channel_to_use>=0 && channel_to_use < channels.size()){
         ret[i]=channels[channel_to_use];
       }
     }else{

--- a/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
+++ b/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
@@ -1,0 +1,70 @@
+//
+// Created by consti10 on 06.05.23.
+//
+
+#ifndef OPENHD_CHANNELMAPPINGUTIL_H
+#define OPENHD_CHANNELMAPPINGUTIL_H
+
+#include <array>
+#include <string>
+#include "openhd_spdlog.h"
+
+// Util methods for simple channel mapping, where each channel's input can be defined by the user.
+namespace openhd{
+
+static constexpr auto N_MAPPED_CHANNELS=8;
+
+// Channel mapping: just look at the default to understand ;)
+using CHAN_MAP=std::array<int,N_MAPPED_CHANNELS>;
+
+static bool validate_channel_mapping(const CHAN_MAP& chan_map) {
+  for(const auto& el:chan_map){ // NOLINT(readability-use-anyofallof)
+    if(el<0 || el>=N_MAPPED_CHANNELS){
+      openhd::log::get_default()->warn("Channel mapping not a valid value{}",el);
+      return false;
+    }
+  }
+  return true;
+}
+
+static std::optional<CHAN_MAP>
+convert_string_to_channel_mapping(const std::string& input) {
+  auto split_into_substrings=OHDUtil::split_into_substrings(input,',');
+  if(split_into_substrings.size()!=N_MAPPED_CHANNELS){
+    openhd::log::get_default()->warn("Channel mapping wrong n channels:{}",split_into_substrings.size());
+    return std::nullopt;
+  }
+  CHAN_MAP parsed_as_int{};
+  for(int i=0;i<N_MAPPED_CHANNELS;i++){
+    const auto as_int=OHDUtil::string_to_int(split_into_substrings[i]);
+    if(!as_int.has_value())return std::nullopt;
+    parsed_as_int[i]=as_int.value();
+  }
+  if(!validate_channel_mapping(parsed_as_int))return std::nullopt;
+  return parsed_as_int;
+}
+
+static CHAN_MAP get_default_channel_mapping() {
+  CHAN_MAP ret{};
+  for(int i=0;i<N_MAPPED_CHANNELS;i++){
+    ret[i]=i;
+  }
+  return ret;
+}
+
+static std::array<uint16_t,18> remap_channels(const std::array<uint16_t,18>& channels,const CHAN_MAP& chan_map){
+  std::array<uint16_t,18> ret{};
+  for(int i=0;i<18;i++){
+    if(i<8){
+      const auto channel_to_use=chan_map[i];
+      ret[i]=channels[channel_to_use];
+    }else{
+      ret[i]=channels[i];
+    }
+  }
+  return ret;
+}
+
+
+}
+#endif  // OPENHD_CHANNELMAPPINGUTIL_H

--- a/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
+++ b/OpenHD/ohd_telemetry/src/rc/ChannelMappingUtil.hpp
@@ -52,6 +52,15 @@ static CHAN_MAP get_default_channel_mapping() {
   return ret;
 }
 
+static CHAN_MAP convert_string_to_channel_mapping_or_default(const std::string& input){
+  auto ret= convert_string_to_channel_mapping(input);
+  if(ret.has_value()){
+    return ret.value();
+  }
+  return get_default_channel_mapping();
+}
+
+
 static std::array<uint16_t,18> remap_channels(const std::array<uint16_t,18>& channels,const CHAN_MAP& chan_map){
   std::array<uint16_t,18> ret{};
   for(int i=0;i<18;i++){

--- a/OpenHD/ohd_telemetry/src/rc/JoystickReader.h
+++ b/OpenHD/ohd_telemetry/src/rc/JoystickReader.h
@@ -16,6 +16,7 @@
 #include "openhd_util.h"
 
 /**
+ * Hides away all the (nasty) "SDL Stuff"
  * The Paradigm of this class is similar to how for example external devices
  * are handled in general in OpenHD: If the user says he wants RC joystick
  * control, try to open the joystick and read data, re-connect if anything goes

--- a/OpenHD/ohd_telemetry/src/rc/JoystickReader.h
+++ b/OpenHD/ohd_telemetry/src/rc/JoystickReader.h
@@ -44,20 +44,12 @@ class JoystickReader {
     // the name of the joystick
     std::string joystick_name="unknown";
   };
-  // Channel mapping: just look at the default to understand ;)
-  using CHAN_MAP=std::array<int,N_CHANNELS_RESERVED_FOR_AXES>;
-  explicit JoystickReader(CHAN_MAP chan_map);
+  explicit JoystickReader();
   ~JoystickReader();
   // Get the current "state", thread-safe
   CurrChannelValues get_current_state();
-  // update the channel mapping, thread-safe
-  void update_channel_maping(const CHAN_MAP& new_chan_map);
   // For debugging
   static std::string curr_state_to_string(const CurrChannelValues& curr_channel_values);
-  // (custom) channel mapping - rudimentary, since one can do that just as well on the FC
-  static std::optional<CHAN_MAP> convert_string_to_channel_mapping(const std::string& input);
-  static bool validate_channel_mapping(const CHAN_MAP& chan_map);
-  static std::array<int,N_CHANNELS_RESERVED_FOR_AXES> get_default_channel_mapping();
  private:
   void loop();
   void connect_once_and_read_until_error();
@@ -71,12 +63,9 @@ class JoystickReader {
   std::mutex m_curr_values_mutex;
   CurrChannelValues m_curr_values;
   std::shared_ptr<spdlog::logger> m_console;
-  std::mutex m_chan_map_mutex;
-  CHAN_MAP m_chan_map{};
  private:
   void write_matching_axis(std::array<uint16_t,JoystickReader::N_CHANNELS>& rc_data,uint8_t axis_index,int16_t value);
   static void write_matching_button(std::array<uint16_t,18>&rc_data,uint8_t button,bool up);
-  std::optional<int> get_mapped_axis(int axis_index);
 };
 
 #endif //OPENHD_OPENHD_OHD_TELEMETRY_SRC_RC_JOYSTICKREADER_H_

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
@@ -21,7 +21,7 @@ void RcJoystickSender::send_data_until_terminate() {
     // We only send data if the joystick is in the connected state
     // Otherwise, we just stop sending data, which should result in a failsafe at the FC.
     if(curr.considered_connected){
-      // map the channels
+      // map all the channels before we send them out
       auto curr_mapping=get_current_channel_mapping();
       auto mapped_channels=openhd::remap_channels(curr.values,curr_mapping);
       m_cb(mapped_channels);

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
@@ -6,9 +6,9 @@
 
 #include <utility>
 
-RcJoystickSender::RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,JoystickReader::CHAN_MAP chan_map):
+RcJoystickSender::RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,openhd::CHAN_MAP chan_map):
 m_cb(std::move(cb)),m_delay_in_milliseconds(1000/update_rate_hz) {
-  m_joystick_reader=std::make_unique<JoystickReader>(chan_map);
+  m_joystick_reader=std::make_unique<JoystickReader>();
   m_send_data_thread=std::make_unique<std::thread>([this] {
     send_data_until_terminate();
   });
@@ -42,8 +42,8 @@ void RcJoystickSender::change_update_rate(int update_rate_hz) {
   }
 }
 
-void RcJoystickSender::update_channel_maping(const JoystickReader::CHAN_MAP& new_chan_map) {
-  m_joystick_reader->update_channel_maping(new_chan_map);
+void RcJoystickSender::update_channel_maping(const openhd::CHAN_MAP& new_chan_map) {
+  //m_joystick_reader->update_channel_maping(new_chan_map);
 }
 
 #endif //OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
@@ -43,7 +43,16 @@ void RcJoystickSender::change_update_rate(int update_rate_hz) {
 }
 
 void RcJoystickSender::update_channel_maping(const openhd::CHAN_MAP& new_chan_map) {
-  //m_joystick_reader->update_channel_maping(new_chan_map);
+  std::lock_guard<std::x> guard(m_chan_map_mutex);
+  if(!openhd::validate_channel_mapping(new_chan_map)){
+    return;
+  }
+  m_chan_map=new_chan_map;
+}
+
+openhd::CHAN_MAP RcJoystickSender::get_current_channel_mapping() {
+  std::lock_guard<std::mutex> guard(m_chan_map_mutex);
+  return m_chan_map;
 }
 
 #endif //OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
@@ -6,8 +6,10 @@
 
 #include <utility>
 
-RcJoystickSender::RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,openhd::CHAN_MAP chan_map):
-m_cb(std::move(cb)),m_delay_in_milliseconds(1000/update_rate_hz),m_chan_map(chan_map) {
+RcJoystickSender::RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,openhd::CHAN_MAP chan_map)
+    : m_cb(std::move(cb)),
+      m_delay_in_milliseconds(1000/update_rate_hz),
+      m_chan_map(chan_map) {
   if(!openhd::validate_channel_mapping(chan_map)){
     openhd::log::get_default()->warn("Invalid channel mapping");
     m_chan_map=openhd::get_default_channel_mapping();

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
@@ -25,6 +25,7 @@ void RcJoystickSender::send_data_until_terminate() {
     // Otherwise, we just stop sending data, which should result in a failsafe at the FC.
     if(curr.considered_connected){
       // map all the channels before we send them out
+      // mapping might change at any time, and the compute overhead - well, we are not on a microcontroller ;)
       auto curr_mapping=get_current_channel_mapping();
       auto mapped_channels=openhd::remap_channels(curr.values,curr_mapping);
       m_cb(mapped_channels);

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
@@ -46,7 +46,7 @@ void RcJoystickSender::change_update_rate(int update_rate_hz) {
   }
 }
 
-void RcJoystickSender::update_channel_maping(const openhd::CHAN_MAP& new_chan_map) {
+void RcJoystickSender::update_channel_mapping(const openhd::CHAN_MAP& new_chan_map) {
   std::lock_guard<std::mutex> guard(m_chan_map_mutex);
   if(!openhd::validate_channel_mapping(new_chan_map)){
     return;

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.cpp
@@ -8,6 +8,7 @@
 
 RcJoystickSender::RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,openhd::CHAN_MAP chan_map):
 m_cb(std::move(cb)),m_delay_in_milliseconds(1000/update_rate_hz) {
+  m_chan_map=openhd::get_default_channel_mapping();
   m_joystick_reader=std::make_unique<JoystickReader>();
   m_send_data_thread=std::make_unique<std::thread>([this] {
     send_data_until_terminate();
@@ -20,7 +21,10 @@ void RcJoystickSender::send_data_until_terminate() {
     // We only send data if the joystick is in the connected state
     // Otherwise, we just stop sending data, which should result in a failsafe at the FC.
     if(curr.considered_connected){
-      m_cb(curr.values);
+      // map the channels
+      auto curr_mapping=get_current_channel_mapping();
+      auto mapped_channels=openhd::remap_channels(curr.values,curr_mapping);
+      m_cb(mapped_channels);
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(m_delay_in_milliseconds));
   }
@@ -43,7 +47,7 @@ void RcJoystickSender::change_update_rate(int update_rate_hz) {
 }
 
 void RcJoystickSender::update_channel_maping(const openhd::CHAN_MAP& new_chan_map) {
-  std::lock_guard<std::x> guard(m_chan_map_mutex);
+  std::lock_guard<std::mutex> guard(m_chan_map_mutex);
   if(!openhd::validate_channel_mapping(new_chan_map)){
     return;
   }

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
@@ -8,6 +8,7 @@
 #include "JoystickReader.h"
 #include "../mav_helper.h"
 #include <memory>
+#include <atomic>
 #include "ChannelMappingUtil.hpp"
 
 // Really simple, have a thread that send out telemetry RC data at a fixed rate
@@ -30,7 +31,8 @@ class RcJoystickSender {
   std::unique_ptr<std::thread> m_send_data_thread;
   const SEND_MESSAGE_CB m_cb;
   // Controls the update rate how often we send the rc packets to the air unit.
-  int m_delay_in_milliseconds;
+  // We can just use std::atomic for thread safety here
+  std::atomic<int> m_delay_in_milliseconds;
   bool terminate=false;
  private:
   std::mutex m_chan_map_mutex;

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
@@ -20,7 +20,7 @@ class RcJoystickSender {
   RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,openhd::CHAN_MAP chan_map);
   void change_update_rate(int update_rate_hz);
   // update the channel mapping, thread-safe
-  void update_channel_maping(const openhd::CHAN_MAP& new_chan_map);
+  void update_channel_mapping(const openhd::CHAN_MAP& new_chan_map);
   // get the current channel mapping, thread-safe
   openhd::CHAN_MAP  get_current_channel_mapping();
   ~RcJoystickSender();

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
@@ -8,6 +8,7 @@
 #include "JoystickReader.h"
 #include "../mav_helper.h"
 #include <memory>
+#include "ChannelMappingUtil.hpp"
 
 // Really simple, have a thread that send out telemetry RC data at a fixed rate
 // (we cannot just use the thread that fetches data from the joystick, at least not for now)
@@ -16,10 +17,10 @@ class RcJoystickSender {
   // This callback is called in regular intervalls with valid rc channel data as long as there is a joystick connected & well.
   // If there is something wrong with the joystick / no joystick connected this cb is not called (such that FC can do failsafe)
   typedef std::function<void(std::array<uint16_t,18> channels)> SEND_MESSAGE_CB;
-  RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,JoystickReader::CHAN_MAP chan_map);
+  RcJoystickSender(SEND_MESSAGE_CB cb,int update_rate_hz,openhd::CHAN_MAP chan_map);
   void change_update_rate(int update_rate_hz);
   // update the channel mapping, thread-safe
-  void update_channel_maping(const JoystickReader::CHAN_MAP& new_chan_map);
+  void update_channel_maping(const openhd::CHAN_MAP& new_chan_map);
   ~RcJoystickSender();
  private:
   void send_data_until_terminate();
@@ -28,6 +29,8 @@ class RcJoystickSender {
   const SEND_MESSAGE_CB m_cb;
   int m_delay_in_milliseconds;
   bool terminate=false;
+ private:
+
 };
 
 #endif  // OPENHD_OPENHD_OHD_TELEMETRY_SRC_RC_RCJOYSTICKSENDER_H_

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
@@ -21,6 +21,8 @@ class RcJoystickSender {
   void change_update_rate(int update_rate_hz);
   // update the channel mapping, thread-safe
   void update_channel_maping(const openhd::CHAN_MAP& new_chan_map);
+  // get the current channel mapping, thread-safe
+  openhd::CHAN_MAP  get_current_channel_mapping();
   ~RcJoystickSender();
  private:
   void send_data_until_terminate();
@@ -31,7 +33,8 @@ class RcJoystickSender {
   int m_delay_in_milliseconds;
   bool terminate=false;
  private:
-
+  std::mutex m_chan_map_mutex;
+  openhd::CHAN_MAP m_chan_map;
 };
 
 #endif  // OPENHD_OPENHD_OHD_TELEMETRY_SRC_RC_RCJOYSTICKSENDER_H_

--- a/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
+++ b/OpenHD/ohd_telemetry/src/rc/RcJoystickSender.h
@@ -27,6 +27,7 @@ class RcJoystickSender {
   std::unique_ptr<JoystickReader> m_joystick_reader;
   std::unique_ptr<std::thread> m_send_data_thread;
   const SEND_MESSAGE_CB m_cb;
+  // Controls the update rate how often we send the rc packets to the air unit.
   int m_delay_in_milliseconds;
   bool terminate=false;
  private:


### PR DESCRIPTION
1) Count from 1 not 0 in the user provided channel mapping string
2) Re-mapping of all 18 channels.
3) re-factoring for better separation of reading joy and remapping 
-> can now be enabled / disabled at run time
-> remapp all on each packet (immediately apply new mapping)


Since the N of channels changed, settings cannot be migrated (apply defaults from qopenhd).