### PR TITLE
A few x20 fixes

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -247,7 +247,7 @@ int main(int argc, char *argv[]) {
     // We start ohd_telemetry as early as possible, since even without a link
     // (transmission) it still picks up local log message(s) and forwards them
     // to any ground station clients (e.g. QOpenHD)
-    auto ohdTelemetry = std::make_shared<OHDTelemetry>(platform, profile);
+    auto ohdTelemetry = std::make_shared<OHDTelemetry>(profile);
 
     // Then start ohdInterface, which discovers detected wifi cards and more.
     auto ohdInterface = std::make_shared<OHDInterface>(platform, profile);

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -250,7 +250,7 @@ int main(int argc, char *argv[]) {
     auto ohdTelemetry = std::make_shared<OHDTelemetry>(profile);
 
     // Then start ohdInterface, which discovers detected wifi cards and more.
-    auto ohdInterface = std::make_shared<OHDInterface>(platform, profile);
+    auto ohdInterface = std::make_shared<OHDInterface>( profile);
 
     // Telemetry allows changing all settings (even from other modules)
     ohdTelemetry->add_settings_generic(ohdInterface->get_all_settings());

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -264,7 +264,7 @@ int main(int argc, char *argv[]) {
 #ifdef ENABLE_AIR
     std::unique_ptr<OHDVideoAir> ohd_video_air = nullptr;
     if (profile.is_air) {
-      auto cameras = OHDVideoAir::discover_cameras(platform);
+      auto cameras = OHDVideoAir::discover_cameras();
       ohd_video_air = std::make_unique<OHDVideoAir>(
           cameras, ohdInterface->get_link_handle());
       // First add camera specific settings (primary & secondary camera)

--- a/OpenHD/ohd_common/inc/openhd_platform.h
+++ b/OpenHD/ohd_common/inc/openhd_platform.h
@@ -40,7 +40,7 @@ std::string x_platform_type_to_string(int platform_type);
 
 // Depends on single threaded CPU performance & weather NEON is available
 // Rough estimate
-int get_fec_max_block_size_for_platform(int platform_type);
+int get_fec_max_block_size_for_platform();
 
 // All these members must not change during run time once they have been
 // discovered !

--- a/OpenHD/ohd_common/inc/openhd_platform.h
+++ b/OpenHD/ohd_common/inc/openhd_platform.h
@@ -25,7 +25,7 @@ static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W =
     20;  // Zero 3 W
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_A = 21;
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B = 22;
-static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1126_UNDEFINED = 23;  // FUTRE
+static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1126_UNDEFINED = 23;  // FUTURE
 
 // Numbers 30..35 are reserved for allwinner
 static constexpr int X_PLATFORM_TYPE_ALWINNER_X20 = 30;
@@ -52,7 +52,6 @@ struct OHDPlatform {
   [[nodiscard]] std::string to_string() const;
   static const OHDPlatform& instance();
   bool is_rpi() const;
-  bool is_rpi_weak() const;
   bool is_rock() const;
   bool is_zero3w() const;
   bool is_rock5_a() const;

--- a/OpenHD/ohd_common/inc/openhd_platform.h
+++ b/OpenHD/ohd_common/inc/openhd_platform.h
@@ -54,6 +54,7 @@ struct OHDPlatform {
   bool is_rpi() const;
   bool is_rpi_weak() const;
   bool is_rock() const;
+  bool is_zero3w() const;
   bool is_rpi_or_x86() const;
   // alwinner
   bool is_x20() const;

--- a/OpenHD/ohd_common/inc/openhd_platform.h
+++ b/OpenHD/ohd_common/inc/openhd_platform.h
@@ -23,9 +23,9 @@ static constexpr int X_PLATFORM_TYPE_RPI_5 = 12;
 // Numbers 20..30 are reserved for rockchip
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W =
     20;  // Zero 3 W
-static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5 =
-    21;                                                               // ROCK 5
-static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1126_UNDEFINED = 22;  // FUTRE
+static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_A = 21;
+static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B = 22;
+static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1126_UNDEFINED = 23;  // FUTRE
 
 // Numbers 30..35 are reserved for allwinner
 static constexpr int X_PLATFORM_TYPE_ALWINNER_X20 = 30;
@@ -55,6 +55,9 @@ struct OHDPlatform {
   bool is_rpi_weak() const;
   bool is_rock() const;
   bool is_zero3w() const;
+  bool is_rock5_a() const;
+  bool is_rock5_b() const;
+  bool is_rock5_a_b() const;
   bool is_rpi_or_x86() const;
   // alwinner
   bool is_x20() const;

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -135,7 +135,8 @@ std::string x_platform_type_to_string(int platform_type) {
   ss << "ERR-UNDEFINED{" << platform_type << "}";
   return ss.str();
 }
-int get_fec_max_block_size_for_platform(int platform_type) {
+int get_fec_max_block_size_for_platform() {
+  auto platform_type = OHDPlatform::instance().platform_type;
   if (platform_type == X_PLATFORM_TYPE_RPI_4 ||
       platform_type == X_PLATFORM_TYPE_RPI_CM4) {
     return 50;

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -187,3 +187,6 @@ bool OHDPlatform::is_rpi_weak() const {
   return is_rpi() && (!(platform_type == X_PLATFORM_TYPE_RPI_4 ||
                         platform_type == X_PLATFORM_TYPE_RPI_CM4));
 }
+bool OHDPlatform::is_zero3w() const {
+  return platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W;
+}

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -187,10 +187,6 @@ bool OHDPlatform::is_rpi_or_x86() const {
 bool OHDPlatform::is_x20() const {
   return platform_type == X_PLATFORM_TYPE_ALWINNER_X20;
 }
-bool OHDPlatform::is_rpi_weak() const {
-  return is_rpi() && (!(platform_type == X_PLATFORM_TYPE_RPI_4 ||
-                        platform_type == X_PLATFORM_TYPE_RPI_CM4));
-}
 bool OHDPlatform::is_zero3w() const {
   return platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W;
 }

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -38,7 +38,8 @@ static int internal_discover_platform() {
     if (regex_search(compatible_content, sm, r)) {
       const std::string chip = sm[1];
       if (chip == "rk3588") {
-        return X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5;
+        // TODO - rock 5 a or b ?
+        return X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B;
       } else if (chip == "rk3566") {
         return X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W;
       } else if (chip == "rv1126") {
@@ -114,8 +115,10 @@ std::string x_platform_type_to_string(int platform_type) {
     // RPI END
     case X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W:
       return "RADXA ZERO3W";
-    case X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5:
-      return "RADXA ROCK5";
+    case X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_A:
+      return "RADXA ROCK5 A";
+    case X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B:
+      return "RADXA ROCK5 B";
     case X_PLATFORM_TYPE_ROCKCHIP_RV1126_UNDEFINED:
       return "RV1126 UNDEFINED";
     // ROCK END
@@ -144,7 +147,8 @@ int get_fec_max_block_size_for_platform(int platform_type) {
     return 80;
   }
   if (platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W ||
-      platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5) {
+      platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_A ||
+      platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B) {
     return 50;
   }
   // For now
@@ -190,3 +194,10 @@ bool OHDPlatform::is_rpi_weak() const {
 bool OHDPlatform::is_zero3w() const {
   return platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W;
 }
+bool OHDPlatform::is_rock5_a() const {
+  return platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_A;
+}
+bool OHDPlatform::is_rock5_b() const {
+  return platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B;
+}
+bool OHDPlatform::is_rock5_a_b() const { return is_rock5_a() || is_rock5_b(); }

--- a/OpenHD/ohd_interface/inc/ohd_interface.h
+++ b/OpenHD/ohd_interface/inc/ohd_interface.h
@@ -38,7 +38,7 @@ class OHDInterface {
    * @param opt_action_handler r.n used to propagate rate control from wb_link
    * to ohd_video
    */
-  explicit OHDInterface(OHDPlatform platform, OHDProfile profile);
+  explicit OHDInterface(OHDProfile profile);
   OHDInterface(const OHDInterface&) = delete;
   OHDInterface(const OHDInterface&&) = delete;
   ~OHDInterface();
@@ -62,7 +62,6 @@ class OHDInterface {
 
  private:
   const OHDProfile m_profile;
-  const OHDPlatform m_platform;
   std::shared_ptr<spdlog::logger> m_console;
   std::shared_ptr<WBLink> m_wb_link;
   std::shared_ptr<MicrohardLink> m_microhard_link;

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -47,8 +47,7 @@ class WBLink : public OHDLink {
    * nullptr during testing of specific modules instead of testing a complete
    * running openhd instance)
    */
-  explicit WBLink(OHDProfile profile, OHDPlatform platform,
-                  std::vector<WiFiCard> broadcast_cards);
+  explicit WBLink(OHDProfile profile, std::vector<WiFiCard> broadcast_cards);
   WBLink(const WBLink&) = delete;
   WBLink(const WBLink&&) = delete;
   ~WBLink();
@@ -168,7 +167,6 @@ class WBLink : public OHDLink {
 
  private:
   const OHDProfile m_profile;
-  const OHDPlatform m_platform;
   const std::vector<WiFiCard> m_broadcast_cards;
   std::shared_ptr<spdlog::logger> m_console;
   std::unique_ptr<openhd::WBLinkSettingsHolder> m_settings;

--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -238,6 +238,8 @@ class WBLink : public OHDLink {
   static constexpr uint8_t THERMAL_PROTECTION_RATE_REDUCED = 1;
   static constexpr uint8_t THERMAL_PROTECTION_VIDEO_DISABLED = 2;
   std::atomic_uint8_t m_thermal_protection_level = 0;
+  std::chrono::steady_clock::time_point m_thermal_protection_enable_tp =
+      std::chrono::steady_clock::now();
 
  private:
   openhd::wb::ForeignPacketsHelper m_foreign_p_helper;

--- a/OpenHD/ohd_interface/inc/wb_link_helper.h
+++ b/OpenHD/ohd_interface/inc/wb_link_helper.h
@@ -50,7 +50,6 @@ bool validate_air_mcs_index_change(
 
 bool any_card_support_frequency(
     uint32_t frequency, const std::vector<WiFiCard>& m_broadcast_cards,
-    const OHDPlatform& platform,
     const std::shared_ptr<spdlog::logger>& m_console);
 
 bool set_frequency_and_channel_width_for_all_cards(

--- a/OpenHD/ohd_interface/inc/wb_link_settings.h
+++ b/OpenHD/ohd_interface/inc/wb_link_settings.h
@@ -118,7 +118,6 @@ struct WBLinkSettings {
 };
 
 WBLinkSettings create_default_wb_stream_settings(
-    const OHDPlatform& platform,
     const std::vector<WiFiCard>& wifibroadcast_cards);
 
 static bool validate_wb_rtl8812au_tx_pwr_idx_override(int value) {
@@ -134,18 +133,16 @@ class WBLinkSettingsHolder : public openhd::PersistentSettings<WBLinkSettings> {
    * @param platform needed to figure out the proper default params
    * @param wifibroadcast_cards1 needed to figure out the proper default params
    */
-  explicit WBLinkSettingsHolder(OHDPlatform platform, OHDProfile profile,
+  explicit WBLinkSettingsHolder(OHDProfile profile,
                                 std::vector<WiFiCard> wifibroadcast_cards1)
       : openhd::PersistentSettings<WBLinkSettings>(
             get_interface_settings_directory()),
         m_cards(std::move(wifibroadcast_cards1)),
-        m_platform(platform),
         m_profile(std::move(profile)) {
     init();
   }
 
  public:
-  const OHDPlatform m_platform;
   const OHDProfile m_profile;
   const std::vector<WiFiCard> m_cards;
 
@@ -156,7 +153,7 @@ class WBLinkSettingsHolder : public openhd::PersistentSettings<WBLinkSettings> {
     return ss.str();
   }
   [[nodiscard]] WBLinkSettings create_default() const override {
-    return create_default_wb_stream_settings(m_platform, m_cards);
+    return create_default_wb_stream_settings(m_cards);
   }
 
  private:

--- a/OpenHD/ohd_interface/inc/wifi_card_discovery.h
+++ b/OpenHD/ohd_interface/inc/wifi_card_discovery.h
@@ -18,7 +18,7 @@ namespace DWifiCards {
 
 void main_discover_an_process_wifi_cards(
     const openhd::Config& config, const OHDProfile& m_profile,
-    const OHDPlatform& m_platform, std::shared_ptr<spdlog::logger>& m_console,
+    std::shared_ptr<spdlog::logger>& m_console,
     std::vector<WiFiCard>& m_monitor_mode_cards,
     std::optional<WiFiCard>& m_opt_hotspot_card);
 
@@ -42,8 +42,7 @@ struct ProcessedWifiCards {
 };
 
 ProcessedWifiCards process_and_evaluate_cards(
-    const std::vector<WiFiCard>& discovered_cards, const OHDPlatform& platform,
-    const OHDProfile& profile);
+    const std::vector<WiFiCard>& discovered_cards, const OHDProfile& profile);
 
 // for users who use the manual file to define their card(s)
 ProcessedWifiCards find_cards_from_manual_file(

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -9,6 +9,7 @@
 
 #include <utility>
 
+#include "ethernet_helper.hpp"
 #include "microhard_link.h"
 #include "openhd_config.h"
 #include "openhd_global_constants.hpp"
@@ -72,7 +73,13 @@ OHDInterface::OHDInterface(OHDPlatform platform1, OHDProfile profile1)
   } else if (m_profile.is_ground() && m_platform.is_zero3w()) {
     // We don't have an ethernet card, but you can connect a usb hub with
     // ethernet
-    // TODO
+    constexpr auto ETH_CARD_NAME_GUESS = "eth0";
+    if (openhd::ethernet::check_eth_adapter_up(ETH_CARD_NAME_GUESS)) {
+      opt_ethernet_card = ETH_CARD_NAME_GUESS;
+    }
+  } else if (m_profile.is_ground() && (m_platform.is_rock5_a_b())) {
+    // We have a ethernet card connected
+    opt_ethernet_card = "eth0";
   }
   if (opt_ethernet_card != std::nullopt) {
     const std::string ethernet_card = opt_ethernet_card.value();

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -69,6 +69,10 @@ OHDInterface::OHDInterface(OHDPlatform platform1, OHDProfile profile1)
     opt_ethernet_card = config.NW_ETHERNET_CARD;
   } else if (m_profile.is_ground() && m_platform.is_rpi()) {
     opt_ethernet_card = std::string("eth0");
+  } else if (m_profile.is_ground() && m_platform.is_zero3w()) {
+    // We don't have an ethernet card, but you can connect a usb hub with
+    // ethernet
+    // TODO
   }
   if (opt_ethernet_card != std::nullopt) {
     const std::string ethernet_card = opt_ethernet_card.value();

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -16,8 +16,8 @@
 #include "openhd_util_filesystem.h"
 #include "wb_link.h"
 
-OHDInterface::OHDInterface(OHDPlatform platform1, OHDProfile profile1)
-    : m_platform(platform1), m_profile(std::move(profile1)) {
+OHDInterface::OHDInterface(OHDProfile profile1)
+    : m_profile(std::move(profile1)) {
   m_console = openhd::log::create_or_get("interface");
   assert(m_console);
   m_monitor_mode_cards = {};
@@ -28,8 +28,7 @@ OHDInterface::OHDInterface(OHDPlatform platform1, OHDProfile profile1)
     return;
   }
   DWifiCards::main_discover_an_process_wifi_cards(
-      config, m_profile, m_platform, m_console, m_monitor_mode_cards,
-      m_opt_hotspot_card);
+      config, m_profile, m_console, m_monitor_mode_cards, m_opt_hotspot_card);
   m_console->debug("monitor_mode card(s):{}",
                    debug_cards(m_monitor_mode_cards));
   if (m_opt_hotspot_card.has_value()) {
@@ -52,8 +51,7 @@ OHDInterface::OHDInterface(OHDPlatform platform1, OHDProfile profile1)
   } else {
     // Set the card(s) we have into monitor mode
     openhd::wb::takeover_cards_monitor_mode(m_monitor_mode_cards, m_console);
-    m_wb_link =
-        std::make_shared<WBLink>(m_profile, m_platform, m_monitor_mode_cards);
+    m_wb_link = std::make_shared<WBLink>(m_profile, m_monitor_mode_cards);
   }
   // The USB tethering listener is always enabled on ground - it doesn't
   // interfere with anything
@@ -66,18 +64,19 @@ OHDInterface::OHDInterface(OHDPlatform platform1, OHDProfile profile1)
   // On rpi, we do that by default when on ground, on other platforms, only if
   // the user explicitly requested it.
   std::optional<std::string> opt_ethernet_card = std::nullopt;
+  const auto platform = OHDPlatform::instance();
   if (openhd::nw_ethernet_card_manual_active(config)) {
     opt_ethernet_card = config.NW_ETHERNET_CARD;
-  } else if (m_profile.is_ground() && m_platform.is_rpi()) {
+  } else if (m_profile.is_ground() && platform.is_rpi()) {
     opt_ethernet_card = std::string("eth0");
-  } else if (m_profile.is_ground() && m_platform.is_zero3w()) {
+  } else if (m_profile.is_ground() && platform.is_zero3w()) {
     // We don't have an ethernet card, but you can connect a usb hub with
     // ethernet
     constexpr auto ETH_CARD_NAME_GUESS = "eth0";
     if (openhd::ethernet::check_eth_adapter_up(ETH_CARD_NAME_GUESS)) {
       opt_ethernet_card = ETH_CARD_NAME_GUESS;
     }
-  } else if (m_profile.is_ground() && (m_platform.is_rock5_a_b())) {
+  } else if (m_profile.is_ground() && (platform.is_rock5_a_b())) {
     // We have a ethernet card connected
     opt_ethernet_card = "eth0";
   }

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -19,13 +19,11 @@
 
 static constexpr auto WB_LINK_ARM_CHANGED_TX_POWER_TAG = "wb_link_tx_power";
 
-WBLink::WBLink(OHDProfile profile, OHDPlatform platform,
-               std::vector<WiFiCard> broadcast_cards)
+WBLink::WBLink(OHDProfile profile, std::vector<WiFiCard> broadcast_cards)
     : m_profile(std::move(profile)),
-      m_platform(platform),
       m_broadcast_cards(std::move(broadcast_cards)),
       m_recommended_max_fec_blk_size_for_this_platform(
-          get_fec_max_block_size_for_platform(platform.platform_type)) {
+          get_fec_max_block_size_for_platform()) {
   m_console = openhd::log::create_or_get("wb_streams");
   assert(m_console);
   m_frame_drop_helper.set_console(m_console);
@@ -42,7 +40,7 @@ WBLink::WBLink(OHDProfile profile, OHDPlatform platform,
   }
   // this fetches the last settings, otherwise creates default ones
   m_settings = std::make_unique<openhd::WBLinkSettingsHolder>(
-      m_platform, m_profile, m_broadcast_cards);
+      m_profile, m_broadcast_cards);
   WBTxRx::Options txrx_options{};
   txrx_options.session_key_packet_interval = SESSION_KEY_PACKETS_INTERVAL;
   txrx_options.use_gnd_identifier = m_profile.is_ground();
@@ -1318,7 +1316,7 @@ void WBLink::perform_channel_scan(
       if (done_early) break;
       // Skip channels / frequencies the card doesn't support anyways
       if (!openhd::wb::any_card_support_frequency(
-              channel.frequency, m_broadcast_cards, m_platform, m_console)) {
+              channel.frequency, m_broadcast_cards, m_console)) {
         continue;
       }
       // set new frequency, reset the packet count, sleep, then check if any

--- a/OpenHD/ohd_interface/src/wb_link_helper.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_helper.cpp
@@ -51,7 +51,6 @@ bool openhd::wb::all_cards_support_frequency_and_channel_width(
 
 bool openhd::wb::any_card_support_frequency(
     uint32_t frequency, const std::vector<WiFiCard>& m_broadcast_cards,
-    const OHDPlatform& platform,
     const std::shared_ptr<spdlog::logger>& m_console) {
   bool any_supports_frequency = false;
   for (const auto& card : m_broadcast_cards) {

--- a/OpenHD/ohd_interface/src/wb_link_settings.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_settings.cpp
@@ -49,6 +49,10 @@ WBLinkSettings create_default_wb_stream_settings(
     // Should work even on ali cards without burning them
     settings.wb_rtl8812au_tx_pwr_idx_override = 10;
   }
+  if(OHDPlatform::instance().is_x20()){
+    settings.wb_enable_stbc=true;
+    settings.wb_enable_ldpc= true;
+  }
   return settings;
 }
 }  // namespace openhd

--- a/OpenHD/ohd_interface/src/wb_link_settings.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_settings.cpp
@@ -29,7 +29,6 @@ std::string WBLinkSettingsHolder::imp_serialize(
 }
 
 WBLinkSettings create_default_wb_stream_settings(
-    const OHDPlatform &platform,
     const std::vector<WiFiCard> &wifibroadcast_cards) {
   assert(!wifibroadcast_cards.empty());
   const auto &first_card = wifibroadcast_cards.at(0);

--- a/OpenHD/ohd_interface/src/wb_link_settings.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_settings.cpp
@@ -49,9 +49,9 @@ WBLinkSettings create_default_wb_stream_settings(
     // Should work even on ali cards without burning them
     settings.wb_rtl8812au_tx_pwr_idx_override = 10;
   }
-  if(OHDPlatform::instance().is_x20()){
-    settings.wb_enable_stbc=true;
-    settings.wb_enable_ldpc= true;
+  if (OHDPlatform::instance().is_x20()) {
+    settings.wb_enable_stbc = true;
+    settings.wb_enable_ldpc = true;
   }
   return settings;
 }

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -256,8 +256,7 @@ std::vector<WiFiCard> reorder_monitor_mode_cards(std::vector<WiFiCard> cards) {
 }
 
 DWifiCards::ProcessedWifiCards DWifiCards::process_and_evaluate_cards(
-    const std::vector<WiFiCard>& discovered_cards, const OHDPlatform& platform,
-    const OHDProfile& profile) {
+    const std::vector<WiFiCard>& discovered_cards, const OHDProfile& profile) {
   // We need to figure out what's the best usage for the card(s) connected to
   // the system based on their capabilities.
   std::vector<WiFiCard> monitor_mode_cards{};
@@ -325,9 +324,10 @@ WiFiCard DWifiCards::create_card_monitor_emulate() {
 
 void DWifiCards::main_discover_an_process_wifi_cards(
     const openhd::Config& config, const OHDProfile& m_profile,
-    const OHDPlatform& m_platform, std::shared_ptr<spdlog::logger>& m_console,
+    std::shared_ptr<spdlog::logger>& m_console,
     std::vector<WiFiCard>& m_monitor_mode_cards,
     std::optional<WiFiCard>& m_opt_hotspot_card) {
+  const auto m_platform = OHDPlatform::instance();
   m_console->debug("Waiting for wifi card(s)...");
   const bool debug = false;
   if (config.WIFI_MONITOR_CARD_EMULATE) {
@@ -404,8 +404,8 @@ void DWifiCards::main_discover_an_process_wifi_cards(
     }
   }
   // now decide what to use the card(s) for
-  const auto evaluated = DWifiCards::process_and_evaluate_cards(
-      connected_cards, m_platform, m_profile);
+  const auto evaluated =
+      DWifiCards::process_and_evaluate_cards(connected_cards, m_profile);
   m_monitor_mode_cards = evaluated.monitor_mode_cards;
   m_opt_hotspot_card = evaluated.hotspot_card;
   if (m_monitor_mode_cards.empty()) {

--- a/OpenHD/ohd_interface/test/test_interface.cpp
+++ b/OpenHD/ohd_interface/test/test_interface.cpp
@@ -47,7 +47,7 @@ int main(int argc, char *argv[]) {
 
   const auto platform = OHDPlatform::instance();
   const OHDProfile profile{is_air, "0"};
-  OHDInterface ohdInterface(platform, profile);
+  OHDInterface ohdInterface(profile);
 
   std::cout << "OHDInterface started\n";
 

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -12,20 +12,17 @@
 #include "openhd_util.h"
 #include "openhd_util_time.h"
 
-AirTelemetry::AirTelemetry(OHDPlatform platform)
-    : m_platform(platform), MavlinkSystem(OHD_SYS_ID_AIR) {
+AirTelemetry::AirTelemetry() : MavlinkSystem(OHD_SYS_ID_AIR) {
   m_console = openhd::log::create_or_get("air_tele");
   assert(m_console);
-  m_air_settings =
-      std::make_unique<openhd::telemetry::air::SettingsHolder>(platform);
+  m_air_settings = std::make_unique<openhd::telemetry::air::SettingsHolder>();
   m_fc_serial = std::make_unique<SerialEndpointManager>();
-  m_ohd_main_component =
-      std::make_shared<OHDMainComponent>(m_platform, _sys_id, true);
+  m_ohd_main_component = std::make_shared<OHDMainComponent>(_sys_id, true);
   m_components.push_back(m_ohd_main_component);
   //
   m_generic_mavlink_param_provider = std::make_shared<XMavlinkParamProvider>(
       _sys_id, MAV_COMP_ID_ONBOARD_COMPUTER);
-  if (m_platform.is_rpi()) {
+  if (OHDPlatform::instance().is_rpi()) {
     m_opt_gpio_control =
         std::make_unique<openhd::telemetry::rpi::GPIOControl>();
   }

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.h
@@ -28,7 +28,7 @@
  */
 class AirTelemetry : public MavlinkSystem {
  public:
-  explicit AirTelemetry(OHDPlatform platform);
+  explicit AirTelemetry();
   AirTelemetry(const AirTelemetry&) = delete;
   AirTelemetry(const AirTelemetry&&) = delete;
   ~AirTelemetry();
@@ -83,7 +83,6 @@ class AirTelemetry : public MavlinkSystem {
   void setup_uart();
 
  private:
-  const OHDPlatform m_platform;
   std::unique_ptr<openhd::telemetry::air::SettingsHolder> m_air_settings;
   std::unique_ptr<SerialEndpointManager> m_fc_serial;
   // send/receive data via wb

--- a/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
@@ -51,9 +51,8 @@ static constexpr auto FC_BATT_N_CELLS = "FC_BATT_N_CELLS";
 
 class SettingsHolder : public openhd::PersistentSettings<Settings> {
  public:
-  explicit SettingsHolder(OHDPlatform platform)
-      : m_platform(platform),
-        openhd::PersistentSettings<Settings>(
+  explicit SettingsHolder()
+      : openhd::PersistentSettings<Settings>(
             openhd::get_telemetry_settings_directory()) {
     init();
   }
@@ -62,13 +61,12 @@ class SettingsHolder : public openhd::PersistentSettings<Settings> {
   }
 
  private:
-  OHDPlatform m_platform;
   [[nodiscard]] std::string get_unique_filename() const override {
     return "air_settings.json";
   }
   [[nodiscard]] Settings create_default() const override {
     Settings ret{};
-    if (m_platform.is_rpi()) {
+    if (OHDPlatform::instance().is_rpi()) {
       // Enable serial to FC by default
       ret.fc_uart_connection_type = "/dev/serial0";
     }

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -12,8 +12,7 @@
 #include "openhd_util.h"
 #include "openhd_util_time.h"
 
-GroundTelemetry::GroundTelemetry(OHDPlatform platform)
-    : _platform(platform), MavlinkSystem(OHD_SYS_ID_GROUND) {
+GroundTelemetry::GroundTelemetry() : MavlinkSystem(OHD_SYS_ID_GROUND) {
   m_console = openhd::log::create_or_get("ground_tele");
   assert(m_console);
   m_gnd_settings =
@@ -39,8 +38,7 @@ GroundTelemetry::GroundTelemetry(OHDPlatform platform)
           on_messages_ground_station_clients(messages);
         });
   }
-  m_ohd_main_component =
-      std::make_shared<OHDMainComponent>(_platform, _sys_id, false);
+  m_ohd_main_component = std::make_shared<OHDMainComponent>(_sys_id, false);
   m_components.push_back(m_ohd_main_component);
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
   if (m_gnd_settings->get_settings().enable_rc_over_joystick) {

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -28,7 +28,7 @@
  */
 class GroundTelemetry : public MavlinkSystem {
  public:
-  explicit GroundTelemetry(OHDPlatform platform);
+  explicit GroundTelemetry();
   GroundTelemetry(const GroundTelemetry&) = delete;
   GroundTelemetry(const GroundTelemetry&&) = delete;
   ~GroundTelemetry();
@@ -65,7 +65,6 @@ class GroundTelemetry : public MavlinkSystem {
   void set_link_handle(std::shared_ptr<OHDLink> link);
 
  private:
-  const OHDPlatform _platform;
   // called every time one or more messages from the air unit are received
   void on_messages_air_unit(const std::vector<MavlinkMessage>& messages);
   // send messages to the air unit, lossy

--- a/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
@@ -7,13 +7,11 @@
 #include "AirTelemetry.h"
 #include "GroundTelemetry.h"
 
-OHDTelemetry::OHDTelemetry(OHDPlatform platform1, OHDProfile profile1,
-                           bool enableExtendedLogging)
-    : m_platform(platform1),
-      m_profile(std::move(profile1)),
+OHDTelemetry::OHDTelemetry(OHDProfile profile1, bool enableExtendedLogging)
+    : m_profile(std::move(profile1)),
       m_enableExtendedLogging(enableExtendedLogging) {
   if (this->m_profile.is_air) {
-    m_air_telemetry = std::make_unique<AirTelemetry>(m_platform);
+    m_air_telemetry = std::make_unique<AirTelemetry>();
     assert(m_air_telemetry);
     m_loop_thread = std::make_unique<std::thread>([this] {
       assert(m_air_telemetry);
@@ -21,7 +19,7 @@ OHDTelemetry::OHDTelemetry(OHDPlatform platform1, OHDProfile profile1,
                                      this->m_enableExtendedLogging);
     });
   } else {
-    m_ground_telemetry = std::make_unique<GroundTelemetry>(m_platform);
+    m_ground_telemetry = std::make_unique<GroundTelemetry>();
     assert(m_ground_telemetry);
     m_loop_thread = std::make_unique<std::thread>([this] {
       assert(m_ground_telemetry);

--- a/OpenHD/ohd_telemetry/src/OHDTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/OHDTelemetry.h
@@ -26,8 +26,7 @@ class GroundTelemetry;
  */
 class OHDTelemetry {
  public:
-  OHDTelemetry(OHDPlatform platform1, OHDProfile profile1,
-               bool enableExtendedLogging = false);
+  OHDTelemetry(OHDProfile profile1, bool enableExtendedLogging = false);
   OHDTelemetry(const OHDTelemetry&) = delete;
   OHDTelemetry(const OHDTelemetry&&) = delete;
   ~OHDTelemetry();
@@ -67,7 +66,6 @@ class OHDTelemetry {
   // Receive threads
   std::unique_ptr<std::thread> m_loop_thread;
   bool m_loop_thread_terminate = false;
-  const OHDPlatform m_platform;
   const OHDProfile m_profile;
   const bool m_enableExtendedLogging;
 };

--- a/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
+++ b/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.cpp
@@ -14,10 +14,8 @@
 #include "openhd_reboot_util.h"
 #include "openhd_spdlog_include.h"
 
-OHDMainComponent::OHDMainComponent(OHDPlatform platform1, uint8_t parent_sys_id,
-                                   bool runsOnAir)
-    : m_platform(platform1),
-      RUNS_ON_AIR(runsOnAir),
+OHDMainComponent::OHDMainComponent(uint8_t parent_sys_id, bool runsOnAir)
+    : RUNS_ON_AIR(runsOnAir),
       MavlinkComponent(parent_sys_id, MAV_COMP_ID_ONBOARD_COMPUTER),
       m_heartbeats_interval(RUNS_ON_AIR ? std::chrono::milliseconds(500)
                                         : std::chrono::milliseconds(200)),
@@ -29,7 +27,7 @@ OHDMainComponent::OHDMainComponent(OHDPlatform platform1, uint8_t parent_sys_id,
   m_console = openhd::log::create_or_get("t_main_c");
   assert(m_console);
   m_onboard_computer_status_provider =
-      std::make_unique<OnboardComputerStatusProvider>(m_platform, true);
+      std::make_unique<OnboardComputerStatusProvider>(true);
   const auto config = openhd::load_config();
   if (!RUNS_ON_AIR && config.GEN_ENABLE_LAST_KNOWN_POSITION) {
     m_last_known_position = std::make_unique<LastKnowPosition>();

--- a/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.h
+++ b/OpenHD/ohd_telemetry/src/internal/OHDMainComponent.h
@@ -37,8 +37,7 @@
 // generate_mavlink_messages() and then send out in the upper level.
 class OHDMainComponent : public MavlinkComponent {
  public:
-  explicit OHDMainComponent(OHDPlatform platform, uint8_t parent_sys_id,
-                            bool runsOnAir);
+  explicit OHDMainComponent(uint8_t parent_sys_id, bool runsOnAir);
   ~OHDMainComponent();
   // override from component
   std::vector<MavlinkMessage> generate_mavlink_messages() override;
@@ -55,7 +54,6 @@ class OHDMainComponent : public MavlinkComponent {
 
  private:
   const bool RUNS_ON_AIR;
-  const OHDPlatform m_platform;
   // Interval in between heartbeats
   const std::chrono::milliseconds m_heartbeats_interval;
   std::chrono::steady_clock::time_point m_last_heartbeat =

--- a/OpenHD/ohd_telemetry/src/internal/OnboardComputerStatusProvider.cpp
+++ b/OpenHD/ohd_telemetry/src/internal/OnboardComputerStatusProvider.cpp
@@ -28,11 +28,8 @@ static int read_cpu_current_frequency_linux_mhz() {
   return value.value() / 1000;
 }
 
-OnboardComputerStatusProvider::OnboardComputerStatusProvider(
-    OHDPlatform platform, bool enable)
-    : m_platform(platform),
-      m_enable(enable),
-      m_ina_219(SHUNT_OHMS, MAX_EXPECTED_AMPS) {
+OnboardComputerStatusProvider::OnboardComputerStatusProvider(bool enable)
+    : m_enable(enable), m_ina_219(SHUNT_OHMS, MAX_EXPECTED_AMPS) {
   ina219_log_warning_once();
   if (!m_ina_219.has_any_error) {
     m_ina_219.configure(RANGE, GAIN, BUS_ADC, SHUNT_ADC);
@@ -106,7 +103,7 @@ void OnboardComputerStatusProvider::calculate_other_until_terminate() {
       curr_ina219_voltage = voltage;
       curr_ina219_current = current;
     }
-    if (m_platform.is_rpi()) {
+    if (OHDPlatform::instance().is_rpi()) {
       curr_temperature_core =
           (int8_t)openhd::onboard::rpi::read_temperature_soc_degree();
       // temporary, until we have our own message
@@ -123,9 +120,9 @@ void OnboardComputerStatusProvider::calculate_other_until_terminate() {
       curr_rpi_undervolt = openhd::onboard::rpi::vcgencmd_get_undervolt();
     } else {
       const auto cpu_temp = (int8_t)openhd::onboard::readTemperature();
+      const auto platform = OHDPlatform::instance();
       curr_temperature_core = cpu_temp;
-      if (m_platform.is_rock() ||
-          m_platform.platform_type == X_PLATFORM_TYPE_X86) {
+      if (platform.is_rock() || platform.platform_type == X_PLATFORM_TYPE_X86) {
         curr_clock_cpu = read_cpu_current_frequency_linux_mhz();
       }
     }

--- a/OpenHD/ohd_telemetry/src/internal/OnboardComputerStatusProvider.h
+++ b/OpenHD/ohd_telemetry/src/internal/OnboardComputerStatusProvider.h
@@ -37,8 +37,7 @@ class OnboardComputerStatusProvider {
    * a lot of CPU resources on its own
    * - disable for testing
    */
-  explicit OnboardComputerStatusProvider(OHDPlatform platform,
-                                         bool enable = true);
+  explicit OnboardComputerStatusProvider(bool enable = true);
   ~OnboardComputerStatusProvider();
   // Thread-safe, should never block for a significant amount of time
   mavlink_onboard_computer_status_t get_current_status();
@@ -53,7 +52,6 @@ class OnboardComputerStatusProvider {
       const std::optional<ExtraUartInfo>& extra_uart);
 
  private:
-  const OHDPlatform m_platform;
   const bool m_enable;
   std::mutex m_curr_onboard_computer_status_mutex;
   mavlink_onboard_computer_status_t m_curr_onboard_computer_status{};

--- a/OpenHD/ohd_telemetry/test/test_air_locally.cpp
+++ b/OpenHD/ohd_telemetry/test/test_air_locally.cpp
@@ -18,7 +18,7 @@ int main() {
   {
     OHDProfile profile{true, "YY"};
     const auto platform = OHDPlatform::instance();
-    air = std::make_unique<OHDTelemetry>(platform, profile, true);
+    air = std::make_unique<OHDTelemetry>(profile, true);
   }
   static bool quit = false;
   signal(SIGTERM, [](int sig) { quit = true; });

--- a/OpenHD/ohd_telemetry/test/test_ground_and_air_locally.cpp
+++ b/OpenHD/ohd_telemetry/test/test_ground_and_air_locally.cpp
@@ -19,14 +19,14 @@ int main() {
   {
     OHDProfile profile{false, "XX"};
     const auto platform = OHDPlatform::instance();
-    ohdTelemGround = std::make_unique<OHDTelemetry>(platform, profile);
+    ohdTelemGround = std::make_unique<OHDTelemetry>(profile);
     ohdTelemGround->add_settings_generic(
         openhd::testing::create_dummy_ground_settings());
   }
   {
     OHDProfile profile{true, "XX"};
     const auto platform = OHDPlatform::instance();
-    ohdTelemAir = std::make_unique<OHDTelemetry>(platform, profile);
+    ohdTelemAir = std::make_unique<OHDTelemetry>(profile);
     ohdTelemAir->add_settings_generic(
         openhd::testing::create_dummy_camera_settings());
   }

--- a/OpenHD/ohd_telemetry/test/test_ground_locally.cpp
+++ b/OpenHD/ohd_telemetry/test/test_ground_locally.cpp
@@ -20,7 +20,7 @@ int main() {
   {
     OHDProfile profile{false, "XX"};
     const auto platform = OHDPlatform::instance();
-    ground = std::make_unique<OHDTelemetry>(platform, profile);
+    ground = std::make_unique<OHDTelemetry>(profile);
     // MAV_COMP_ID_ONBOARD_COMPUTER2=192
     ground->add_settings_generic(
         openhd::testing::create_dummy_ground_settings());

--- a/OpenHD/ohd_telemetry/test/test_onboard_computer_status_read_stuff.cpp
+++ b/OpenHD/ohd_telemetry/test/test_onboard_computer_status_read_stuff.cpp
@@ -11,8 +11,7 @@
 
 int main() {
   const auto platform = OHDPlatform::instance();
-  const auto provider =
-      std::make_unique<OnboardComputerStatusProvider>(platform);
+  const auto provider = std::make_unique<OnboardComputerStatusProvider>();
 
   static bool quit = false;
   signal(SIGTERM, [](int sig) { quit = true; });

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -74,7 +74,7 @@ static constexpr int X_CAM_TYPE_RPI_V4L2_VEYE_MVCAM = 63;
 // X20 Specific starts here
 //
 // Right now we only have one camera, but more (might) follow.
-static constexpr int X_CAM_TYPE_X20_RUNCAM_NANO = 70;
+static constexpr int X_CAM_TYPE_X20_RUNCAM_GENERIC = 70;
 // ... 9 reserved for future use
 //
 // ROCK Specific starts here
@@ -145,8 +145,8 @@ static std::string x_cam_type_to_string(int camera_type) {
     case X_CAM_TYPE_RPI_V4L2_VEYE_MVCAM:
       return "VEYE_MVCAM";
     // All the x20 begin
-    case X_CAM_TYPE_X20_RUNCAM_NANO:
-      return "X20_RUNCAM_NANO";
+    case X_CAM_TYPE_X20_RUNCAM_GENERIC:
+      return "X20_RUNCAM_GENERIC";
     // All the rock begin
     case X_CAM_TYPE_ROCK_HDMI_IN:
       return "ROCK_HDMI_IN";
@@ -511,10 +511,10 @@ static std::vector<ManufacturerForPlatform> get_camera_choices_for_platform(
         MANUFACTURER_DEBUG};
   } else if (platform_type == X_PLATFORM_TYPE_ALWINNER_X20) {
     std::vector<CameraNameAndType> runcam_cameras{
-        CameraNameAndType{"RUNCAM NANO", X_CAM_TYPE_X20_RUNCAM_NANO},
+        CameraNameAndType{"RUNCAM", X_CAM_TYPE_X20_RUNCAM_GENERIC},
     };
     return std::vector<ManufacturerForPlatform>{
-        ManufacturerForPlatform{"RUNCAM", runcam_cameras}};
+        ManufacturerForPlatform{"HDZERO", runcam_cameras}};
   } else if (platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W) {
     std::vector<CameraNameAndType> arducam_cameras{
         CameraNameAndType{"IMX219", X_CAM_TYPE_ROCK_RK3566_IMX219},

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -524,7 +524,10 @@ static std::vector<ManufacturerForPlatform> get_camera_choices_for_platform(
     return std::vector<ManufacturerForPlatform>{
         ManufacturerForPlatform{"ARDUCAM", arducam_cameras}, MANUFACTURER_USB,
         MANUFACTURER_DEBUG};
-  } else if (platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5) {
+  } else if (platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_A) {
+    return std::vector<ManufacturerForPlatform>{MANUFACTURER_USB,
+                                                MANUFACTURER_DEBUG};
+  } else if (platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B) {
     std::vector<CameraNameAndType> hdmi_cameras{
         CameraNameAndType{"HDMI IN", X_CAM_TYPE_ROCK_HDMI_IN},
     };

--- a/OpenHD/ohd_video/inc/camera_discovery.h
+++ b/OpenHD/ohd_video/inc/camera_discovery.h
@@ -22,8 +22,7 @@ class DCameras {
     int v4l2_device_number;
   };
   static std::vector<DiscoveredUSBCamera> detect_usb_cameras(
-      const OHDPlatform& platform, std::shared_ptr<spdlog::logger>& m_console,
-      bool debug = false);
+      std::shared_ptr<spdlog::logger>& m_console, bool debug = false);
 
   // NOTE: IP cameras cannot be auto detected !
 };

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -717,8 +717,8 @@ static std::string create_input_custom_udp_rtp_port(
 }
 
 // Dummy stream using either HW or SW encode.
-static std::string createDummyStreamX(const OHDPlatform& platform,
-                                      const CameraSettings& settings) {
+static std::string createDummyStreamX(const CameraSettings& settings) {
+  const auto platform = OHDPlatform::instance();
   std::stringstream ss;
   ss << "videotestsrc name=videotestsrc ! ";
   // h265 cannot do NV12, but I420.
@@ -746,8 +746,8 @@ static std::string createDummyStreamX(const OHDPlatform& platform,
   return ss.str();
 }
 
-static std::string create_dummy_filesrc_stream(const OHDPlatform& platform,
-                                               const CameraSettings& settings) {
+static std::string create_dummy_filesrc_stream(const CameraSettings& settings) {
+  const auto platform = OHDPlatform::instance();
   auto files = OHDFilesystemUtil::getAllEntriesFullPathInDirectory(
       "/usr/local/share/openhd/dev");
   // std::string filename="/usr/local/share/openhd/dev/test.mp4";

--- a/OpenHD/ohd_video/inc/ohd_video_air.h
+++ b/OpenHD/ohd_video/inc/ohd_video_air.h
@@ -40,7 +40,7 @@ class OHDVideoAir {
   ~OHDVideoAir();
   OHDVideoAir(const OHDVideoAir&) = delete;
   OHDVideoAir(const OHDVideoAir&&) = delete;
-  static std::vector<XCamera> discover_cameras(const OHDPlatform& platform);
+  static std::vector<XCamera> discover_cameras();
   /**
    * In ohd-telemetry, we create a mavlink settings component for each of the
    * camera(s),instead of using one generic settings component like for the rest

--- a/OpenHD/ohd_video/src/camera_discovery.cpp
+++ b/OpenHD/ohd_video/src/camera_discovery.cpp
@@ -379,8 +379,8 @@ static std::optional<XValidEndpoint> probe_v4l2_device(
 }  // namespace openhd::v4l2
 
 std::vector<DCameras::DiscoveredUSBCamera> DCameras::detect_usb_cameras(
-    const OHDPlatform &platform, std::shared_ptr<spdlog::logger> &m_console,
-    bool debug) {
+    std::shared_ptr<spdlog::logger> &m_console, bool debug) {
+  const auto platform = OHDPlatform::instance();
   if (platform.is_rpi_or_x86()) {
     DThermalCamerasHelper::enableFlirIfFound();
     DThermalCamerasHelper::enableSeekIfFound();

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -118,15 +118,13 @@ std::string GStreamerStream::create_source_encode_pipeline(
     pipeline << OHDGstHelper::createV4l2SrcRawAndSwEncodeStream(
         v4l2_device_name, setting);
   } else if (camera.camera_type == X_CAM_TYPE_DUMMY_SW) {
-    pipeline << OHDGstHelper::createDummyStreamX(OHDPlatform::instance(),
-                                                 setting);
+    pipeline << OHDGstHelper::createDummyStreamX(setting);
     // pipeline<<OHDGstHelper::createDummyStreamRPI(setting);
   } else if (camera.camera_type == X_CAM_TYPE_EXTERNAL ||
              camera.camera_type == X_CAM_TYPE_EXTERNAL_IP) {
     pipeline << OHDGstHelper::create_input_custom_udp_rtp_port(setting);
   } else if (camera.camera_type == X_CAM_TYPE_DEVELOPMENT_FILESRC) {
-    pipeline << OHDGstHelper::create_dummy_filesrc_stream(
-        OHDPlatform::instance(), setting);
+    pipeline << OHDGstHelper::create_dummy_filesrc_stream(setting);
   } else if (camera.camera_type == X_CAM_TYPE_NVIDIA_XAVIER_IMX577) {
     pipeline << OHDGstHelper::create_nvidia_xavier_stream(setting);
   } else {

--- a/OpenHD/ohd_video/src/ohd_video_air.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air.cpp
@@ -279,14 +279,14 @@ void OHDVideoAir::update_arming_state(bool armed) {
 }
 
 #ifdef ENABLE_USB_CAMERAS
-static std::vector<int> x_discover_usb_cameras(const OHDPlatform& platform,
-                                               int num_usb_cameras) {
+static std::vector<int> x_discover_usb_cameras(int num_usb_cameras) {
+  const auto platform = OHDPlatform::instance();
   auto console = openhd::log::get_default();
   const auto discovery_begin = std::chrono::steady_clock::now();
   console->debug("Waiting for usb camera(s)");
   std::vector<DCameras::DiscoveredUSBCamera> usb_cameras;
   while (true) {
-    usb_cameras = DCameras::detect_usb_cameras(platform, console, false);
+    usb_cameras = DCameras::detect_usb_cameras(console, false);
     if (usb_cameras.size() >= num_usb_cameras) {
       break;
     }
@@ -322,8 +322,8 @@ static int get_num_usb_cameras(const int primary_camera_type,
   return num_usb_cameras;
 }
 #endif
-std::vector<XCamera> OHDVideoAir::discover_cameras(
-    const OHDPlatform& platform) {
+std::vector<XCamera> OHDVideoAir::discover_cameras() {
+  auto platform = OHDPlatform::instance();
   auto global_settings_holder =
       std::make_unique<AirCameraGenericSettingsHolder>();
   auto global_settings = global_settings_holder->get_settings();
@@ -338,7 +338,7 @@ std::vector<XCamera> OHDVideoAir::discover_cameras(
                           global_settings.secondary_camera_type);
   if (num_usb_cameras > 0) {
     // ONLY usb cameras we need to discover
-    usb_cam_bus_names = x_discover_usb_cameras(platform, num_usb_cameras);
+    usb_cam_bus_names = x_discover_usb_cameras(num_usb_cameras);
   }
 #endif
   std::vector<XCamera> ret;

--- a/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
@@ -56,7 +56,7 @@ AirCameraGenericSettings AirCameraGenericSettingsHolder::create_default()
   if (OHDPlatform::instance().is_rpi()) {
     ret.primary_camera_type = rpi_get_default_primary_cam_type();
   } else if (OHDPlatform::instance().is_x20()) {
-    ret.primary_camera_type = X_CAM_TYPE_X20_RUNCAM_NANO;
+    ret.primary_camera_type = X_CAM_TYPE_X20_RUNCAM_GENERIC;
   } else if (OHDPlatform::instance().platform_type ==
              X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W) {
     ret.primary_camera_type = X_CAM_TYPE_ROCK_RK3566_IMX219;

--- a/OpenHD/ohd_video/test/test_video.cpp
+++ b/OpenHD/ohd_video/test/test_video.cpp
@@ -23,7 +23,7 @@ int main(int argc, char* argv[]) {
   OHDUtil::terminate_if_not_root();
   const auto platform = OHDPlatform::instance();
 
-  auto cameras = OHDVideoAir::discover_cameras(platform);
+  auto cameras = OHDVideoAir::discover_cameras();
   openhd::BitrateDebugger bitrate_debugger{"Bitrate", true};
 
   auto forwarder = openhd::UDPForwarder("127.0.0.1", 5600);


### PR DESCRIPTION
1) avoid oscilation - additionally, add 10 seconds minimum period overy time overheat is activated
2) enable stbc, ldpc on x20 by default
3) rename cam name
4) simplify platform (ROCK 5 A / ROCK 5 B)