### PR TITLE
Add developer manual for dynamic plugin system

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_platform.h
+++ b/OpenHD/ohd_common/inc/openhd_platform.h
@@ -53,6 +53,7 @@ static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_CM3 = 24;
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1126 = 23;
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1106 = 25;
 static constexpr int X_PLATFORM_TYPE_ROCKCHIP_RV1103 = 26;
+static constexpr int X_PLATFORM_TYPE_LUCKFOX_LYRA = 27;
 
 // Numbers 30..35 are reserved for allwinner
 static constexpr int X_PLATFORM_TYPE_ALWINNER_X20 = 30;

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -136,6 +136,9 @@ static int internal_discover_platform() {
       } else if (chip == "rv1106") {
         openhd::log::get_default()->warn("Detected Rockchip RV1106");
         return X_PLATFORM_TYPE_ROCKCHIP_RV1106;
+      } else if (chip == "rk3506") {
+        openhd::log::get_default()->warn("Detected Luckfox Lyra");
+        return X_PLATFORM_TYPE_LUCKFOX_LYRA;
       }
     }
 

--- a/OpenHD/ohd_telemetry/src/mav_include.h
+++ b/OpenHD/ohd_telemetry/src/mav_include.h
@@ -26,7 +26,7 @@
 
 extern "C" {
 // NOTE: Make sure to include the openhd mavlink flavour, otherwise the custom
-// messages won't bw parsed.
+// messages won't be parsed.
 #include <openhd/mavlink.h>
 }
 

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -657,10 +657,15 @@ static int nxp_calculate_number_of_mbs_in_a_slice(int frame_height_px, int n_sli
 static std::string create_willy_camera1_stream(const int device_index,
                                                const CameraSettings& settings) {
   std::stringstream ss;
-  const int bps = (settings.h26x_bitrate_kbits * 0.8);
-  const int n_slices = settings.h26x_num_slices > 1 ? settings.h26x_num_slices : 2;
-  const int mbs_per_slice = nxp_calculate_number_of_mbs_in_a_slice(
-      settings.streamed_video_format.height, n_slices);
+  const int bps = static_cast<int>(settings.h26x_bitrate_kbits * 0.8);
+  const bool use_slicing = settings.h26x_num_slices >= 2;
+
+  std::string slicing_str;
+  if (use_slicing) {
+    const int mbs_per_slice = nxp_calculate_number_of_mbs_in_a_slice(
+        settings.streamed_video_format.height, settings.h26x_num_slices);
+    slicing_str = fmt::format(",number_of_mbs_in_a_slice={}", mbs_per_slice);
+  }
 
   ss << fmt::format("v4l2src device=/dev/video3 ! ");
   ss << fmt::format(
@@ -670,15 +675,13 @@ static std::string create_willy_camera1_stream(const int device_index,
                     "h264_profile=1,"
                     "repeat_sequence_header=1,"
                     "generate_access_unit_delimiters=1,"
-                    "video_bitrate={},"
-                    "number_of_mbs_in_a_slice={}\" ! ",
-                    bps, mbs_per_slice);
+                    "video_bitrate={}{}\" ! ",
+                    bps, slicing_str);
 
   ss << "video/x-h264,profile=constrained-baseline ! ";
 
   return ss.str();
 }
-
 
 /**
  * For Qualcomm Cameras

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -647,7 +647,7 @@ ss << fmt::format(
 "video/x-raw,width={},height={},framerate={}/1,format=NV12 ! ",
 settings.streamed_video_format.width,
 settings.streamed_video_format.height,
-settings.streamed_video_format.fps);
+settings.streamed_video_format.framerate);
 
 ss << "imxvpuenc_h264 ";
 

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -674,6 +674,7 @@ static std::string create_willy_camera1_stream(const int device_index,
   ss << fmt::format("v4l2h264enc extra-controls=\"controls,"
                     "h264_profile=1,"
                     "repeat_sequence_header=1,"
+                    "video_bitrate_mode=1,"
                     "video_bitrate={}{}\" ! ",
                     bps, slicing_str);
 

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -632,41 +632,51 @@ static std::string createAllwinnerStream(const CameraSettings& settings) {
 /**
  * For WILLY Cameras
  */
-static std::string create_willy_camera1_stream(const int device_index,
-  const CameraSettings& settings) {
-std::stringstream ss;
+static int nxp_calculate_number_of_mbs_in_a_slice(int frame_height_px, int n_slices) {
+  if (n_slices < 2)
+    return 0;
 
-const int bitrate_kbps = settings.h26x_bitrate_kbits;
-const int gop_size = settings.h26x_keyframe_interval > 0 ? settings.h26x_keyframe_interval : 30;
+  int frame_mb_rows = (frame_height_px + 15) / 16;
+  if (n_slices > frame_mb_rows) {
+    openhd::log::get_default()->warn(
+        "Too many slices requested: frame_mb_rows={}, n_slices={}", frame_mb_rows, n_slices);
+    return frame_mb_rows;
+  }
 
-// Calculate number of macroblocks per row (16x16 MB grid)
-const int macroblocks_per_row = settings.streamed_video_format.width / 16;
+  int slice_row_mb = frame_mb_rows / n_slices;
+  if (frame_mb_rows % n_slices)
+    slice_row_mb++;
 
-ss << fmt::format("v4l2src device=/dev/video{} ! ", device_index);
-ss << fmt::format(
-"video/x-raw,width={},height={},framerate={}/1,format=NV12 ! ",
-settings.streamed_video_format.width,
-settings.streamed_video_format.height,
-settings.streamed_video_format.framerate);
+  openhd::log::get_default()->debug(
+      "NXP slice calculation -> frame_height_px={}, n_slices={}, frame_mb_rows={}, mbs_per_slice={}",
+      frame_height_px, n_slices, frame_mb_rows, slice_row_mb);
 
-ss << "imxvpuenc_h264 ";
-
-// Bitrate-based or constant quantization
-if (bitrate_kbps > 0) {
-ss << fmt::format("bitrate={} ", bitrate_kbps);
-ss << fmt::format("gop-size={} ", gop_size);
-} else {
-ss << "bitrate=0 ";
-ss << "quantization=20 ";
+  return slice_row_mb;
 }
 
-// Always enable intra-refresh based on row size
-ss << fmt::format("intra-refresh={} ", macroblocks_per_row);
+static std::string create_willy_camera1_stream(const int device_index,
+                                               const CameraSettings& settings) {
+  std::stringstream ss;
+  const int bps = (settings.h26x_bitrate_kbits * 0.8);
+  const int n_slices = settings.h26x_num_slices > 1 ? settings.h26x_num_slices : 2;
+  const int mbs_per_slice = nxp_calculate_number_of_mbs_in_a_slice(
+      settings.streamed_video_format.height, n_slices);
 
-// Output caps
-ss << "! video/x-h264,profile=baseline ! ";
+  ss << fmt::format("v4l2src device=/dev/video3 ! ");
+  ss << fmt::format(
+      "video/x-raw,width=960,height=720,framerate=120/1,format=NV12 ! ");
 
-return ss.str();
+  ss << fmt::format("v4l2h264enc extra-controls=\"controls,"
+                    "h264_profile=1,"
+                    "repeat_sequence_header=1,"
+                    "generate_access_unit_delimiters=1,"
+                    "video_bitrate={},"
+                    "number_of_mbs_in_a_slice={}\" ! ",
+                    bps, mbs_per_slice);
+
+  ss << "video/x-h264,profile=constrained-baseline ! ";
+
+  return ss.str();
 }
 
 

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -674,7 +674,6 @@ static std::string create_willy_camera1_stream(const int device_index,
   ss << fmt::format("v4l2h264enc extra-controls=\"controls,"
                     "h264_profile=1,"
                     "repeat_sequence_header=1,"
-                    "generate_access_unit_delimiters=1,"
                     "video_bitrate={}{}\" ! ",
                     bps, slicing_str);
 

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -633,19 +633,42 @@ static std::string createAllwinnerStream(const CameraSettings& settings) {
  * For WILLY Cameras
  */
 static std::string create_willy_camera1_stream(const int device_index,
-                                               const CameraSettings& settings) {
-  std::stringstream ss;
-  const int bps = (settings.h26x_bitrate_kbits * 0.8);
-  const int rotation = get_rotation_degree_qcom(settings);
-  ss << fmt::format("v4l2src device=/dev/video3 ! ");
-  ss << fmt::format(
-      "video/x-raw,width=960,height=720,framerate=120/1,format=NV12 ! ");
-  ss << "vpuenc_h264 ";
-  ss << "bitrate=" << bps << " ";
-  ss << "! ";
+  const CameraSettings& settings) {
+std::stringstream ss;
 
-  return ss.str();
+const int bitrate_kbps = settings.h26x_bitrate_kbits;
+const int gop_size = settings.h26x_keyframe_interval > 0 ? settings.h26x_keyframe_interval : 30;
+
+// Calculate number of macroblocks per row (16x16 MB grid)
+const int macroblocks_per_row = settings.streamed_video_format.width / 16;
+
+ss << fmt::format("v4l2src device=/dev/video{} ! ", device_index);
+ss << fmt::format(
+"video/x-raw,width={},height={},framerate={}/1,format=NV12 ! ",
+settings.streamed_video_format.width,
+settings.streamed_video_format.height,
+settings.streamed_video_format.fps);
+
+ss << "imxvpuenc_h264 ";
+
+// Bitrate-based or constant quantization
+if (bitrate_kbps > 0) {
+ss << fmt::format("bitrate={} ", bitrate_kbps);
+ss << fmt::format("gop-size={} ", gop_size);
+} else {
+ss << "bitrate=0 ";
+ss << "quantization=20 ";
 }
+
+// Always enable intra-refresh based on row size
+ss << fmt::format("intra-refresh={} ", macroblocks_per_row);
+
+// Output caps
+ss << "! video/x-h264,profile=baseline ! ";
+
+return ss.str();
+}
+
 
 /**
  * For Qualcomm Cameras

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -657,7 +657,7 @@ static int nxp_calculate_number_of_mbs_in_a_slice(int frame_height_px, int n_sli
 static std::string create_willy_camera1_stream(const int device_index,
                                                const CameraSettings& settings) {
   std::stringstream ss;
-  const int bps = static_cast<int>(settings.h26x_bitrate_kbits * 0.8);
+  const int bps = static_cast<int>(settings.h26x_bitrate_kbits * 800);
   const bool use_slicing = settings.h26x_num_slices >= 2;
 
   std::string slicing_str;

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -503,7 +503,7 @@ void GStreamerStream::stream_once() {
   // change(s)
   const uint64_t timeout_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(
-          std::chrono::milliseconds(40))
+          std::chrono::nanoseconds(1000000 * 40))
           .count();
   // For 'bugged camera restart' fix
   std::chrono::steady_clock::time_point m_last_camera_frame =

--- a/plugin_system_guide/01_intro.md
+++ b/plugin_system_guide/01_intro.md
@@ -1,0 +1,42 @@
+# 01. Introduction
+
+## Purpose
+- Provide a concise, actionable developer manual for creating a dynamic plugin system for OpenHD.
+- Enable incremental implementation via code-generation tools or manual coding.
+- Establish the workflow for migrating encryption/bindphrase logic into a runtime-loaded plugin.
+
+## Scope
+- Covers design decisions, build integration, testing, and fallback strategies.
+- Focuses on GNU/Linux builds first, with Windows notes where relevant.
+- Targets experienced C/C++ developers familiar with OpenHD's codebase structure.
+
+## Prerequisites
+- Functional C/C++ toolchain (gcc/clang, g++, make, cmake, ninja).
+- Basic understanding of shared libraries (.so/.dll) and dynamic linking (dlopen/LoadLibrary).
+- Access to the OpenHD repository with full history to inspect encryption/bindphrase code.
+- Ability to run `rg`, `grep`, `cmake`, `ninja`, and existing OpenHD build scripts.
+
+## High-Level Workflow
+1. Audit OpenHD for encryption/bindphrase usage.
+2. Design a portable plugin interface and lifecycle functions.
+3. Implement a plugin manager responsible for discovery, loading, and dispatch.
+4. Move encryption functionality into a shared library plugin that adheres to the interface.
+5. Update OpenHD core to call the plugin via the manager, including graceful fallback.
+6. Extend build, packaging, and test scripts to build and validate the plugin.
+
+## Repository Touchpoints
+- `OpenHD/OpenHD/` (core application sources).
+- `OpenHD/CMakeLists.txt` and nested `CMakeLists.txt` files.
+- Encryption/bindphrase sources (search for `bindphrase`, `encryption`, `crypto`).
+- New directory: `OpenHD/plugins/encryption/` for plugin sources and CMake entries.
+- New runtime data folder (e.g., `/usr/lib/openhd/plugins` or `lib/openhd/plugins`).
+
+## Suggested Branch & Workflow
+- Create a dedicated feature branch: `git checkout -b feature/plugin-encryption`.
+- Commit incremental steps with descriptive messages for traceability.
+- Use feature flags or config options to toggle plugin usage during migration.
+
+## Automation Prompt
+```
+You are assisting with "01. Introduction" for the OpenHD plugin system manual. Summarize repository prerequisites, enumerate high-level tasks, and ensure output includes bullet lists for scope, prerequisites, workflow, repository touchpoints, and branching strategy. Do not write code; focus on structured guidance aimed at senior developers.
+```

--- a/plugin_system_guide/02_plugin_architecture.md
+++ b/plugin_system_guide/02_plugin_architecture.md
@@ -1,0 +1,56 @@
+# 02. Plugin Architecture
+
+## Architectural Goals
+- Modularize optional subsystems via dynamically loaded plugins.
+- Maintain a minimal core binary with extension points for features like encryption.
+- Provide deterministic lifecycle management (init → runtime calls → deinit).
+
+## Key Components
+- **Plugin Manager** (`plugin_manager.cpp/.h`)
+  - Discovers plugin binaries (configurable directories, e.g., `/usr/lib/openhd/plugins`).
+  - Loads libraries using platform-appropriate APIs.
+  - Registers and tracks plugin instances.
+- **Plugin Interface Header** (`include/openhd/plugin.h`)
+  - Defines the ABI contract (function pointers, struct layout, version identifiers).
+  - Provides macros for exporting symbols (`OPENHD_PLUGIN_EXPORT`).
+- **Core Integration Layer**
+  - Hooks into existing OpenHD modules (e.g., telemetry, encryption handlers).
+  - Delegates functionality to loaded plugins when available.
+- **Plugin Implementations**
+  - Standalone shared libraries packaged separately.
+  - Follow naming convention `libopenhd_<feature>_plugin.so` or `openhd_<feature>.dll`.
+
+## Data Flow Overview
+1. Configuration instructs the manager which plugins to load (e.g., `openhd.conf`).
+2. Manager scans directories, filters by naming convention, and loads each library.
+3. Manager resolves `openhd_plugin_get_descriptor()` to obtain metadata & function table.
+4. Manager validates API version, registers capabilities, and calls `init` with context.
+5. Core subsystems invoke plugin functions through the manager.
+6. On shutdown or reload, manager calls `deinit` and unloads the library.
+
+## Lifecycle States
+- **Discovered** → file path identified, pending validation.
+- **Loaded** → shared object opened, descriptor retrieved.
+- **Initialized** → plugin `init` executed successfully.
+- **Active** → plugin functions callable.
+- **Failed** → plugin rejected; fallback path triggered.
+
+## Threading & Concurrency Considerations
+- Access to plugin registry guarded via mutex or reader-writer lock.
+- Plugin callbacks executed on worker thread(s) determined by caller context.
+- Document requirement: plugins must be thread-safe or note thread affinity in metadata.
+
+## Error Handling Strategy
+- Centralize error codes/enums for plugin loading failures (file missing, symbol missing, version mismatch).
+- Log failures with actionable diagnostics (`OPENHD_LOG_ERROR`).
+- Provide fallback path (internal stub) when plugin fails.
+
+## Configuration Hooks
+- Extend existing configuration to include plugin directories and load order.
+- Support environment variable overrides (`OPENHD_PLUGIN_PATH`).
+- Allow runtime reload trigger (optional) via command or signal.
+
+## Automation Prompt
+```
+You are assisting with "02. Plugin Architecture" for the OpenHD plugin system manual. Describe the core components (manager, interface, implementations), lifecycle, data flow, and error handling using bullet lists and numbered steps. Include configuration and concurrency considerations. Focus on guidance for implementing architecture scaffolding without writing final code.
+```

--- a/plugin_system_guide/03_dynamic_loading.md
+++ b/plugin_system_guide/03_dynamic_loading.md
@@ -1,0 +1,142 @@
+# 03. Dynamic Loading Mechanics
+
+## Platform Abstractions
+- Use `#ifdef _WIN32` blocks to differentiate between Windows and POSIX.
+- Wrap platform APIs in `openhd::DynamicLibrary` helper class with methods:
+  - `bool open(const std::string &path);`
+  - `void close();`
+  - `void* resolve(const char *symbol);`
+  - `std::string last_error() const;`
+- POSIX implementation leverages `dlopen`, `dlclose`, `dlsym`, `dlerror`.
+- Windows implementation uses `LoadLibraryA`, `FreeLibrary`, `GetProcAddress`, `GetLastError`.
+
+## Step-by-Step Implementation (POSIX-first)
+1. **Create abstraction header** `include/openhd/dylib.h`:
+   ```c++
+   #pragma once
+   #include <string>
+
+   namespace openhd {
+   class DynamicLibrary {
+   public:
+       DynamicLibrary() = default;
+       ~DynamicLibrary();
+
+       bool open(const std::string &path);
+       void close();
+       void* resolve(const char *symbol) const;
+       std::string last_error() const;
+
+   private:
+       void *handle_ {nullptr};
+   };
+   }
+   ```
+2. **Add POSIX source** `src/dylib_posix.cpp`:
+   ```c++
+   #include "openhd/dylib.h"
+   #include <dlfcn.h>
+
+   namespace openhd {
+   DynamicLibrary::~DynamicLibrary() { close(); }
+
+   bool DynamicLibrary::open(const std::string &path) {
+       handle_ = dlopen(path.c_str(), RTLD_NOW);
+       return handle_ != nullptr;
+   }
+
+   void DynamicLibrary::close() {
+       if (handle_) {
+           dlclose(handle_);
+           handle_ = nullptr;
+       }
+   }
+
+   void* DynamicLibrary::resolve(const char *symbol) const {
+       return handle_ ? dlsym(handle_, symbol) : nullptr;
+   }
+
+   std::string DynamicLibrary::last_error() const {
+       const char *err = dlerror();
+       return err ? std::string(err) : std::string();
+   }
+   }
+   ```
+3. **Add Windows source** `src/dylib_win.cpp` (compiled only on `_WIN32`):
+   ```c++
+   #include "openhd/dylib.h"
+   #include <windows.h>
+
+   namespace openhd {
+   DynamicLibrary::~DynamicLibrary() { close(); }
+
+   bool DynamicLibrary::open(const std::string &path) {
+       handle_ = LoadLibraryA(path.c_str());
+       return handle_ != nullptr;
+   }
+
+   void DynamicLibrary::close() {
+       if (handle_) {
+           FreeLibrary(static_cast<HMODULE>(handle_));
+           handle_ = nullptr;
+       }
+   }
+
+   void* DynamicLibrary::resolve(const char *symbol) const {
+       return handle_ ? reinterpret_cast<void*>(GetProcAddress(static_cast<HMODULE>(handle_), symbol)) : nullptr;
+   }
+
+   std::string DynamicLibrary::last_error() const {
+       DWORD error = GetLastError();
+       if (!error) return {};
+       LPSTR buffer = nullptr;
+       size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                                    nullptr, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                                    reinterpret_cast<LPSTR>(&buffer), 0, nullptr);
+       std::string message(buffer, size);
+       LocalFree(buffer);
+       return message;
+   }
+   }
+   ```
+
+## CMake Integration
+- Update top-level `CMakeLists.txt`:
+  ```cmake
+  target_sources(openhd PRIVATE
+      src/dylib_posix.cpp
+  )
+  if (WIN32)
+      target_sources(openhd PRIVATE src/dylib_win.cpp)
+      target_link_libraries(openhd PRIVATE ws2_32)
+  else()
+      target_link_libraries(openhd PRIVATE dl)
+  endif()
+  ```
+- Ensure include directory (`include/`) is exposed via `target_include_directories`.
+
+## Runtime Loading Example
+```c++
+openhd::DynamicLibrary lib;
+if (!lib.open(candidate_path)) {
+    OPENHD_LOG_ERROR("Failed to open %s: %s", candidate_path.c_str(), lib.last_error().c_str());
+    return PluginLoadResult::FileOpenFailed;
+}
+auto symbol = reinterpret_cast<openhd_plugin_descriptor*(*)()>(lib.resolve("openhd_plugin_get_descriptor"));
+if (!symbol) {
+    OPENHD_LOG_ERROR("Missing descriptor symbol in %s", candidate_path.c_str());
+    lib.close();
+    return PluginLoadResult::MissingSymbol;
+}
+auto *descriptor = symbol();
+```
+
+## Diagnostics & Logging
+- Wrap `dlerror()` reads with guard to avoid stale error messages (`dlerror(); dlopen(...); dlerror();`).
+- Log library path, resolved version, and function table size.
+- Provide verbose mode to dump plugin metadata for debugging.
+
+## Automation Prompt
+```
+You are assisting with "03. Dynamic Loading Mechanics" for the OpenHD plugin system manual. Generate POSIX and Windows pseudocode/templated code for a DynamicLibrary helper, include CMake snippets, and demonstrate sample usage. Ensure instructions are sequential and copy-paste friendly.
+```

--- a/plugin_system_guide/04_plugin_interface_design.md
+++ b/plugin_system_guide/04_plugin_interface_design.md
@@ -1,0 +1,89 @@
+# 04. Plugin Interface Design
+
+## Interface Objectives
+- Define a stable ABI between OpenHD core and plugins.
+- Support version negotiation and backward compatibility.
+- Allow plugins to declare capabilities, configuration needs, and thread-safety.
+
+## Descriptor Structure
+```c++
+#pragma once
+#include <stdint.h>
+
+#define OPENHD_PLUGIN_API_VERSION 1
+
+#ifdef _WIN32
+#define OPENHD_PLUGIN_EXPORT extern "C" __declspec(dllexport)
+#else
+#define OPENHD_PLUGIN_EXPORT extern "C"
+#endif
+
+typedef struct openhd_plugin_descriptor {
+    uint32_t api_version;          // Must equal OPENHD_PLUGIN_API_VERSION
+    const char *name;              // Human-readable
+    const char *version;           // Semantic version string
+    const char *description;       // Short summary
+    uint32_t capabilities;         // Bitmask for feature flags (e.g., ENCRYPTION=0x1)
+    int (*init)(const struct openhd_plugin_context *ctx);
+    void (*deinit)(void);
+    const struct openhd_encryption_vtable *encryption; // NULL if not provided
+} openhd_plugin_descriptor;
+```
+
+## Context & VTables
+- **Context**: Provided by the core during `init` to supply services (logging, configuration access, telemetry hooks).
+  ```c++
+  typedef struct openhd_plugin_context {
+      uint32_t size; // ABI guard
+      void (*log)(int level, const char *component, const char *fmt, ...);
+      void *(*allocate)(size_t bytes);
+      void (*deallocate)(void *ptr);
+      void *user_data; // Optional pointer for core-managed state
+  } openhd_plugin_context;
+  ```
+- **Encryption VTable**: Encapsulates function pointers exposed by the plugin.
+  ```c++
+  typedef struct openhd_encryption_vtable {
+      int (*set_bindphrase)(const char *phrase);
+      int (*encrypt_frame)(const uint8_t *in, size_t in_size, uint8_t *out, size_t *out_size);
+      int (*decrypt_frame)(const uint8_t *in, size_t in_size, uint8_t *out, size_t *out_size);
+      int (*current_status)(struct openhd_encryption_status *status);
+  } openhd_encryption_vtable;
+  ```
+
+## Capability Flags
+- `OPENHD_CAP_ENCRYPTION = 0x0001`
+- `OPENHD_CAP_BINDPHRASE = 0x0002`
+- Additional flags reserved for telemetry, video encoding, etc.
+
+## Versioning Strategy
+- Increment `OPENHD_PLUGIN_API_VERSION` when breaking ABI changes.
+- Maintain compatibility by allowing plugins to implement multiple descriptors via optional `openhd_plugin_get_descriptor_vN()` exports (future).
+- Provide helper `openhd::PluginVersion` struct to compare plugin semantic versions.
+
+## Plugin Entry Point
+- Each plugin exports exactly one symbol:
+  ```c++
+  OPENHD_PLUGIN_EXPORT const openhd_plugin_descriptor* openhd_plugin_get_descriptor();
+  ```
+- Manager validates `descriptor->api_version`.
+- Manager stores pointer to descriptor for the lifetime of the plugin (must remain valid).
+
+## Core Consumption Pattern
+```c++
+const openhd_plugin_descriptor *desc = load_descriptor(path);
+if (desc->capabilities & OPENHD_CAP_ENCRYPTION) {
+    active_encryption_vtable = desc->encryption;
+    desc->init(&core_context);
+}
+```
+
+## Safety Notes
+- All structs padded to avoid alignment issues; document requirement for `sizeof(openhd_plugin_context)`.
+- Use `extern "C"` to avoid name mangling.
+- Document thread-safety expectations explicitly in descriptor description field.
+
+## Automation Prompt
+```
+You are assisting with "04. Plugin Interface Design" for the OpenHD plugin system manual. Produce header-style code blocks for descriptor, context, and encryption vtable definitions, list capability flags, and explain versioning and entry point conventions.
+```

--- a/plugin_system_guide/05_migrating_encryption_to_plugin.md
+++ b/plugin_system_guide/05_migrating_encryption_to_plugin.md
@@ -1,0 +1,133 @@
+# 05. Migrating Encryption to a Plugin
+
+## Objective
+- Extract all encryption/bindphrase logic from OpenHD core into `plugins/encryption/` shared library.
+- Maintain functional parity with existing features while allowing optional plugin deployment.
+
+## Phase 1: Inventory Existing Logic
+1. Search for relevant keywords:
+   ```bash
+   rg "bindphrase" -n OpenHD/
+   rg "encrypt" -n OpenHD/
+   rg "decrypt" -n OpenHD/
+   rg "libsodium" -n
+   ```
+2. Catalog:
+   - Source files containing encryption functions (e.g., `OpenHD/src/encryption.cpp`).
+   - Configuration interfaces (CLI flags, config files).
+   - Data structures or enums referencing bindphrase.
+   - Unit/integration tests covering encryption.
+3. Document dependencies (e.g., libsodium, OpenSSL) and confirm they can be linked from plugin.
+
+## Phase 2: Define Core ↔ Plugin Boundary
+- Map each function to plugin vtable entry (encrypt/decrypt/set_bindphrase/status).
+- Identify any global state to move into plugin-owned static or context-managed storage.
+- Decide which configuration flows remain in core (e.g., loading bindphrase string) and which move into plugin.
+
+## Phase 3: Create Plugin Skeleton
+1. Create directory structure:
+   ```bash
+   mkdir -p plugins/encryption/include
+   mkdir -p plugins/encryption/src
+   ```
+2. Add `plugins/encryption/CMakeLists.txt`:
+   ```cmake
+   add_library(openhd_encryption_plugin SHARED
+       src/encryption_plugin.cpp
+       src/bindphrase_manager.cpp
+   )
+   target_include_directories(openhd_encryption_plugin
+       PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+       PUBLIC ${CMAKE_SOURCE_DIR}/include
+   )
+   target_link_libraries(openhd_encryption_plugin
+       PRIVATE sodium
+   )
+   set_target_properties(openhd_encryption_plugin PROPERTIES
+       OUTPUT_NAME "openhd_encryption"
+       LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins
+   )
+   ```
+3. Add to root `CMakeLists.txt`:
+   ```cmake
+   add_subdirectory(plugins/encryption)
+   install(TARGETS openhd_encryption_plugin
+       LIBRARY DESTINATION lib/openhd/plugins
+       RUNTIME DESTINATION lib/openhd/plugins
+   )
+   install(FILES plugins/encryption/plugin.json DESTINATION share/openhd/plugins)
+   ```
+
+## Phase 4: Move Implementation
+1. Copy encryption headers into `plugins/encryption/include/` and adjust includes to reference `openhd/plugin.h`.
+2. Implement descriptor and vtable in `src/encryption_plugin.cpp`:
+   ```c++
+   #include "openhd/plugin.h"
+   #include "bindphrase_manager.h"
+
+   static openhd_encryption_vtable g_vtable {
+       &set_bindphrase_impl,
+       &encrypt_frame_impl,
+       &decrypt_frame_impl,
+       &current_status_impl
+   };
+
+   static openhd_plugin_descriptor g_descriptor {
+       OPENHD_PLUGIN_API_VERSION,
+       "OpenHD Encryption",
+       "1.0.0",
+       "Provides encryption & bindphrase handling",
+       OPENHD_CAP_ENCRYPTION | OPENHD_CAP_BINDPHRASE,
+       &plugin_init,
+       &plugin_deinit,
+       &g_vtable
+   };
+
+   OPENHD_PLUGIN_EXPORT const openhd_plugin_descriptor* openhd_plugin_get_descriptor() {
+       return &g_descriptor;
+   }
+   ```
+3. Port logic from original files into plugin sources, updating namespaces and removing direct dependencies on OpenHD globals.
+4. Provide `plugin_init` to capture context pointers and configure logging.
+
+## Phase 5: Update Core to Use Plugin
+1. Add plugin manager calls in initialization path (e.g., `OpenHD/src/main.cpp`):
+   ```c++
+   plugin_manager.load_all();
+   auto encryption = plugin_manager.get_encryption();
+   if (encryption) {
+       encryption->set_bindphrase(config.bindphrase.c_str());
+   } else {
+       OPENHD_LOG_WARN("Encryption plugin unavailable; running without encryption");
+   }
+   ```
+2. Replace direct encryption calls with `encryption->encrypt_frame(...)` wrappers.
+3. Remove old encryption sources from `target_sources(openhd ...)`.
+4. Keep lightweight compatibility stubs to log warnings when plugin missing.
+
+## Phase 6: Configuration & Packaging
+- Update configuration docs to mention plugin requirement and path.
+- Ensure runtime packaging copies `.so` plus optional `plugin.json` metadata.
+- Provide fallback config flag `enable_encryption_plugin=false` for builds without plugin.
+
+## Phase 7: Verification
+1. Build plugin and core:
+   ```bash
+   cmake -S . -B build -DENABLE_ENCRYPTION_PLUGIN=ON
+   cmake --build build --target openhd openhd_encryption_plugin
+   ```
+2. Run existing tests to confirm no regressions:
+   ```bash
+   ctest --test-dir build
+   ```
+3. Execute runtime smoke test:
+   ```bash
+   build/openhd --config openhd.conf --log-level debug
+   ```
+   - Observe logs confirming plugin load and bindphrase application.
+4. Test fallback by removing plugin from search path and verifying warnings only.
+
+## Automation Prompt
+```
+You are assisting with "05. Migrating Encryption to a Plugin" for the OpenHD plugin system manual. Produce step-by-step shell commands, CMake snippets, and C++ templates to move encryption/bindphrase logic into a new plugin directory. Ensure you cover inventory, skeleton creation, core updates, packaging, and verification.
+```

--- a/plugin_system_guide/06_building_and_testing_plugins.md
+++ b/plugin_system_guide/06_building_and_testing_plugins.md
@@ -1,0 +1,69 @@
+# 06. Building & Testing Plugins
+
+## Build Configuration
+- Add cache options in top-level `CMakeLists.txt`:
+  ```cmake
+  option(OPENHD_ENABLE_PLUGINS "Enable plugin subsystem" ON)
+  option(OPENHD_BUILD_ENCRYPTION_PLUGIN "Build bundled encryption plugin" ON)
+  set(OPENHD_PLUGIN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/plugins" CACHE PATH "Runtime plugin directory")
+  ```
+- Wrap plugin-specific logic with `if (OPENHD_ENABLE_PLUGINS)` guards.
+- Expose output directory to runtime via configuration file (`openhd.conf`).
+
+## Full Build Sequence
+1. Configure project with plugins enabled:
+   ```bash
+   cmake -S . -B build -DOPENHD_ENABLE_PLUGINS=ON -DOPENHD_BUILD_ENCRYPTION_PLUGIN=ON \
+         -DOPENHD_PLUGIN_OUTPUT_DIR=$PWD/build/plugins
+   ```
+2. Build targets:
+   ```bash
+   cmake --build build --target openhd openhd_encryption_plugin
+   ```
+3. Install artifacts into staging directory:
+   ```bash
+   cmake --install build --prefix $PWD/stage
+   ```
+4. Verify plugin placement:
+   ```bash
+   ls -R build/plugins
+   ls stage/lib/openhd/plugins
+   ```
+
+## Unit & Integration Tests
+- Extend existing test suites with plugin-aware cases:
+  - Create `tests/plugin_manager_tests.cpp` verifying load success/failure paths.
+  - Mock plugin descriptors for unit tests without requiring real `.so`.
+- Example `ctest` invocation:
+  ```bash
+  ctest --test-dir build --output-on-failure -R plugin
+  ```
+- Add runtime integration test script `scripts/test_encryption_plugin.sh`:
+  ```bash
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export OPENHD_PLUGIN_PATH="$PWD/build/plugins"
+  build/openhd --config configs/encryption_plugin.conf --dry-run
+  ```
+
+## Continuous Integration Updates
+- Update `.github/workflows/build.yml` (or equivalent CI) to:
+  - Add matrix entry `OPENHD_ENABLE_PLUGINS=ON`.
+  - Upload plugin `.so` as artifact for downstream packaging.
+  - Run smoke tests with plugin path configured.
+- Add caching for build dependencies to reduce CI time.
+
+## Local Debugging Tips
+- Set `OPENHD_LOG_LEVEL=debug` to trace plugin load/unload events.
+- Use `ldd build/plugins/libopenhd_encryption.so` to confirm dependency resolution.
+- Leverage `strace -e openat` (Linux) to ensure plugin search paths are correct.
+
+## Packaging Considerations
+- Document plugin directory layout in packaging scripts (`package.sh`).
+- Ensure Debian/RPM spec files install plugin to `/usr/lib/openhd/plugins`.
+- Provide `postinst` script to create plugin directory with correct permissions.
+
+## Automation Prompt
+```
+You are assisting with "06. Building & Testing Plugins" for the OpenHD plugin system manual. Produce CMake configuration snippets, shell commands for building/installing/testing, CI checklist updates, and debugging tips. Use bullet lists and fenced code blocks.
+```

--- a/plugin_system_guide/07_notes_and_future_extensions.md
+++ b/plugin_system_guide/07_notes_and_future_extensions.md
@@ -1,0 +1,40 @@
+# 07. Notes & Future Extensions
+
+## Lessons Learned
+- Keep plugin API surface minimal to simplify ABI stability.
+- Document every exported symbol and struct field to help third-party developers.
+- Treat plugin loading failures as expected events; prefer graceful degradation over crashes.
+
+## Maintenance Checklist
+- [ ] Update API version and changelog whenever descriptor layout changes.
+- [ ] Run plugin regression tests before cutting new releases.
+- [ ] Validate plugin binary compatibility across supported architectures (ARM, x86_64).
+- [ ] Ensure documentation references correct plugin installation path after packaging updates.
+
+## Potential Enhancements
+- **Hot Reloading**: Implement filesystem watcher to reload plugins without restarting OpenHD.
+- **Sandboxing**: Explore seccomp/apparmor or Windows Job Objects to limit plugin permissions.
+- **Dependency Injection**: Expand context to expose more services (e.g., telemetry callbacks, metrics emitters).
+- **Version Negotiation**: Allow plugins to declare supported API ranges for smoother upgrades.
+- **Plugin Marketplace**: Define metadata schema (`plugin.json`) for discovery and auto-updates.
+
+## Security Considerations
+- Sign official plugins and verify signatures before loading.
+- Provide checksum verification for community plugins.
+- Run static analysis (`clang-tidy`, `cppcheck`) on plugin sources.
+- Adopt fuzz testing for encryption APIs to catch edge cases.
+
+## Documentation Roadmap
+- Publish developer guide on wiki with diagrams illustrating plugin load flow.
+- Record screencasts demonstrating plugin creation and integration tests.
+- Maintain FAQ covering troubleshooting steps for missing plugins.
+
+## Collaboration Tips
+- Encourage contributors to submit plugins in separate repositories.
+- Provide template repository with CI configured for plugin development.
+- Define review checklist ensuring interface compliance and logging coverage.
+
+## Automation Prompt
+```
+You are assisting with "07. Notes & Future Extensions" for the OpenHD plugin system manual. Summarize lessons learned, maintenance checklist, future enhancements, security notes, documentation roadmap, and collaboration tips using bullet lists and checkboxes where appropriate.
+```


### PR DESCRIPTION
## Summary
- add a seven-part markdown guide for implementing a runtime plugin architecture in OpenHD
- document dynamic loading mechanics, interface design, and the encryption plugin migration plan
- include build, testing, and future extension guidance plus automation prompts for code-generation tools

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d835352064832fbc99e4d59913d09e