### PR TITLE
unreff appsink and bitrate control element before freeing the pipelin…

### DIFF
--- a/OpenHD/ohd_video/inc/gst_bitrate_controll_wrapper.hpp
+++ b/OpenHD/ohd_video/inc/gst_bitrate_controll_wrapper.hpp
@@ -74,4 +74,13 @@ static bool change_bitrate(const GstBitrateControlElement& ctrl_el,int bitrate_k
   return true;
 }
 
+static void unref_bitrate_element(GstBitrateControlElement& element){
+  if(element.encoder){
+    openhd::log::get_default()->debug("Unref bitrate control element begin");
+    gst_object_unref(element.encoder);
+    element.encoder= nullptr;
+    openhd::log::get_default()->debug("Unref bitrate control element end");
+  }
+}
+
 #endif  // OPENHD_OPENHD_OHD_VIDEO_INC_GST_BITRATE_CONTROLL_WRAPPER_H_

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -682,7 +682,9 @@ static std::string createOutputUdpLocalhost(const int udpOutPort) {
 }
 
 static std::string createOutputAppSink(){
-  return " appsink drop=true name=out_appsink";
+  // @wait-on-eos: set to false since when terminating, we don't care if all buffers of appsink
+  // have been consumed or not.
+  return " appsink drop=true name=out_appsink wait-on-eos=false";
 }
 
 // Needs to match below

--- a/OpenHD/ohd_video/src/gst_appsink_helper.h
+++ b/OpenHD/ohd_video/src/gst_appsink_helper.h
@@ -101,5 +101,14 @@ static void loop_pull_appsink_samples(bool& keep_looping,GstElement *app_sink_el
   }
 }
 
+static void unref_appsink_element(GstElement *appsink){
+  if(appsink){
+    openhd::log::get_default()->debug("Unref appsink begin");
+    gst_object_unref(appsink);
+    appsink= nullptr;
+    openhd::log::get_default()->debug("Unref appsink end");
+  }
+}
+
 }
 #endif  // OPENHD_OPENHD_OHD_VIDEO_SRC_GST_APPSINK_HELPER_H_


### PR DESCRIPTION
…e itself. on appsink, use wait-on-eos=false.
Be a bit more verbose on terminating.