### PR TITLE
Add flag to disable WiFi hotspot on ground

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -54,12 +54,13 @@
 
 // A few run time options, only for development. Way more configuration (during
 // development) can be done by using the hardware.config file
-static const char optstr[] = "?:agcwr:h:";
+static const char optstr[] = "?:agcwor:h:";
 static const struct option long_options[] = {
     {"air", no_argument, nullptr, 'a'},
     {"ground", no_argument, nullptr, 'g'},
     {"clean-start", no_argument, nullptr, 'c'},
     {"no-qt-autostart", no_argument, nullptr, 'w'},
+    {"no-hotspot", no_argument, nullptr, 'o'},
     {"run-time-seconds", required_argument, nullptr, 'r'},
     {"hardware-config-file", required_argument, nullptr, 'h'},
     {nullptr, 0, nullptr, 0},
@@ -73,6 +74,7 @@ struct OHDRunOptions {
   bool run_as_air = false;
   bool reset_all_settings = false;
   bool no_qopenhd_autostart=false;
+  bool no_hotspot=false;
   int run_time_seconds = -1;  //-1= infinite, only usefully for debugging
   // Specify the hardware.config file, otherwise,
   // the default location (and default values if no file exists at the default
@@ -111,6 +113,9 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]) {
       case 'w':
         ret.no_qopenhd_autostart = true;
         break;
+      case 'o':
+        ret.no_hotspot = true;
+        break;
       case 'r':
         ret.run_time_seconds = atoi(tmp_optarg);
         break;
@@ -127,6 +132,7 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]) {
         ss << "--clean-start -c  [Wipe all persistent settings OpenHD has "
               "written, can fix any boot issues when switching hw around] \n";
         ss << "--no-qt-autostart [disable auto start of QOpenHD on ground] \n";
+        ss << "--no-hotspot      [disable WiFi hotspot on ground] \n";
         ss << "--run-time-seconds -r [Manually specify run time (default "
               "infinite),for debugging] \n";
         ss << "--hardware-config-file -h [specify path to hardware.config "
@@ -293,7 +299,8 @@ int main(int argc, char *argv[]) {
     auto ohdTelemetry = std::make_shared<OHDTelemetry>(profile);
 
     // Then start ohdInterface, which discovers detected wifi cards and more.
-    auto ohdInterface = std::make_shared<OHDInterface>( profile);
+    auto ohdInterface =
+        std::make_shared<OHDInterface>(profile, options.no_hotspot);
 
     // Telemetry allows changing all settings (even from other modules)
     ohdTelemetry->add_settings_generic(ohdInterface->get_all_settings());

--- a/OpenHD/ohd_interface/inc/ohd_interface.h
+++ b/OpenHD/ohd_interface/inc/ohd_interface.h
@@ -57,7 +57,7 @@ class OHDInterface {
    * @param opt_action_handler r.n used to propagate rate control from wb_link
    * to ohd_video
    */
-  explicit OHDInterface(OHDProfile profile);
+  explicit OHDInterface(OHDProfile profile, bool disable_wifi_hotspot = false);
   OHDInterface(const OHDInterface&) = delete;
   OHDInterface(const OHDInterface&&) = delete;
   ~OHDInterface();
@@ -90,6 +90,7 @@ class OHDInterface {
   std::shared_ptr<EthernetLink> m_ethernet_link;
   std::vector<WiFiCard> m_monitor_mode_cards{};
   std::optional<WiFiCard> m_opt_hotspot_card = std::nullopt;
+  const bool m_disable_wifi_hotspot;
   NetworkingSettingsHolder m_nw_settings;
 };
 

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -62,8 +62,9 @@ bool is_microhard_device_present() {
   return false;
 }
 
-OHDInterface::OHDInterface(OHDProfile profile1)
-    : m_profile(std::move(profile1)) {
+OHDInterface::OHDInterface(OHDProfile profile1, bool disable_wifi_hotspot)
+    : m_profile(std::move(profile1)),
+      m_disable_wifi_hotspot(disable_wifi_hotspot) {
   m_console = openhd::log::create_or_get("interface");
   assert(m_console);
   m_monitor_mode_cards = {};
@@ -125,7 +126,7 @@ OHDInterface::OHDInterface(OHDProfile profile1)
     // m_nw_settings.get_settings().ethernet_operating_mode
   }
   // Wi-Fi hotspot functionality if possible.
-  if (m_opt_hotspot_card.has_value()) {
+  if (!m_disable_wifi_hotspot && m_opt_hotspot_card.has_value()) {
     if (WiFiClient::create_if_enabled()) {
       // Wifi client active
     } else {


### PR DESCRIPTION
## Summary
- allow passing `--no-hotspot` to avoid starting the WiFi hotspot when running ground unit
- support the new flag in `OHDInterface`

## Testing
- `./OpenHD/run_clang_format.sh` *(fails: code should be clang-formatted)*
- `cmake -S OpenHD -B build` 
- `cmake --build build -j 2` *(interrupted at ~87% build progress)*

------
https://chatgpt.com/codex/tasks/task_e_68b497e7f690832fb852bdcbc6593667