### PR TITLE
Add experimental MPP-based video streaming option

### DIFF
--- a/OpenHD/ohd_video/CMakeLists.txt
+++ b/OpenHD/ohd_video/CMakeLists.txt
@@ -46,6 +46,7 @@ if(ENABLE_AIR)
             src/camerastream.cpp
             src/camera_discovery.cpp
             src/gstreamerstream.cpp
+            src/mpp_stream.cpp
             src/ohd_video_air.cpp
             src/rtp_eof_helper.cpp
             src/camera_holder.cpp

--- a/OpenHD/ohd_video/inc/mpp_stream.h
+++ b/OpenHD/ohd_video/inc/mpp_stream.h
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#ifndef OPENHD_MPP_STREAM_H
+#define OPENHD_MPP_STREAM_H
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "camerastream.h"
+#include "openhd_rtp.h"
+#include "openhd_spdlog.h"
+
+/**
+ * Basic CameraStream implementation that uses the Rockchip MPP encoder instead
+ * of gstreamer. The encoder is spawned as an external process and its output is
+ * parsed into NAL units which are then packetised into RTP fragments.
+ *
+ * The implementation is intentionally minimal and serves as a starting point
+ * for platforms where gstreamer is not desired. The external encoder command
+ * must be available on the system and accessible as "mpp_stream".
+ */
+class MPPStream : public CameraStream {
+ public:
+  MPPStream(std::shared_ptr<CameraHolder> camera_holder,
+            openhd::ON_ENCODE_FRAME_CB out_cb);
+  ~MPPStream() override;
+
+  void start_looping() override;
+  void terminate_looping() override;
+  void handle_change_bitrate_request(
+      openhd::LinkActionHandler::LinkBitrateInformation lb) override;
+  void handle_update_arming_state(bool armed) override;
+
+ private:
+  void loop();
+  std::shared_ptr<openhd::RTPHelper> m_rtp_helper;
+  std::atomic_bool m_keep_looping{false};
+  std::unique_ptr<std::thread> m_thread;
+  std::shared_ptr<spdlog::logger> m_console;
+};
+
+#endif  // OPENHD_MPP_STREAM_H

--- a/OpenHD/ohd_video/inc/ohd_video_air_generic_settings.h
+++ b/OpenHD/ohd_video/inc/ohd_video_air_generic_settings.h
@@ -47,6 +47,11 @@ struct AirCameraGenericSettings {
   // Audio can be enabled, in which case gstreamer hopefully picks up the right
   // audio source via autoaudiosrc
   int enable_audio = OPENHD_AUDIO_DISABLE;
+  // Enable experimental gstreamer-less video streaming using the
+  // Rockchip MPP encoder. When enabled, OpenHD will spawn an external
+  // MPP based encoder instead of constructing a gstreamer pipeline.
+  // This is currently only supported on Rockchip based boards.
+  bool use_mpp_video = false;
 };
 
 static bool is_valid_dualcam_primary_video_allocated_bandwidth(

--- a/OpenHD/ohd_video/mpp_streaming.md
+++ b/OpenHD/ohd_video/mpp_streaming.md
@@ -1,0 +1,29 @@
+# MPP based video streaming
+
+OpenHD traditionally uses a GStreamer pipeline to capture and encode video
+before forwarding the resulting RTP stream through the wifibroadcast link.  On
+Rockchip based platforms an alternative approach is now available which avoids
+GStreamer entirely.  Instead the Rockchip **MPP** (Media Processing Platform)
+encoder is invoked directly.
+
+When `use_mpp_video` is enabled in `air_camera_generic.json` the video module
+spawns an external `mpp_stream` process.  The tool is expected to output an
+H.264/H.265 elementary stream to `stdout`.  OpenHD reads this byte stream,
+extracts NAL units and packetises them into RTP fragments using the existing
+`RTPHelper` infrastructure.  The resulting fragments are then forwarded via the
+wifibroadcast link just like in the GStreamer based workflow.
+
+The command line used to start the encoder is built from the current camera
+settings (resolution, frame‑rate and bitrate):
+
+```
+mpp_stream --width <w> --height <h> --fps <f> --bitrate <b> --output -
+```
+
+Make sure the `mpp_stream` utility is installed on the system and supports these
+parameters.  Any additional arguments can be provided by adjusting the command
+construction inside `mpp_stream.cpp`.
+
+This mode is still experimental and does not yet support dynamic bitrate changes
+or onboard recording.  It is intended as a minimal example showing how OpenHD
+can integrate with MPP without relying on GStreamer.

--- a/OpenHD/ohd_video/src/mpp_stream.cpp
+++ b/OpenHD/ohd_video/src/mpp_stream.cpp
@@ -1,0 +1,136 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#include "mpp_stream.h"
+
+#include <fmt/format.h>
+
+#include <cstdio>
+
+#include "camera_holder.h"
+#include "nalu/fragment_helper.h"
+
+namespace {
+// Helper to find next start code in a buffer. Returns -1 if none found.
+int find_start_code(const std::vector<uint8_t>& data, int offset) {
+  for (size_t i = offset; i + 3 < data.size(); ++i) {
+    if (data[i] == 0x00 && data[i + 1] == 0x00 && data[i + 2] == 0x00 &&
+        data[i + 3] == 0x01) {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+}  // namespace
+
+MPPStream::MPPStream(std::shared_ptr<CameraHolder> camera_holder,
+                     openhd::ON_ENCODE_FRAME_CB out_cb)
+    : CameraStream(std::move(camera_holder), std::move(out_cb)) {
+  m_console = openhd::log::create_or_get("mpp_stream");
+}
+
+MPPStream::~MPPStream() { terminate_looping(); }
+
+void MPPStream::start_looping() {
+  const auto camera = m_camera_holder->get_camera();
+  const bool is_h265 =
+      m_camera_holder->get_settings().streamed_video_format.videoCodec ==
+      VideoCodec::H265;
+  m_rtp_helper = std::make_shared<openhd::RTPHelper>(is_h265);
+  m_rtp_helper->set_out_cb([this, camera](auto fragments) {
+    openhd::FragmentedVideoFrame frame{};
+    frame.rtp_fragments = std::move(fragments);
+    frame.enable_ultra_secure_encryption =
+        m_camera_holder->get_settings().enable_ultra_secure_encryption;
+    m_output_cb(camera.index, frame);
+  });
+  m_keep_looping = true;
+  m_thread = std::make_unique<std::thread>(&MPPStream::loop, this);
+}
+
+void MPPStream::terminate_looping() {
+  m_keep_looping = false;
+  if (m_thread && m_thread->joinable()) {
+    m_thread->join();
+  }
+}
+
+void MPPStream::handle_change_bitrate_request(
+    openhd::LinkActionHandler::LinkBitrateInformation lb) {
+  // Basic implementation – the external encoder would need to be restarted with
+  // the new bitrate. For now we simply log the request.
+  m_console->info("bitrate change request {} kbit/s", lb.recommended_bitrate);
+}
+
+void MPPStream::handle_update_arming_state(bool /*armed*/) {
+  // No-op for now. Recording based on arming state is not implemented for MPP
+  // mode yet.
+}
+
+void MPPStream::loop() {
+  const auto settings = m_camera_holder->get_settings();
+  const int width = settings.streamed_video_format.width;
+  const int height = settings.streamed_video_format.height;
+  const int fps = settings.streamed_video_format.framerate;
+  const int bitrate = settings.h26x_bitrate_kbits;
+
+  // Command to spawn external MPP encoder. The "mpp_stream" tool is expected to
+  // output a raw H26x byte stream with start codes to stdout.
+  const std::string cmd = fmt::format(
+      "mpp_stream --width {} --height {} --fps {} --bitrate {} --output -",
+      width, height, fps, bitrate);
+
+  m_console->info("Starting MPP encoder: {}", cmd);
+  FILE* pipe = popen(cmd.c_str(), "r");
+  if (!pipe) {
+    m_console->error("Failed to start mpp_stream process");
+    return;
+  }
+
+  std::vector<uint8_t> buffer(64 * 1024);
+  std::vector<uint8_t> pending;
+  while (m_keep_looping) {
+    size_t bytes = fread(buffer.data(), 1, buffer.size(), pipe);
+    if (bytes == 0) {
+      break;
+    }
+    pending.insert(pending.end(), buffer.begin(), buffer.begin() + bytes);
+    int start = find_start_code(pending, 0);
+    while (start >= 0) {
+      int next = find_start_code(pending, start + 4);
+      if (next > start) {
+        m_rtp_helper->feed_nalu(pending.data() + start, next - start);
+        pending.erase(pending.begin(), pending.begin() + next);
+        start = find_start_code(pending, 0);
+      } else {
+        // Keep remaining bytes for next read
+        if (start > 0) {
+          pending.erase(pending.begin(), pending.begin() + start);
+        }
+        break;
+      }
+    }
+  }
+  pclose(pipe);
+  m_console->info("MPP encoder terminated");
+}

--- a/OpenHD/ohd_video/src/ohd_video_air.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air.cpp
@@ -28,6 +28,7 @@
 #include "camera_discovery.h"
 #include "gstaudiostream.h"
 #include "gstreamerstream.h"
+#include "mpp_stream.h"
 #include "nalu/fragment_helper.h"
 #include "openhd_config.h"
 #include "openhd_reboot_util.h"
@@ -119,12 +120,18 @@ void OHDVideoAir::configure(
              const openhd::FragmentedVideoFrame& fragmented_video_frame) {
         this->on_video_data(stream_index, fragmented_video_frame);
       };
-  // R.N we use gstreamer for pretty much everything
-  // But this might change in the future
-  m_console->debug("GStreamerStream for Camera index:{}", camera.index);
-  auto stream = std::make_shared<GStreamerStream>(camera_holder, frame_cb);
-  stream->start_looping();
-  m_camera_streams.push_back(stream);
+  if (m_generic_settings->get_settings().use_mpp_video) {
+    m_console->debug("MPPStream for Camera index:{}", camera.index);
+    auto stream = std::make_shared<MPPStream>(camera_holder, frame_cb);
+    stream->start_looping();
+    m_camera_streams.push_back(stream);
+  } else {
+    // Default: gstreamer based pipeline
+    m_console->debug("GStreamerStream for Camera index:{}", camera.index);
+    auto stream = std::make_shared<GStreamerStream>(camera_holder, frame_cb);
+    stream->start_looping();
+    m_camera_streams.push_back(stream);
+  }
 }
 
 std::array<std::vector<openhd::Setting>, 2>

--- a/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
@@ -36,7 +36,7 @@ extern AirCameraGenericSettings g_airCameraGenericSettings;
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(
     AirCameraGenericSettings, switch_primary_and_secondary,
     dualcam_primary_video_allocated_bandwidth_perc, primary_camera_type,
-    secondary_camera_type, enable_audio);
+    secondary_camera_type, enable_audio, use_mpp_video);
 
 std::optional<AirCameraGenericSettings>
 AirCameraGenericSettingsHolder::impl_deserialize(


### PR DESCRIPTION
## Summary
- add `use_mpp_video` setting to enable gstreamer-less Rockchip MPP streaming
- implement `MPPStream` to feed MPP encoded NAL units into existing RTP pipeline
- document MPP streaming workflow

## Testing
- `./run_clang_format.sh` *(fails: There are formatting errors)*
- `./build_cmake.sh` *(interrupted: build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c29add6af4832f9974e557b63c9811