### PR TITLE
1 new feature - tx power armed / disarmed

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_action_handler.hpp
+++ b/OpenHD/ohd_common/inc/openhd_action_handler.hpp
@@ -110,10 +110,18 @@ class ActionHandler{
     openhd::log::get_default()->debug("MAV armed:{}",OHDUtil::yes_or_no(armed));
     {
       // Needs to be called when armed / disarmed
-      auto tmp2=m_action_record_video_when_armed;
-      if(tmp2){
-        ACTION_RECORD_VIDEO_WHEN_ARMED cb2=*tmp2;
-        cb2(armed);
+      auto tmp=m_action_record_video_when_armed;
+      if(tmp){
+        ACTION_RECORD_VIDEO_WHEN_ARMED cb=*tmp;
+        cb(armed);
+      }
+    }
+    {
+      // Also needs to be called when armed / disarmed
+      auto tmp=m_action_tx_power_when_armed;
+      if(tmp){
+        ACTION_TX_POWER_WHEN_ARMED cb=*tmp;
+        cb(armed);
       }
     }
     // We only need to call this when armed (not disarmed)
@@ -157,6 +165,9 @@ class ActionHandler{
   // For automatically stop recording when armed / disarmed
   typedef std::function<void(bool armed)> ACTION_RECORD_VIDEO_WHEN_ARMED;
   std::shared_ptr<ACTION_RECORD_VIDEO_WHEN_ARMED> m_action_record_video_when_armed =nullptr;
+  // For increasing / decreasing TX power when armed / disarmed
+  typedef std::function<void(bool armed)> ACTION_TX_POWER_WHEN_ARMED;
+  std::shared_ptr<ACTION_TX_POWER_WHEN_ARMED> m_action_tx_power_when_armed =nullptr;
  private:
   // By using shared_ptr to wrap the stored the cb we are semi thread-safe
   std::shared_ptr<ACTION_REQUEST_BITRATE_CHANGE> m_action_request_bitrate_change =nullptr;

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -70,6 +70,8 @@ class WBLink :public OHDLink{
   bool set_mcs_index(int mcs_index);
   // this is special, mcs index can not only be changed via mavlink param, but also via RC channel (if enabled)
   void set_mcs_index_from_rc_channel(const std::array<int,18>& rc_channels);
+  // special, change tx power depending if the FC is armed / disarmed
+  void update_arming_state(bool armed);
   // These do not "break" the bidirectional connectivity and therefore
   // can be changed easily on the fly
   bool set_video_fec_block_length(int block_length);

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -175,6 +175,9 @@ class WBLink :public OHDLink{
   int m_n_detected_and_reset_tx_errors=0;
   uint32_t m_max_video_rate_for_current_wifi_config =0;
   uint32_t m_recommended_video_bitrate=0;
+  // Set to true when armed, disarmed by default
+  // Used to differentiate between different tx power levels when armed / disarmed
+  bool m_is_armed= false;
 };
 
 #endif

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -70,7 +70,7 @@ class WBLink :public OHDLink{
   bool set_mcs_index(int mcs_index);
   // this is special, mcs index can not only be changed via mavlink param, but also via RC channel (if enabled)
   void set_mcs_index_from_rc_channel(const std::array<int,18>& rc_channels);
-  // special, change tx power depending if the FC is armed / disarmed
+  // special, change tx power depending on if the FC is armed / disarmed
   void update_arming_state(bool armed);
   // These do not "break" the bidirectional connectivity and therefore
   // can be changed easily on the fly

--- a/OpenHD/ohd_interface/inc/wb_link_settings.hpp
+++ b/OpenHD/ohd_interface/inc/wb_link_settings.hpp
@@ -28,7 +28,8 @@ static constexpr auto DEFAULT_CHANNEL_WIDTH=20;
 static constexpr auto DEFAULT_WIFI_TX_POWER_MILLI_WATT=25;
 // Measured to be about /below 25mW, RTL8812au only (or future cards who use the recommended power level index approach)
 static constexpr auto DEFAULT_RTL8812AU_TX_POWER_INDEX=22;
-static constexpr auto DEFAULT_RTL8812AU_TX_POWER_INDEX_ARMED=22;
+// by default, we do not differentiate (to not confuse users)
+static constexpr auto RTL8812AU_TX_POWER_INDEX_ARMED_DISABLED=0;
 
 // Set to 0 for fec auto block length
 // Set to 1 or greater for fixed k fec
@@ -61,7 +62,7 @@ struct WBLinkSettings {
   // (under this name they were known already in previous openhd releases, but we now support changing them dynamcially at run time)
   uint32_t wb_rtl8812au_tx_pwr_idx_override=DEFAULT_RTL8812AU_TX_POWER_INDEX;
   // applied when armed
-  //uint32_t wb_rtl8812au_tx_pwr_idx_armed=DEFAULT_RTL8812AU_TX_POWER_INDEX_ARMED;
+  uint32_t wb_rtl8812au_tx_pwr_idx_armed=RTL8812AU_TX_POWER_INDEX_ARMED_DISABLED;
   // 0 means auto, aka variable block size (default, gives best results in most cases and has 0 additional latency)
   uint32_t wb_video_fec_block_length=DEFAULT_WB_VIDEO_FEC_BLOCK_LENGTH;
   uint32_t wb_video_fec_percentage=DEFAULT_WB_VIDEO_FEC_PERCENTAGE;
@@ -79,7 +80,7 @@ struct WBLinkSettings {
 };
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WBLinkSettings, wb_frequency, wb_channel_width, wb_mcs_index,
                                    wb_enable_stbc,wb_enable_ldpc,wb_enable_short_guard,
-                                   wb_tx_power_milli_watt,wb_rtl8812au_tx_pwr_idx_override,
+                                   wb_tx_power_milli_watt,wb_rtl8812au_tx_pwr_idx_override,wb_rtl8812au_tx_pwr_idx_armed,
                                    wb_video_fec_block_length, wb_video_fec_percentage,wb_max_fec_block_size_for_platform,
                                    wb_mcs_index_via_rc_channel,
                                    enable_wb_video_variable_bitrate);
@@ -183,6 +184,7 @@ static constexpr auto WB_MAX_FEC_BLOCK_SIZE_FOR_PLATFORM="WB_MAX_D_BZ";
 static constexpr auto WB_TX_POWER_MILLI_WATT="WB_TX_POWER_MW";
 // annoying 16 char settings limit
 static constexpr auto WB_RTL8812AU_TX_PWR_IDX_OVERRIDE="WB_TX_PWR_IDX_O";
+static constexpr auto WB_RTL8812AU_TX_PWR_IDX_ARMED="TX_POWER_ARMED";
 //
 static constexpr auto WB_VIDEO_VARIABLE_BITRATE="VARIABLE_BITRATE";
 //

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -61,16 +61,18 @@ WBLink::WBLink(OHDProfile profile,OHDPlatform platform,std::vector<WiFiCard> bro
   m_work_thread_run = true;
   m_work_thread =std::make_unique<std::thread>(&WBLink::loop_do_work, this);
   if(m_opt_action_handler){
-        auto cb2=[this](openhd::ActionHandler::ScanChannelsParam param){
+        auto cb_scan=[this](openhd::ActionHandler::ScanChannelsParam param){
           async_scan_channels(param);
         };
-        m_opt_action_handler->action_wb_link_scan_channels_register(cb2);
-  }
-  if(m_opt_action_handler){
-        auto cb=[this](const std::array<int,18>& rc_channels){
+        m_opt_action_handler->action_wb_link_scan_channels_register(cb_scan);
+        auto cb_mcs=[this](const std::array<int,18>& rc_channels){
           set_mcs_index_from_rc_channel(rc_channels);
         };
-        m_opt_action_handler->action_on_ony_rc_channel_register(cb);
+        m_opt_action_handler->action_on_ony_rc_channel_register(cb_mcs);
+        auto cb_arm=[this](bool armed){
+          update_arming_state(armed);
+        };
+        m_opt_action_handler->m_action_tx_power_when_armed=std::make_shared<openhd::ActionHandler::ACTION_TX_POWER_WHEN_ARMED>(cb_arm);
   }
   // exp
   /*const auto t_radio_port_rx = m_profile.is_air ? openhd::TELEMETRY_WIFIBROADCAST_RX_RADIO_PORT : openhd::TELEMETRY_WIFIBROADCAST_TX_RADIO_PORT;

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -90,6 +90,8 @@ WBLink::~WBLink() {
   m_console->debug("WBLink::~WBLink() begin");
   if(m_opt_action_handler){
     m_opt_action_handler->action_wb_link_scan_channels_register(nullptr);
+    m_opt_action_handler->action_on_ony_rc_channel_register(nullptr);
+    m_opt_action_handler->m_action_tx_power_when_armed= nullptr;
   }
   if(m_work_thread){
     m_work_thread_run =false;

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -1100,3 +1100,7 @@ void WBLink::set_mcs_index_from_rc_channel(const std::array<int, 18>& rc_channel
   // apply the wanted mcs index
   set_mcs_index(mcs_index);
 }
+
+void WBLink::update_arming_state(bool armed) {
+  m_console->debug("update arming state, armed: {}",armed);
+}


### PR DESCRIPTION
For rtl8812au, add the option such that the user can specifiy seperate tx power (indices) when the FC is armed / disarmed.
By default, the second (when armed) tx power index is set to 0 (Off), which means the same tx power is applied when armed /
disarmed (the default mW)