### PR TITLE
Fix bind phrase

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_global_constants.hpp
+++ b/OpenHD/ohd_common/inc/openhd_global_constants.hpp
@@ -32,5 +32,11 @@ static_assert(VIDEO_GROUND_VIDEO_STREAM_1_UDP != VIDEO_GROUND_VIDEO_STREAM_2_UDP
 
 static constexpr auto VERSION_NUMBER_STRING="2.5.3-evo-release";
 
+// This optional file contains an encryption keypair (up/down).
+// It is generated at first boot if the user specifies a pw during flash.
+// If this file does not exist, the default keypair from the default pw (openhd)
+// is generated at run time.
+static constexpr auto SECURITY_KEYPAIR_FILENAME="/usr/local/share/openhd/txrx.key";
+
 }
 #endif //OPEN_HD_OPNHD_GLOBAL_CONSTANTS_H

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -54,6 +54,8 @@ class WBLink :public OHDLink{
    * @return the current wb channel space
    */
   [[nodiscard]] openhd::WifiSpace get_current_frequency_channel_space()const;
+  //static constexpr auto OPENHD_KEYPAIR_FILENAME="/boot/openhd/txrx.key";
+  static constexpr auto OPENHD_KEYPAIR_FILENAME="/usr/local/share/openhd/txrx.key";
  private:
   // NOTE:
   // For everything prefixed with 'request_', we validate the param (since it comes from mavlink and might be unsafe to apply)

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -54,8 +54,6 @@ class WBLink :public OHDLink{
    * @return the current wb channel space
    */
   [[nodiscard]] openhd::WifiSpace get_current_frequency_channel_space()const;
-  //static constexpr auto OPENHD_KEYPAIR_FILENAME="/boot/openhd/txrx.key";
-  static constexpr auto OPENHD_KEYPAIR_FILENAME="/usr/local/share/openhd/txrx.key";
  private:
   // NOTE:
   // For everything prefixed with 'request_', we validate the param (since it comes from mavlink and might be unsafe to apply)

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -3,13 +3,14 @@
 //
 
 #include "ohd_interface.h"
-#include "openhd_config.h"
-#include "openhd_util_filesystem.h"
 
 #include <wifi_card_discovery.h>
 
 #include <utility>
 
+#include "openhd_config.h"
+#include "openhd_global_constants.hpp"
+#include "openhd_util_filesystem.h"
 #include "wb_link.h"
 
 OHDInterface::OHDInterface(OHDPlatform platform1,OHDProfile profile1,std::shared_ptr<openhd::ActionHandler> opt_action_handler,bool continue_without_wb_card)
@@ -239,7 +240,7 @@ void OHDInterface::generate_keys_from_pw_if_exists_and_delete() {
     OHDUtil::trim(pw);
     openhd::log::get_default()->info("Generating key(s) from pw xxx"); // don't show the pw
     auto keys=wb::generate_keypair_from_bind_phrase(pw);
-    wb::write_keypair_to_file(keys,WBLink::OPENHD_KEYPAIR_FILENAME);
+    wb::write_keypair_to_file(keys,openhd::SECURITY_KEYPAIR_FILENAME);
     // delete the file
     OHDFilesystemUtil::remove_if_existing(PW_FILENAME);
   }

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -239,7 +239,7 @@ void OHDInterface::generate_keys_from_pw_if_exists_and_delete() {
     OHDUtil::trim(pw);
     openhd::log::get_default()->info("Generating key(s) from pw xxx"); // don't show the pw
     auto keys=wb::generate_keypair_from_bind_phrase(pw);
-    wb::write_keypair_to_file(keys,"/boot/openhd/txrx.key");
+    wb::write_keypair_to_file(keys,WBLink::OPENHD_KEYPAIR_FILENAME);
     // delete the file
     OHDFilesystemUtil::remove_if_existing(PW_FILENAME);
   }

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -55,10 +55,9 @@ WBLink::WBLink(OHDProfile profile,OHDPlatform platform,std::vector<WiFiCard> bro
   //txrx_options.debug_decrypt_time= true;
   //txrx_options.debug_encrypt_time= true;
   //txrx_options.debug_packet_gaps= true;
-  const auto keypair_file= "/boot/openhd/txrx.key";
-  if(OHDFilesystemUtil::exists(keypair_file)){
-    txrx_options.secure_keypair=wb::read_keypair_from_file(keypair_file);
-    m_console->debug("Using key from file {}",keypair_file);
+  if(OHDFilesystemUtil::exists(OPENHD_KEYPAIR_FILENAME)){
+    txrx_options.secure_keypair=wb::read_keypair_from_file(OPENHD_KEYPAIR_FILENAME);
+    m_console->debug("Using key from file {}",OPENHD_KEYPAIR_FILENAME);
   }else{
       txrx_options.secure_keypair = std::nullopt;
       m_console->debug("Using key from default bind phrase");
@@ -391,7 +390,7 @@ bool WBLink::apply_frequency_and_channel_width(int frequency, int channel_width_
     // Weird bug hunting - I hope this makes the driver less likely too crash
     // Temporarily stop injecting packets
     m_wb_txrx->set_passive_mode(true);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10)); // Dirty - wait for any tx packets to drain
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Dirty - wait for any tx packets to drain
     const auto res=openhd::wb::set_frequency_and_channel_width_for_all_cards(frequency,channel_width_rx,m_broadcast_cards);
     m_tx_header_1->update_channel_width(channel_width_tx);
     m_wb_txrx->tx_reset_stats();

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -55,9 +55,9 @@ WBLink::WBLink(OHDProfile profile,OHDPlatform platform,std::vector<WiFiCard> bro
   //txrx_options.debug_decrypt_time= true;
   //txrx_options.debug_encrypt_time= true;
   //txrx_options.debug_packet_gaps= true;
-  if(OHDFilesystemUtil::exists(OPENHD_KEYPAIR_FILENAME)){
-    txrx_options.secure_keypair=wb::read_keypair_from_file(OPENHD_KEYPAIR_FILENAME);
-    m_console->debug("Using key from file {}",OPENHD_KEYPAIR_FILENAME);
+  if(OHDFilesystemUtil::exists(openhd::SECURITY_KEYPAIR_FILENAME)){
+    txrx_options.secure_keypair=wb::read_keypair_from_file(openhd::SECURITY_KEYPAIR_FILENAME);
+    m_console->debug("Using key from file {}",openhd::SECURITY_KEYPAIR_FILENAME);
   }else{
       txrx_options.secure_keypair = std::nullopt;
       m_console->debug("Using key from default bind phrase");


### PR DESCRIPTION
Looks like on rpi we cannot write the keys to /boot/openhd directory (exact cause unknown)
FIX: write the keys in /usr/local/share

the password.txt path stays the same, deleting a file under /boot/openhd should not be a problem.
This way the user also can still change the bind phrase by generating a password.txt file on the sd.