### PR TITLE
ethernetlink configuration added

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_temporary_air_or_ground.h
+++ b/OpenHD/ohd_common/inc/openhd_temporary_air_or_ground.h
@@ -1,5 +1,6 @@
 //
 // Created by consti10 on 28.10.22.
+// modified by ahmetozkaraca 29.11.2024
 //
 
 #ifndef OPENHD_OPENHD_OHD_COMMON_OPENHD_TEMPORARY_AIR_OR_GROUND_H_
@@ -7,18 +8,27 @@
 
 #include "config_paths.h"
 #include "openhd_util_filesystem.h"
-// Dirty, temporary
+#include <string>
+#include <sstream>
+#include <map>
+
 namespace openhd::tmp {
 
 // Note: case sensitive
 const auto FILENAME_AIR = std::string(getConfigBasePath()) + "air.txt";
 const auto FILENAME_GROUND = std::string(getConfigBasePath()) + "ground.txt";
+const auto FILENAME_ETHERNET = std::string(getConfigBasePath()) + "ethernet.txt";
 
 static bool file_air_exists() {
   return OHDFilesystemUtil::exists(FILENAME_AIR);
 }
+
 static bool file_ground_exists() {
   return OHDFilesystemUtil::exists(FILENAME_GROUND);
+}
+
+static bool file_ethernet_exists() {
+  return OHDFilesystemUtil::exists(FILENAME_ETHERNET);
 }
 
 static bool file_air_or_ground_exists() {
@@ -30,6 +40,10 @@ static void delete_any_file_air_or_ground() {
   OHDFilesystemUtil::remove_if_existing(FILENAME_GROUND);
 }
 
+static void delete_file_ethernet() {
+  OHDFilesystemUtil::remove_if_existing(FILENAME_ETHERNET);
+}
+
 static void write_file_air() {
   OHDFilesystemUtil::create_directories(std::string(getConfigBasePath()));
   OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_AIR, " ");
@@ -38,6 +52,65 @@ static void write_file_air() {
 static void write_file_ground() {
   OHDFilesystemUtil::create_directories(std::string(getConfigBasePath()));
   OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_GROUND, " ");
+}
+
+// Structure for Ethernet configuration
+struct EthernetConfig {
+  std::string ground_unit_ip = "192.168.2.1";
+  std::string air_unit_ip = "192.168.2.18";
+  int video_port = 5910;
+  int telemetry_port = 5920;
+
+  // Parse Ethernet configuration from string
+  static EthernetConfig fromString(const std::string& content) {
+    EthernetConfig config;
+    std::istringstream stream(content);
+    std::string line;
+    while (std::getline(stream, line)) {
+      if (line.empty() || line[0] == '#') continue; // Skip comments and empty lines
+      auto pos = line.find('=');
+      if (pos != std::string::npos) {
+        auto key = line.substr(0, pos);
+        auto value = line.substr(pos + 1);
+        if (key == "GROUND_UNIT_IP") config.ground_unit_ip = value;
+        else if (key == "AIR_UNIT_IP") config.air_unit_ip = value;
+        else if (key == "VIDEO_PORT") config.video_port = std::stoi(value);
+        else if (key == "TELEMETRY_PORT") config.telemetry_port = std::stoi(value);
+      }
+    }
+    return config;
+  }
+
+  // Serialize Ethernet configuration to string
+  std::string toString() const {
+    std::ostringstream stream;
+    stream << "GROUND_UNIT_IP=" << ground_unit_ip << "\n";
+    stream << "AIR_UNIT_IP=" << air_unit_ip << "\n";
+    stream << "VIDEO_PORT=" << video_port << "\n";
+    stream << "TELEMETRY_PORT=" << telemetry_port << "\n";
+    return stream.str();
+  }
+};
+
+// Write Ethernet configuration to file
+static void write_file_ethernet(const EthernetConfig& config) {
+  OHDFilesystemUtil::create_directories(getConfigBasePath());
+  OHDFilesystemUtil::write_file(openhd::tmp::FILENAME_ETHERNET, config.toString());
+}
+
+// Read Ethernet configuration from file
+static EthernetConfig read_file_ethernet() {
+  if (!file_ethernet_exists()) {
+    throw std::runtime_error("Ethernet configuration file not found: " + FILENAME_ETHERNET);
+  }
+  auto content = OHDFilesystemUtil::read_file(FILENAME_ETHERNET);
+  return EthernetConfig::fromString(content);
+}
+
+// Delete all configuration files (air, ground, ethernet)
+static void delete_all_config_files() {
+  delete_any_file_air_or_ground();
+  delete_file_ethernet();
 }
 
 static bool handle_telemetry_change(int value) {
@@ -56,4 +129,5 @@ static bool handle_telemetry_change(int value) {
 }
 
 }  // namespace openhd::tmp
+
 #endif  // OPENHD_OPENHD_OHD_COMMON_OPENHD_TEMPORARY_AIR_OR_GROUND_H_

--- a/OpenHD/ohd_interface/inc/ethernet_link.h
+++ b/OpenHD/ohd_interface/inc/ethernet_link.h
@@ -6,12 +6,6 @@
 #include <memory>
 #include <thread>
 
-// Define constants for IP addresses and ports
-static constexpr const char* AIR_UNIT_IP = "192.168.2.18";
-static constexpr const char* GROUND_UNIT_IP = "192.168.2.1";
-static constexpr int VIDEO_PORT = 5910;
-static constexpr int TELEMETRY_PORT = 5920;
-
 class EthernetLink : public OHDLink {
 public:
     explicit EthernetLink(OHDProfile profile);
@@ -24,6 +18,13 @@ public:
 
 private:
     OHDProfile m_profile;
+
+    // Configuration variables (private)
+    std::string GROUND_UNIT_IP = "192.168.2.1"; // Default IP
+    std::string AIR_UNIT_IP = "192.168.2.18";    // Default IP
+    int VIDEO_PORT = 5910;                      // Default video port
+    int TELEMETRY_PORT = 5920;                  // Default telemetry port
+
     std::unique_ptr<openhd::UDPForwarder> m_video_tx;   // Video transmitter
     std::unique_ptr<openhd::UDPReceiver> m_video_rx;   // Video receiver
     std::unique_ptr<openhd::UDPForwarder> m_telemetry_tx; // Telemetry transmitter

--- a/OpenHD/ohd_interface/src/ethernet_link.cpp
+++ b/OpenHD/ohd_interface/src/ethernet_link.cpp
@@ -4,6 +4,22 @@
 #include <unistd.h>
 
 EthernetLink::EthernetLink(OHDProfile profile) : m_profile(profile) {
+    // Load the Ethernet configuration from ethernet.txt if it exists
+    if (openhd::tmp::file_ethernet_exists()) {
+        try {
+            auto config = openhd::tmp::read_file_ethernet();
+            GROUND_UNIT_IP = config.ground_unit_ip;
+            AIR_UNIT_IP = config.air_unit_ip;
+            VIDEO_PORT = config.video_port;
+            TELEMETRY_PORT = config.telemetry_port;
+        } catch (const std::exception& ex) {
+            std::cerr << "Failed to read ethernet.txt: " << ex.what() << std::endl;
+            throw;
+        }
+    } else {
+        std::cerr << "ethernet.txt not found. Using default configuration." << std::endl;
+    }
+
     // Initialize either air or ground unit based on the profile
     if (m_profile.is_air) {
         initialize_air_unit();


### PR DESCRIPTION
added ethernet configuration settings.
An Example of ethernet.txt

# Ethernet Configuration for OpenHD
# This file defines the IP addresses and ports used for Ethernet communication
# between the air and ground units.

# Ground Unit IP Address
GROUND_UNIT_IP=192.168.2.1

# Air Unit IP Address
AIR_UNIT_IP=192.168.2.18

# Video Stream Port
VIDEO_PORT=5910

# Telemetry Data Port
TELEMETRY_PORT=5920