### PR TITLE
Disable pre-GCC4.4 compat warning

### DIFF
--- a/OpenHD/ohd_video/CMakeLists.txt
+++ b/OpenHD/ohd_video/CMakeLists.txt
@@ -103,6 +103,9 @@ if(LIBCAMERA_FOUND)
     target_compile_definitions(OHDVideoLib PUBLIC OPENHD_LIBCAMERA_PRESENT)
 endif()
 
+# disable compiler warning since we don't link against GCC before 4.4
+target_compile_options(OHDVideoLib PRIVATE -Wno-packed-bitfield-compat)
+
 target_link_libraries(OHDVideoLib PUBLIC ${OHD_VIDEO_USED_LIBS})
 # link and include gstreamer
 target_include_directories(OHDVideoLib PUBLIC ${GST_INCLUDE_DIRS})


### PR DESCRIPTION
Disable warning since we do not link against pre-GCC4.4

rtp_eof_helper.cpp:29:8: note: offset of packed bit-field ‘H265::nal_unit_header_h265_t::layerId’ has changed in GCC 4.4
   29 | struct nal_unit_header_h265_t {
      |        ^~~~~~~~~~~~~~~~~~~~~~