### PR TITLE
fix timeout_ns to nanosecond for func gst_app_sink_try_pull_sample

### DIFF
--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -503,7 +503,7 @@ void GStreamerStream::stream_once() {
   // change(s)
   const uint64_t timeout_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(
-          std::chrono::milliseconds(40))
+          std::chrono::nanoseconds(1000000 * 40))
           .count();
   // For 'bugged camera restart' fix
   std::chrono::steady_clock::time_point m_last_camera_frame =


### PR DESCRIPTION
Fixed timeout_ns (from milliseconds to nanoseconds) used for gst_app_sink_try_pull_sample.