### PR TITLE
Add UVX Mod LED support

### DIFF
--- a/OpenHD/ohd_common/src/openhd_led.cpp
+++ b/OpenHD/ohd_common/src/openhd_led.cpp
@@ -65,6 +65,9 @@ static void initialize_led_file_cache() {
     led_file_cache["/sys/class/leds/openhd-x20dev:green:usr/brightness"] =
         OHDFilesystemUtil::exists(
             "/sys/class/leds/openhd-x20dev:green:usr/brightness");
+  } else if (OHDPlatform::instance().is_uvx_mod()) {
+    led_file_cache["/sys/class/leds/Heartbeat/brightness"] =
+        OHDFilesystemUtil::exists("/sys/class/leds/Heartbeat/brightness");
   }
 }
 
@@ -72,7 +75,8 @@ static void toggle_led(const std::string &filename, const bool on) {
   // Check if the file exists using the cache
   if (led_file_cache.find(filename) != led_file_cache.end() &&
       led_file_cache[filename]) {
-    const auto content = on ? "1" : "0";
+    const bool active_low = OHDPlatform::instance().is_uvx_mod();
+    const auto content = (on != active_low) ? "1" : "0";
     OHDFilesystemUtil::write_file(filename, content);
   }
 }
@@ -86,6 +90,8 @@ static void toggle_secondary_led(const bool on) {
     toggle_led("/sys/class/leds/user-led2/brightness", on);
   } else if (OHDPlatform::instance().is_x20()) {
     toggle_led("/sys/class/leds/openhd-x20dev:red:usr/brightness", on);
+  } else if (OHDPlatform::instance().is_uvx_mod()) {
+    toggle_led("/sys/class/leds/Heartbeat/brightness", on);
   }
 }
 
@@ -102,6 +108,8 @@ static void toggle_primary_led(const bool on) {
     toggle_led("/sys/class/leds/mmc0::/brightness", on);
   } else if (OHDPlatform::instance().is_x20()) {
     toggle_led("/sys/class/leds/openhd-x20dev:green:usr/brightness", on);
+  } else if (OHDPlatform::instance().is_uvx_mod()) {
+    toggle_led("/sys/class/leds/Heartbeat/brightness", on);
   }
 }
 
@@ -164,7 +172,9 @@ openhd::LEDManager::LEDManager()
     : m_loading_thread(nullptr),
       m_running(false),
       m_has_error(false),
-      m_is_loading(false) {}
+      m_is_loading(false) {
+  initialize_led_file_cache();
+}
 
 openhd::LEDManager::~LEDManager() { stop_loading_thread(); }
 

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -56,8 +56,8 @@ static int internal_discover_platform() {
     const std::string model_content =
         OHDFilesystemUtil::read_file("/proc/device-tree/model");
     if (OHDUtil::contains_after_uppercase(model_content, "MX93")) {
-      openhd::log::get_default()->warn("Detected UXV platform.");
-      return X_PLATFORM_TYPE_WILLY;
+      openhd::log::get_default()->warn("Detected UVX Mod platform.");
+      return X_PLATFORM_TYPE_UVX_MOD;
     }
   }
   if (OHDFilesystemUtil::exists(ALLWINNER_BOARDID_PATH)) {
@@ -242,6 +242,8 @@ std::string x_platform_type_to_string(int platform_type) {
       return "RV1106";
     case X_PLATFORM_TYPE_WILLY:
       return "Willy";
+    case X_PLATFORM_TYPE_UVX_MOD:
+      return "UVX_MOD";
     case X_PLATFORM_TYPE_ALWINNER_X20:
       return "X20";
     case X_PLATFORM_TYPE_OPENIPC_SIGMASTAR_UNDEFINED:
@@ -286,7 +288,8 @@ int get_fec_max_block_size_for_platform() {
   if (platform_type == X_PLATFORM_TYPE_NVIDIA_XAVIER) {
     return 50;
   }
-  if (platform_type == X_PLATFORM_TYPE_WILLY) {
+  if (platform_type == X_PLATFORM_TYPE_WILLY ||
+      platform_type == X_PLATFORM_TYPE_UVX_MOD) {
     return 50;
   }
   if (platform_type == X_PLATFORM_TYPE_QUALCOMM_QRB5165 ||


### PR DESCRIPTION
## Summary
- handle UVX Mod platform detection
- control UVX Mod LED via /sys/class/leds/Heartbeat/brightness

## Testing
- `./OpenHD/run_clang_format.sh` *(fails: code should be clang-formatted)*
- `./build_cmake.sh` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c1cea614832f91f91ce888230505