### PR TITLE
2.4 evo consti dev

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_util_filesystem.h
+++ b/OpenHD/ohd_common/inc/openhd_util_filesystem.h
@@ -59,6 +59,10 @@ void make_file_read_write_everyone(const std::string& filename);
 // Return: remaining space in root directory
 int get_remaining_space_in_mb();
 
+// return size of file in bytes,
+// -1 if file does not exist
+long get_file_size_bytes(const std::string& filepath);
+
 }
 
 #endif //OPENHD_OPENHD_OHD_COMMON_OPENHD_UTIL_FILESYSTEM_H_

--- a/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
+++ b/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
@@ -120,3 +120,9 @@ int OHDFilesystemUtil::get_remaining_space_in_mb() {
   boost::filesystem::space_info info = boost::filesystem::space("/");
   return info.available / 1024 / 1024;
 }
+
+long OHDFilesystemUtil::get_file_size_bytes(const std::string &filepath) {
+  struct stat stat_buf{};
+  int rc = stat(filepath.c_str(), &stat_buf);
+  return rc == 0 ? stat_buf.st_size : -1;
+}

--- a/OpenHD/ohd_video/inc/gst_recording_demuxer.h
+++ b/OpenHD/ohd_video/inc/gst_recording_demuxer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <thread>
 #include <vector>
+#include <mutex>
 
 // Simple util class / namespace for demuxing .mkv air recording files
 // uses gstreamer & command line util
@@ -18,10 +19,18 @@ class GstRecordingDemuxer {
   // them to .mp4 for easier use.
   // If a demuxing task is already running, we just spawn another thread - e.g. this method is always
   // guaranteed to return immediately
-  void demux_all_mkv_files_async();
+  void demux_all_remaining_mkv_files_async();
+  // demux a specific .mkv file (async) unless it is already being demuxed
+  void demux_mkv_file_async_threadsafe(std::string filename);
   static GstRecordingDemuxer& instance();
  private:
-  std::vector<std::unique_ptr<std::thread>> m_demux_threads;
+  struct DeMuxOperation{
+    std::string filename;
+    std::shared_ptr<std::thread> thread;
+  };
+  std::vector<DeMuxOperation> m_demux_ops;
+  // makes sure we spawn exactly one demux thread per file
+  std::mutex m_demux_ops_mutex;
 };
 
 #endif  // OPENHD_GST_RECORDING_DEMUXER_H

--- a/OpenHD/ohd_video/inc/gst_recording_demuxer.h
+++ b/OpenHD/ohd_video/inc/gst_recording_demuxer.h
@@ -15,12 +15,11 @@
 class GstRecordingDemuxer {
  public:
   ~GstRecordingDemuxer();
-  // Find all files that end in .mkv in the openhd videos (air recording) directory and demuxes
-  // them to .mp4 for easier use.
-  // If a demuxing task is already running, we just spawn another thread - e.g. this method is always
-  // guaranteed to return immediately
+  // Find all files that end in .mkv in the openhd videos (air recording) directory and then spawns a new thread to demux the file
+  // (unless it is already being demuxed)
   void demux_all_remaining_mkv_files_async();
   // demux a specific .mkv file (async) unless it is already being demuxed
+  // thread-safe
   void demux_mkv_file_async_threadsafe(std::string filename);
   static GstRecordingDemuxer& instance();
  private:
@@ -28,7 +27,7 @@ class GstRecordingDemuxer {
     std::string filename;
     std::shared_ptr<std::thread> thread;
   };
-  std::vector<DeMuxOperation> m_demux_ops;
+  std::vector<DeMuxOperation> m_demux_ops{};
   // makes sure we spawn exactly one demux thread per file
   std::mutex m_demux_ops_mutex;
 };

--- a/OpenHD/ohd_video/src/gst_recording_demuxer.cpp
+++ b/OpenHD/ohd_video/src/gst_recording_demuxer.cpp
@@ -42,6 +42,12 @@ static void demux_mkv(const std::string& in_file){
     console->warn("Cannot convert {} to {}", in_file,out_file_mp4);
     return ;
   }
+  if(OHDFilesystemUtil::get_file_size_bytes(out_file_mp4)==0){
+    // something must have gone wrong during conversion
+    console->warn("Cannot demux,{} is empty",out_file_mp4);
+    OHDFilesystemUtil::remove_if_existing(out_file_mp4);
+    return ;
+  }
   // Now we can safely delete the old file
   OHDFilesystemUtil::remove_if_existing(in_file);
   // and make the new file rw everybody

--- a/OpenHD/ohd_video/src/gst_recording_demuxer.cpp
+++ b/OpenHD/ohd_video/src/gst_recording_demuxer.cpp
@@ -55,8 +55,8 @@ static void demux_mkv(const std::string& in_file){
   console->debug("Demuxing {} done", in_file);
 }
 
-static void demux_all_mkv_files_in_video_directory(){
-  auto console=openhd::log::create_or_get("gst_demuxer");
+// Returns all files ending in .mkv in the video recordings directory
+static std::vector<std::string> get_all_mkv_video_files(){
   const auto files=OHDFilesystemUtil::getAllEntriesFullPathInDirectory(openhd::video::RECORDINGS_PATH);
   std::vector<std::string> files_to_convert{};
   for(const auto& file: files){
@@ -64,16 +64,15 @@ static void demux_all_mkv_files_in_video_directory(){
       files_to_convert.push_back(file);
     }
   }
-  console->debug("Need to convert {} .mkv files",files_to_convert.size());
-  for(const auto& file: files_to_convert){
-    demux_mkv(file);
-  }
+  return files_to_convert;
 }
+
 
 GstRecordingDemuxer::~GstRecordingDemuxer() {
   auto console=openhd::log::create_or_get("gst_demuxer");
-  console->debug("~GstRecordingDemuxer, waiting for {} threads to finish",m_demux_threads.size());
-  for(auto& demux_thread: m_demux_threads){
+  console->debug("~GstRecordingDemuxer, Terminating {} demux ops",m_demux_ops.size());
+  for(auto& demux: m_demux_ops){
+    auto demux_thread=demux.thread;
     if(demux_thread->joinable()){
       console->debug("Waiting for demuxing to end");
       demux_thread->join();
@@ -81,15 +80,38 @@ GstRecordingDemuxer::~GstRecordingDemuxer() {
   }
 }
 
-void GstRecordingDemuxer::demux_all_mkv_files_async() {
+void GstRecordingDemuxer::demux_all_remaining_mkv_files_async() {
   auto console=openhd::log::create_or_get("gst_demuxer");
-  auto demux_thread=std::make_unique<std::thread>([this](){
-    demux_all_mkv_files_in_video_directory();
-  });
-  m_demux_threads.push_back(std::move(demux_thread));
+  auto files_to_demux=get_all_mkv_video_files();
+  for(auto& file:files_to_demux){
+    demux_mkv_file_async_threadsafe(file);
+  }
 }
 
 GstRecordingDemuxer& GstRecordingDemuxer::instance() {
   static GstRecordingDemuxer demuxer;
   return demuxer;
+}
+
+void GstRecordingDemuxer::demux_mkv_file_async_threadsafe(std::string filename) {
+  auto console=openhd::log::create_or_get("gst_demuxer");
+  if(!OHDUtil::endsWith(filename,".mkv")){
+    console->debug("{} not a .mkv file",filename);
+    return ;
+  }
+  // Check if we are already demuxing file X
+  std::lock_guard<std::mutex> guard(m_demux_ops_mutex);
+  auto already_demuxing=std::find_if(
+      m_demux_ops.begin(), m_demux_ops.end(),
+      [&filename](const DeMuxOperation& x) { return x.filename == filename;});
+  if(already_demuxing==m_demux_ops.end()){
+    // not yet demuxed
+    auto demux_thread=std::make_shared<std::thread>([this,filename](){
+      demux_mkv(filename);
+    });
+    m_demux_ops.push_back({filename,demux_thread});
+  }else{
+    // aldrady demuxed / currently demuxing
+    console->debug("Already demuxed {}",filename);
+  }
 }

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -298,11 +298,6 @@ void GStreamerStream::stop_cleanup_restart() {
   const auto before=std::chrono::steady_clock::now();
   stop();
   cleanup_pipe();
-  // after we have stopped the pipeline, if recording was active, we have a .mkv file -
-  // convert it to something more usable in the background, unless the FC is currently armed
-  if(!m_opt_action_handler->is_currently_armed()){
-    GstRecordingDemuxer::instance().demux_all_mkv_files_async();
-  }
   setup();
   start();
   const auto elapsed=std::chrono::steady_clock::now()-before;
@@ -379,6 +374,11 @@ void GStreamerStream::cleanup_pipe() {
     if(OHDFilesystemUtil::get_file_size_bytes(m_opt_curr_recording_filename.value())==0){
       m_console->warn("Ground recording {} is empty",m_opt_curr_recording_filename.value());
       OHDFilesystemUtil::remove_if_existing(m_opt_curr_recording_filename.value());
+    }
+    // after we have stopped the pipeline, if recording was active, we have a .mkv file -
+    // convert it to something more usable in the background, unless the FC is currently armed
+    if(m_opt_action_handler && !m_opt_action_handler->is_currently_armed()){
+      GstRecordingDemuxer::instance().demux_all_remaining_mkv_files_async();
     }
     m_opt_curr_recording_filename=std::nullopt;
   }

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -377,6 +377,7 @@ void GStreamerStream::cleanup_pipe() {
     OHDFilesystemUtil::make_file_read_write_everyone(m_opt_curr_recording_filename.value());
     // we do not want empty files - this can happen rarely in case the file is created, but no video data is actually written to it
     if(OHDFilesystemUtil::get_file_size_bytes(m_opt_curr_recording_filename.value())==0){
+      m_console->warn("Ground recording {} is empty",m_opt_curr_recording_filename.value());
       OHDFilesystemUtil::remove_if_existing(m_opt_curr_recording_filename.value());
     }
     m_opt_curr_recording_filename=std::nullopt;

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -375,6 +375,10 @@ void GStreamerStream::cleanup_pipe() {
   if(m_opt_curr_recording_filename){
     // make file read / writeable by everybody
     OHDFilesystemUtil::make_file_read_write_everyone(m_opt_curr_recording_filename.value());
+    // we do not want empty files - this can happen rarely in case the file is created, but no video data is actually written to it
+    if(OHDFilesystemUtil::get_file_size_bytes(m_opt_curr_recording_filename.value())==0){
+      OHDFilesystemUtil::remove_if_existing(m_opt_curr_recording_filename.value());
+    }
     m_opt_curr_recording_filename=std::nullopt;
   }
   m_console->debug("GStreamerStream::cleanup_pipe() end");

--- a/OpenHD/ohd_video/src/ohd_video_air.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air.cpp
@@ -55,7 +55,7 @@ OHDVideoAir::OHDVideoAir(OHDPlatform platform1,std::vector<Camera> cameras,
     m_rpi_os_change_config_handler=std::make_unique<openhd::rpi::os::ConfigChangeHandler>(m_platform);
   }
   // In case any non-demuxed recordings exists (e.g. due to a openhd crash, unsafe shutdown,...)
-  GstRecordingDemuxer::instance().demux_all_mkv_files_async();
+  GstRecordingDemuxer::instance().demux_all_remaining_mkv_files_async();
   m_console->debug( "OHDVideo::running");
 }
 


### PR DESCRIPTION
automatically delete empty recordings, do not delete original file when demuxing but created file is empty (probably demuxing failed)

make demuxing thread safe