### PR TITLE
Allow mavlink rc_channel_raw message to be used for mcs changes

### DIFF
--- a/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
+++ b/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
@@ -229,7 +229,6 @@ void OHDMainComponent::check_fc_messages_for_actions(const std::vector<MavlinkMe
           if(m_opt_action_handler){
             m_opt_action_handler->fc_rc_channels.update_rc_channels(tmp);
           }
-          m_console->debug("Processed raw RC channels message");
         }
       }
       

--- a/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
+++ b/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
@@ -210,14 +210,29 @@ void OHDMainComponent::check_fc_messages_for_actions(const std::vector<MavlinkMe
     }
     // We only change the mcs on the air unit (since downlink is the only thing that requires 'higher' bandwidth)
     if(RUNS_ON_AIR){
-      if(((msg.m.sysid== OHD_SYS_ID_FC) || (msg.m.sysid== OHD_SYS_ID_FC_BETAFLIGHT)) && msg.m.msgid==MAVLINK_MSG_ID_RC_CHANNELS){
-        mavlink_rc_channels_t rc_channels;
-        mavlink_msg_rc_channels_decode(&msg.m, &rc_channels);
-        const auto tmp=mavlink_msg_rc_channels_to_array(rc_channels);
-        if(m_opt_action_handler){
-          m_opt_action_handler->fc_rc_channels.update_rc_channels(tmp);
+      if((msg.m.sysid== OHD_SYS_ID_FC) || (msg.m.sysid== OHD_SYS_ID_FC_BETAFLIGHT))
+      {
+        if(msg.m.msgid==MAVLINK_MSG_ID_RC_CHANNELS)
+        {
+          mavlink_rc_channels_t rc_channels;
+          mavlink_msg_rc_channels_decode(&msg.m, &rc_channels);
+          const auto tmp=mavlink_msg_rc_channels_to_array(rc_channels);
+          if(m_opt_action_handler){
+            m_opt_action_handler->fc_rc_channels.update_rc_channels(tmp);
+          }
+        }
+        else if(msg.m.msgid==MAVLINK_MSG_ID_RC_CHANNELS_RAW)
+        {
+          mavlink_rc_channels_raw_t rc_channels;
+          mavlink_msg_rc_channels_raw_decode(&msg.m, &rc_channels);
+          const auto tmp=mavlink_msg_rc_channels_raw_to_array(rc_channels);
+          if(m_opt_action_handler){
+            m_opt_action_handler->fc_rc_channels.update_rc_channels(tmp);
+          }
+          m_console->debug("Processed raw RC channels message");
         }
       }
+      
     }
   }
 }

--- a/OpenHD/ohd_telemetry/src/mav_helper.h
+++ b/OpenHD/ohd_telemetry/src/mav_helper.h
@@ -201,6 +201,19 @@ static std::array<int,18> mavlink_msg_rc_channels_to_array(const mavlink_rc_chan
   return ret;
 }
 
+static std::array<int,18> mavlink_msg_rc_channels_raw_to_array(const mavlink_rc_channels_raw_t& parsedMsg){
+    std::array<int,18> ret{};
+    ret[0]=parsedMsg.chan1_raw;
+    ret[1]=parsedMsg.chan2_raw;
+    ret[2]=parsedMsg.chan3_raw;
+    ret[3]=parsedMsg.chan4_raw;
+    ret[4]=parsedMsg.chan5_raw;
+    ret[5]=parsedMsg.chan6_raw;
+    ret[6]=parsedMsg.chan7_raw;
+    ret[7]=parsedMsg.chan8_raw;
+    // Has only 8 channels
+    return ret;
+}
 // Optimize message routing: If a message has a target sys / comp id, only send it to the specified sys / comp id
 struct MTarget{
   uint16_t sys_id;


### PR DESCRIPTION
Allow mavlink rc_channel_raw message to be used for mcs changes as well as rc_channel (betaflight)