### PR TITLE
Add plugin manager for shared object plugins

### DIFF
--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -72,7 +72,10 @@ set(sources
     "src/openhd_util_time.cpp"
     "src/openhd_bitrate.cpp"
     "src/openhd_thermal.cpp"
+    "src/plugins/plugin_manager.c"
 )
+
+set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/plugin_manager.c" PROPERTIES LANGUAGE CXX)
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${sources})
 

--- a/OpenHD/ohd_common/inc/openhd/plugins/plugins.h
+++ b/OpenHD/ohd_common/inc/openhd/plugins/plugins.h
@@ -1,0 +1,53 @@
+#ifndef OPENHD_PLUGINS_PLUGINS_H
+#define OPENHD_PLUGINS_PLUGINS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define OPENHD_PLUGIN_ABI_MAJOR 1
+#define OPENHD_PLUGIN_ABI_MINOR 0
+#define OPENHD_PLUGIN_API_VERSION ((OPENHD_PLUGIN_ABI_MAJOR << 16) | OPENHD_PLUGIN_ABI_MINOR)
+
+enum openhd_plugin_type {
+    OPENHD_PLUGIN_TYPE_UNKNOWN = 0,
+    OPENHD_PLUGIN_TYPE_ENCRYPTION,
+    OPENHD_PLUGIN_TYPE_MAX
+};
+
+struct openhd_plugin_info {
+    uint32_t abi_version;
+    const char *name;
+    const char *description;
+    enum openhd_plugin_type type;
+    uint32_t capabilities;
+};
+
+struct openhd_plugin_context;
+
+struct openhd_plugin {
+    struct openhd_plugin_context *context;
+};
+
+struct openhd_plugin_vtable;
+
+typedef const struct openhd_plugin_info *(*openhd_plugin_get_info_fn)(void);
+typedef struct openhd_plugin *(*openhd_plugin_init_fn)(void *host_context);
+typedef void (*openhd_plugin_shutdown_fn)(struct openhd_plugin *plugin);
+
+typedef bool (*openhd_plugin_query_vtable_fn)(struct openhd_plugin *plugin,
+                                               struct openhd_plugin_vtable *out_vtable);
+
+struct openhd_plugin_vtable {
+    openhd_plugin_shutdown_fn shutdown;
+    void *userdata;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENHD_PLUGINS_PLUGINS_H

--- a/OpenHD/ohd_common/inc/plugins/plugin_manager.h
+++ b/OpenHD/ohd_common/inc/plugins/plugin_manager.h
@@ -1,0 +1,49 @@
+#ifndef OPENHD_PLUGIN_MANAGER_H
+#define OPENHD_PLUGIN_MANAGER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "openhd/plugins/plugins.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct openhd_loaded_plugin {
+    void *dl_handle;
+    struct openhd_plugin *instance;
+    struct openhd_plugin_info info;
+    struct openhd_plugin_vtable vtable;
+    bool initialized;
+    bool load_failed;
+};
+
+struct openhd_plugin_manager {
+    struct openhd_loaded_plugin *plugins;
+    size_t plugin_count;
+    size_t plugin_capacity;
+    char **search_paths;
+    size_t search_path_count;
+    size_t search_path_capacity;
+};
+
+typedef bool (*openhd_plugin_iterate_fn)(struct openhd_loaded_plugin *plugin, void *userdata);
+
+void openhd_plugin_manager_init(struct openhd_plugin_manager *mgr);
+void openhd_plugin_manager_shutdown(struct openhd_plugin_manager *mgr);
+
+bool openhd_plugin_manager_add_search_path(struct openhd_plugin_manager *mgr, const char *path);
+
+bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr, const char *file_path, void *host_context);
+
+void openhd_plugin_manager_foreach(struct openhd_plugin_manager *mgr, openhd_plugin_iterate_fn fn, void *userdata);
+
+struct openhd_loaded_plugin *openhd_plugin_manager_get_by_type(struct openhd_plugin_manager *mgr,
+                                                               enum openhd_plugin_type type);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENHD_PLUGIN_MANAGER_H

--- a/OpenHD/ohd_common/src/plugins/plugin_manager.c
+++ b/OpenHD/ohd_common/src/plugins/plugin_manager.c
@@ -1,0 +1,265 @@
+#include "plugins/plugin_manager.h"
+
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct openhd_plugin_symbol_table {
+    openhd_plugin_get_info_fn get_info;
+    openhd_plugin_init_fn init;
+    openhd_plugin_shutdown_fn shutdown;
+    openhd_plugin_query_vtable_fn query_vtable;
+};
+
+static void openhd_loaded_plugin_reset(struct openhd_loaded_plugin *plugin) {
+    if (!plugin) {
+        return;
+    }
+
+    plugin->dl_handle = NULL;
+    plugin->instance = NULL;
+    memset(&plugin->info, 0, sizeof(plugin->info));
+    memset(&plugin->vtable, 0, sizeof(plugin->vtable));
+    plugin->initialized = false;
+    plugin->load_failed = false;
+}
+
+static bool openhd_plugin_manager_ensure_plugin_capacity(struct openhd_plugin_manager *mgr) {
+    if (mgr->plugin_count < mgr->plugin_capacity) {
+        return true;
+    }
+
+    size_t new_capacity = mgr->plugin_capacity == 0 ? 4 : mgr->plugin_capacity * 2;
+    struct openhd_loaded_plugin *new_plugins = NULL;
+
+    if (mgr->plugin_capacity == 0) {
+        new_plugins = (struct openhd_loaded_plugin *)calloc(new_capacity, sizeof(*new_plugins));
+    } else {
+        new_plugins = (struct openhd_loaded_plugin *)realloc(mgr->plugins, new_capacity * sizeof(*new_plugins));
+    }
+    if (!new_plugins) {
+        // TODO: Replace with OpenHD logging when available.
+        return false;
+    }
+
+    for (size_t i = mgr->plugin_capacity; i < new_capacity; ++i) {
+        openhd_loaded_plugin_reset(&new_plugins[i]);
+    }
+
+    mgr->plugins = new_plugins;
+    mgr->plugin_capacity = new_capacity;
+    return true;
+}
+
+static bool openhd_plugin_manager_ensure_path_capacity(struct openhd_plugin_manager *mgr) {
+    if (mgr->search_path_count < mgr->search_path_capacity) {
+        return true;
+    }
+
+    size_t new_capacity = mgr->search_path_capacity == 0 ? 4 : mgr->search_path_capacity * 2;
+    char **new_paths = NULL;
+
+    if (mgr->search_path_capacity == 0) {
+        new_paths = (char **)calloc(new_capacity, sizeof(*new_paths));
+    } else {
+        new_paths = (char **)realloc(mgr->search_paths, new_capacity * sizeof(*new_paths));
+    }
+    if (!new_paths) {
+        // TODO: Replace with OpenHD logging when available.
+        return false;
+    }
+
+    for (size_t i = mgr->search_path_capacity; i < new_capacity; ++i) {
+        new_paths[i] = NULL;
+    }
+
+    mgr->search_paths = new_paths;
+    mgr->search_path_capacity = new_capacity;
+    return true;
+}
+
+static void openhd_plugin_manager_release_plugin(struct openhd_loaded_plugin *plugin) {
+    if (!plugin) {
+        return;
+    }
+
+    if (plugin->initialized && plugin->vtable.shutdown && plugin->instance) {
+        plugin->vtable.shutdown(plugin->instance);
+    }
+
+    if (plugin->dl_handle) {
+        dlclose(plugin->dl_handle);
+    }
+
+    openhd_loaded_plugin_reset(plugin);
+}
+
+static bool openhd_plugin_manager_load_symbols(void *handle, struct openhd_plugin_symbol_table *out_symbols) {
+    if (!handle || !out_symbols) {
+        return false;
+    }
+
+    memset(out_symbols, 0, sizeof(*out_symbols));
+
+    out_symbols->get_info = (openhd_plugin_get_info_fn)dlsym(handle, "openhd_plugin_get_info");
+    out_symbols->init = (openhd_plugin_init_fn)dlsym(handle, "openhd_plugin_init");
+    out_symbols->shutdown = (openhd_plugin_shutdown_fn)dlsym(handle, "openhd_plugin_shutdown");
+    out_symbols->query_vtable = (openhd_plugin_query_vtable_fn)dlsym(handle, "openhd_plugin_query_vtable");
+
+    if (!out_symbols->get_info || !out_symbols->init || !out_symbols->shutdown) {
+        // TODO: Replace with OpenHD logging when available.
+        return false;
+    }
+
+    return true;
+}
+
+void openhd_plugin_manager_init(struct openhd_plugin_manager *mgr) {
+    if (!mgr) {
+        return;
+    }
+
+    memset(mgr, 0, sizeof(*mgr));
+}
+
+void openhd_plugin_manager_shutdown(struct openhd_plugin_manager *mgr) {
+    if (!mgr) {
+        return;
+    }
+
+    for (size_t i = 0; i < mgr->plugin_count; ++i) {
+        openhd_plugin_manager_release_plugin(&mgr->plugins[i]);
+    }
+
+    free(mgr->plugins);
+    mgr->plugins = NULL;
+    mgr->plugin_count = 0;
+    mgr->plugin_capacity = 0;
+
+    for (size_t i = 0; i < mgr->search_path_count; ++i) {
+        free(mgr->search_paths[i]);
+    }
+
+    free(mgr->search_paths);
+    mgr->search_paths = NULL;
+    mgr->search_path_count = 0;
+    mgr->search_path_capacity = 0;
+}
+
+bool openhd_plugin_manager_add_search_path(struct openhd_plugin_manager *mgr, const char *path) {
+    if (!mgr || !path || path[0] == '\0') {
+        return false;
+    }
+
+    if (!openhd_plugin_manager_ensure_path_capacity(mgr)) {
+        return false;
+    }
+
+    char *copy = strdup(path);
+    if (!copy) {
+        // TODO: Replace with OpenHD logging when available.
+        return false;
+    }
+
+    mgr->search_paths[mgr->search_path_count++] = copy;
+    return true;
+}
+
+bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr, const char *file_path, void *host_context) {
+    if (!mgr || !file_path || file_path[0] == '\0') {
+        return false;
+    }
+
+    void *handle = dlopen(file_path, RTLD_NOW);
+    if (!handle) {
+        // TODO: Replace with OpenHD logging when available.
+        return false;
+    }
+
+    struct openhd_plugin_symbol_table symbols;
+    if (!openhd_plugin_manager_load_symbols(handle, &symbols)) {
+        dlclose(handle);
+        return false;
+    }
+
+    const struct openhd_plugin_info *info = symbols.get_info();
+    if (!info) {
+        // TODO: Replace with OpenHD logging when available.
+        dlclose(handle);
+        return false;
+    }
+
+    if (info->abi_version != OPENHD_PLUGIN_API_VERSION) {
+        // TODO: Replace with OpenHD logging when available.
+        dlclose(handle);
+        return false;
+    }
+
+    struct openhd_plugin *instance = symbols.init(host_context);
+    if (!instance) {
+        // TODO: Replace with OpenHD logging when available.
+        dlclose(handle);
+        return false;
+    }
+
+    struct openhd_plugin_vtable vtable;
+    memset(&vtable, 0, sizeof(vtable));
+
+    if (symbols.query_vtable) {
+        if (!symbols.query_vtable(instance, &vtable)) {
+            // TODO: Replace with OpenHD logging when available.
+            symbols.shutdown(instance);
+            dlclose(handle);
+            return false;
+        }
+    }
+
+    if (!vtable.shutdown) {
+        vtable.shutdown = symbols.shutdown;
+    }
+
+    if (!openhd_plugin_manager_ensure_plugin_capacity(mgr)) {
+        symbols.shutdown(instance);
+        dlclose(handle);
+        return false;
+    }
+
+    struct openhd_loaded_plugin *slot = &mgr->plugins[mgr->plugin_count];
+    openhd_loaded_plugin_reset(slot);
+    slot->dl_handle = handle;
+    slot->instance = instance;
+    memcpy(&slot->info, info, sizeof(slot->info));
+    memcpy(&slot->vtable, &vtable, sizeof(slot->vtable));
+    slot->initialized = true;
+    slot->load_failed = false;
+
+    mgr->plugin_count += 1;
+    return true;
+}
+
+void openhd_plugin_manager_foreach(struct openhd_plugin_manager *mgr, openhd_plugin_iterate_fn fn, void *userdata) {
+    if (!mgr || !fn) {
+        return;
+    }
+
+    for (size_t i = 0; i < mgr->plugin_count; ++i) {
+        if (!fn(&mgr->plugins[i], userdata)) {
+            break;
+        }
+    }
+}
+
+struct openhd_loaded_plugin *openhd_plugin_manager_get_by_type(struct openhd_plugin_manager *mgr,
+                                                               enum openhd_plugin_type type) {
+    if (!mgr) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < mgr->plugin_count; ++i) {
+        if (mgr->plugins[i].initialized && mgr->plugins[i].info.type == type) {
+            return &mgr->plugins[i];
+        }
+    }
+
+    return NULL;
+}


### PR DESCRIPTION
## Summary
- add core plugin ABI definitions for use in C components
- implement a plugin manager capable of loading shared object plugins and tracking search paths
- integrate the plugin manager into the common library build

## Testing
- ninja -C build

------
https://chatgpt.com/codex/tasks/task_e_68d8630846f8832f8505c87fa7929dd3