### PR TITLE
Fix plugin manager interface for clang builds

### DIFF
--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -72,10 +72,8 @@ set(sources
     "src/openhd_util_time.cpp"
     "src/openhd_bitrate.cpp"
     "src/openhd_thermal.cpp"
-    "src/plugins/plugin_manager.c"
+    "src/plugins/plugin_manager.cpp"
 )
-
-set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/plugins/plugin_manager.c" PROPERTIES LANGUAGE CXX)
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${sources})
 

--- a/OpenHD/ohd_common/inc/plugins/plugin_manager.h
+++ b/OpenHD/ohd_common/inc/plugins/plugin_manager.h
@@ -12,7 +12,7 @@ extern "C" {
 
 struct openhd_loaded_plugin {
     void *dl_handle;
-    struct openhd_plugin *instance;
+    struct openhd_plugin_context *instance;
     struct openhd_plugin_info info;
     struct openhd_plugin_vtable vtable;
     bool initialized;

--- a/OpenHD/ohd_common/inc/plugins/plugins.h
+++ b/OpenHD/ohd_common/inc/plugins/plugins.h
@@ -46,6 +46,18 @@ typedef struct openhd_plugin_context *(*openhd_plugin_init_fn)(void *host_contex
 // Shuts down a previously initialized plugin instance and releases resources.
 typedef void (*openhd_plugin_shutdown_fn)(struct openhd_plugin_context *context);
 
+// Generic dispatch table shared by all plugins. Individual plugin categories may extend the
+// payload with additional type-specific data (for example encryption related entry points).
+struct openhd_plugin_vtable {
+    openhd_plugin_shutdown_fn shutdown;  // Mandatory shutdown callback for the plugin instance.
+    void *payload;                       // Optional pointer to category specific dispatch tables.
+};
+
+// Optional callback exposed by plugins that want to provide a richer dispatch table. The function
+// is expected to populate the supplied vtable structure and return true on success.
+typedef bool (*openhd_plugin_query_vtable_fn)(struct openhd_plugin_context *context,
+                                              struct openhd_plugin_vtable *out_vtable);
+
 // Aggregates exported entry points and optional payloads for type-specific data.
 struct openhd_plugin_exports {
     openhd_plugin_get_info_fn get_info;   // Retrieves static plugin information.

--- a/OpenHD/ohd_common/src/plugins/plugin_manager.cpp
+++ b/OpenHD/ohd_common/src/plugins/plugin_manager.cpp
@@ -195,7 +195,7 @@ bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr, const char *f
         return false;
     }
 
-    struct openhd_plugin *instance = symbols.init(host_context);
+    struct openhd_plugin_context *instance = symbols.init(host_context);
     if (!instance) {
         // TODO: Replace with OpenHD logging when available.
         dlclose(handle);


### PR DESCRIPTION
## Summary
- add the missing plugin vtable definition and query callback to the public plugin interface
- update the plugin manager to use the opaque plugin context type and build it as C++
- rename the plugin manager translation unit to .cpp so clang treats it as C++ without warnings

## Testing
- cmake -S OpenHD -B build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68d869943278832faca95c6d86724b72