### PR TITLE
Discovery changes / fixes

### DIFF
--- a/OpenHD/ohd_interface/inc/ohd_interface.h
+++ b/OpenHD/ohd_interface/inc/ohd_interface.h
@@ -64,7 +64,6 @@ class OHDInterface {
   std::vector<WiFiCard> monitor_mode_cards{};
   std::optional<WiFiCard> opt_hotspot_card=std::nullopt;
   NetworkingSettingsHolder m_nw_settings;
-  //NetworkingSettingsHolder m_nw_settings;
 };
 
 #endif //OPENHD_OPENHD_INTERFACE_H

--- a/OpenHD/ohd_interface/inc/wifi_card_discovery.h
+++ b/OpenHD/ohd_interface/inc/wifi_card_discovery.h
@@ -28,6 +28,9 @@ std::optional<WiFiCard> process_card(const std::string &interface_name);
 // discover all connected wifi cards and their capabilities
 std::vector<WiFiCard> discover_connected_wifi_cards();
 
+// Calculate how many cards support injection
+int n_cards_supporting_injection(const std::vector<WiFiCard>& cards);
+
 // Return true if any of the given wifi cards supports injection in monitor mode
 bool any_wifi_card_supporting_injection(const std::vector<WiFiCard>& cards);
 

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -158,17 +158,6 @@ std::string OHDInterface::createDebug() const {
 
 std::vector<openhd::Setting> OHDInterface::get_all_settings(){
   std::vector<openhd::Setting> ret;
-  if(m_profile.is_ground()){
-    auto cb_enable=[this](std::string,int value){
-      if(!openhd::validate_yes_or_no(value))return false;
-      m_nw_settings.unsafe_get_settings().wifi_wifibroadcast_discovery_long_wait=value;
-      m_nw_settings.persist();
-      // requires reboot
-      return true;
-    };
-    ret.push_back(openhd::Setting{"WIFI_DISC_LONG",openhd::IntSetting{
-                                                        m_nw_settings.get_settings().wifi_wifibroadcast_discovery_long_wait,cb_enable}});
-  }
   if(m_wb_link){
     auto settings= m_wb_link->get_all_settings();
     OHDUtil::vec_append(ret,settings);

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -42,7 +42,7 @@ OHDInterface::OHDInterface(OHDPlatform platform1,OHDProfile profile1,std::shared
           break ;
         }
         const auto elapsed = std::chrono::steady_clock::now() - begin;
-        const auto message=fmt::format("Waiting for WB card(s), Found:{}",n_wifibroadcast_capable_cards);
+        const auto message=fmt::format("Waiting for WB capable card(s), Found:{}",n_wifibroadcast_capable_cards);
         if (elapsed > std::chrono::seconds(3)) {
           m_console->warn(message);
         } else {

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -179,11 +179,17 @@ std::optional<WiFiCard> DWifiCards::process_card(const std::string &interface_na
   return card;
 }
 
-bool DWifiCards::any_wifi_card_supporting_injection(const std::vector<WiFiCard>& cards) {
+int DWifiCards::n_cards_supporting_injection(
+    const std::vector<WiFiCard>& cards) {
+  int ret=0;
   for(const auto& card:cards){
-    if(card.supports_injection)return true;
+    if(card.supports_injection)ret++;
   }
   return false;
+}
+
+bool DWifiCards::any_wifi_card_supporting_injection(const std::vector<WiFiCard>& cards) {
+  return n_cards_supporting_injection(cards)>=1;
 }
 
 bool DWifiCards::any_wifi_card_supporting_monitor_mode(
@@ -250,3 +256,4 @@ DWifiCards::ProcessedWifiCards DWifiCards::find_cards_from_manual_file(const std
   }
   return ret;
 }
+

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -183,9 +183,11 @@ int DWifiCards::n_cards_supporting_injection(
     const std::vector<WiFiCard>& cards) {
   int ret=0;
   for(const auto& card:cards){
-    if(card.supports_injection)ret++;
+    if(card.supports_injection){
+      ret++;
+    }
   }
-  return false;
+  return ret;
 }
 
 bool DWifiCards::any_wifi_card_supporting_injection(const std::vector<WiFiCard>& cards) {


### PR DESCRIPTION
This changes the default behaviour during discovery slightly
Should fix both the
1) "no wifi hotspot created" if no air wb card is found 
and
2) "ground does not reliably detect 2 rx card(s) (diversity)"

Issues.
Air waits for 1 wb capable card (or timeout after 10seconds without wb functionality)
Ground waits for 2 wb capable cards (or timeout after 10seconds without wb functionality).

10 Seconds should be enough to catch 2 cards, if they are connected and powered properly.

Increases ground boot up time by 10 seconds for single card users though
