### PR TITLE
Add missing standard headers to main.cpp

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -34,6 +34,8 @@
 #include <iostream>
 #include <memory>
 #include <cstdlib>
+#include <optional>
+#include <sstream>
 
 #include "openhd_buttons.h"
 #include "openhd_global_constants.hpp"


### PR DESCRIPTION
## Summary
- include `<optional>` and `<sstream>` directly in `main.cpp`
- resolve build failures on toolchains that do not provide these headers transitively

## Testing
- cmake --build OpenHD/build

------
https://chatgpt.com/codex/tasks/task_e_68d875b5c914832fa7a81ff0792ceb43