### PR TITLE
Add dummy plugin loaded via plugin manager

### DIFF
--- a/OpenHD/CMakeLists.txt
+++ b/OpenHD/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16.3)
 project(OpenHD)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -25,6 +27,7 @@ add_subdirectory(ohd_common EXCLUDE_FROM_ALL)
 add_subdirectory(ohd_interface EXCLUDE_FROM_ALL)
 add_subdirectory(ohd_telemetry EXCLUDE_FROM_ALL)
 add_subdirectory(ohd_video EXCLUDE_FROM_ALL)
+add_subdirectory(plugins)
 
 # Suppress specific warnings
 add_compile_options(-Wno-address-of-packed-member -Wno-cast-align)
@@ -42,6 +45,15 @@ endif()
 
 # Link the libraries
 target_link_libraries(openhd PRIVATE OHDInterfaceLib OHDVideoLib OHDTelemetryLib OHDCommonLib)
+
+set(OPENHD_PLUGIN_BUILD_DIR "${CMAKE_BINARY_DIR}/plugins")
+set(OPENHD_PLUGIN_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/openhd/plugins")
+set(OPENHD_DUMMY_PLUGIN_FILENAME "${CMAKE_SHARED_LIBRARY_PREFIX}openhd_dummy_plugin${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+target_compile_definitions(openhd PRIVATE
+    OPENHD_BUILTIN_PLUGIN_DIR="${OPENHD_PLUGIN_BUILD_DIR}"
+    OPENHD_INSTALL_PLUGIN_DIR="${OPENHD_PLUGIN_INSTALL_DIR}"
+    OPENHD_DUMMY_PLUGIN_FILENAME="${OPENHD_DUMMY_PLUGIN_FILENAME}")
 
 # Check if libatomic is needed and available
 include(CheckLibraryExists)

--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -31,11 +31,14 @@
 #include <ohd_video_ground.h>
 
 #include <csignal>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <cstdlib>
 #include <optional>
 #include <sstream>
+#include <system_error>
+#include <vector>
 
 #include "openhd_buttons.h"
 #include "openhd_global_constants.hpp"
@@ -45,6 +48,67 @@
 #include "openhd_temporary_air_or_ground.h"
 #include "openhd_config.h"
 #include "config_paths.h"
+#include "plugins/plugin_manager.h"
+
+namespace {
+
+std::vector<std::filesystem::path> collect_plugin_directories() {
+  std::vector<std::filesystem::path> directories;
+  if (const char *env = std::getenv("OPENHD_PLUGIN_DIR")) {
+    if (*env != '\0') {
+      directories.emplace_back(env);
+    }
+  }
+#ifdef OPENHD_BUILTIN_PLUGIN_DIR
+  directories.emplace_back(std::filesystem::path(OPENHD_BUILTIN_PLUGIN_DIR));
+#endif
+#ifdef OPENHD_INSTALL_PLUGIN_DIR
+  directories.emplace_back(std::filesystem::path(OPENHD_INSTALL_PLUGIN_DIR));
+#endif
+  return directories;
+}
+
+bool load_dummy_plugin(struct openhd_plugin_manager *manager,
+                       const std::shared_ptr<spdlog::logger> &logger) {
+  if (!manager) {
+    return false;
+  }
+
+  const auto directories = collect_plugin_directories();
+  bool loaded = false;
+  for (const auto &directory : directories) {
+    if (directory.empty()) {
+      continue;
+    }
+    std::error_code dir_ec;
+    if (!std::filesystem::exists(directory, dir_ec)) {
+      continue;
+    }
+    std::filesystem::path candidate = directory / OPENHD_DUMMY_PLUGIN_FILENAME;
+    std::error_code candidate_ec;
+    if (!std::filesystem::exists(candidate, candidate_ec)) {
+      continue;
+    }
+    const auto candidate_str = candidate.string();
+    if (openhd_plugin_manager_load(manager, candidate_str.c_str(), nullptr)) {
+      if (logger) {
+        logger->debug("Loaded dummy plugin from {}", candidate_str);
+      }
+      loaded = true;
+      break;
+    }
+    if (logger) {
+      logger->warn("Failed to load dummy plugin from {}", candidate_str);
+    }
+  }
+
+  if (!loaded && logger) {
+    logger->debug("Dummy plugin was not loaded");
+  }
+  return loaded;
+}
+
+}  // namespace
 
 // |-------------------------------------------------------------------------------|
 // |                         OpenHD core executable | | Weather you run as air
@@ -256,6 +320,14 @@ int main(int argc, char *argv[]) {
       openhd::log::create_or_get("main");
   assert(m_console);
 
+  struct openhd_plugin_manager plugin_manager;
+  openhd_plugin_manager_init(&plugin_manager);
+  const auto shutdown_plugins = [&plugin_manager]() {
+    openhd_plugin_manager_shutdown(&plugin_manager);
+  };
+
+  load_dummy_plugin(&plugin_manager, m_console);
+
   // not guaranteed, but better than nothing, check if openhd is already running
   // (kinda) and print warning if yes.
   openhd::check_currently_running_file_and_write();
@@ -401,11 +473,14 @@ auto ohdInterface =
     }
   } catch (std::exception &ex) {
     std::cerr << "Error: " << ex.what() << std::endl;
+    shutdown_plugins();
     exit(1);
   } catch (...) {
     std::cerr << "Unknown exception occurred" << std::endl;
+    shutdown_plugins();
     exit(1);
   }
+  shutdown_plugins();
   openhd::remove_currently_running_file();
   return 0;
 }

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -18,6 +18,8 @@ add_compile_options(-Wno-psabi)
 add_library(OHDCommonLib STATIC) # Initialized below
 add_library(OHDCommonLib::OHDCommonLib ALIAS OHDCommonLib)
 
+set_target_properties(OHDCommonLib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 #----------------------------------------------------------------------------------------------------------------------
 # Explicitly link stdc++fs for GCC 8.x compatibility with std::filesystem
 #----------------------------------------------------------------------------------------------------------------------

--- a/OpenHD/plugins/CMakeLists.txt
+++ b/OpenHD/plugins/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(dummy_plugin)

--- a/OpenHD/plugins/dummy_plugin/CMakeLists.txt
+++ b/OpenHD/plugins/dummy_plugin/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_library(openhd_dummy_plugin SHARED dummy_plugin.cpp)
+
+set_target_properties(openhd_dummy_plugin PROPERTIES
+    OUTPUT_NAME "openhd_dummy_plugin"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set_target_properties(openhd_dummy_plugin PROPERTIES PREFIX "")
+endif()
+
+target_include_directories(openhd_dummy_plugin
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/ohd_common/inc)
+
+target_link_libraries(openhd_dummy_plugin
+    PRIVATE
+        OHDCommonLib)
+
+install(TARGETS openhd_dummy_plugin
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/openhd/plugins"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/openhd/plugins"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}/openhd/plugins")

--- a/OpenHD/plugins/dummy_plugin/dummy_plugin.cpp
+++ b/OpenHD/plugins/dummy_plugin/dummy_plugin.cpp
@@ -1,0 +1,74 @@
+#include "plugins/plugins.h"
+
+#include "openhd_spdlog.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <thread>
+
+#include <spdlog/spdlog.h>
+
+namespace {
+
+struct DummyPluginContext {
+  std::shared_ptr<spdlog::logger> logger;
+  std::atomic<bool> running{false};
+  std::thread worker;
+};
+
+void run_worker(DummyPluginContext *context) {
+  using namespace std::chrono_literals;
+  while (context->running.load(std::memory_order_acquire)) {
+    context->logger->debug("Dummy plugin says: hello world");
+    for (int i = 0; i < 50 &&
+                    context->running.load(std::memory_order_acquire);
+         ++i) {
+      std::this_thread::sleep_for(100ms);
+    }
+  }
+}
+
+}  // namespace
+
+extern "C" {
+
+struct openhd_plugin_context {
+  DummyPluginContext impl;
+};
+
+const struct openhd_plugin_info *openhd_plugin_get_info() {
+  static const struct openhd_plugin_info kInfo = {
+      OPENHD_PLUGIN_API_VERSION,
+      "dummy_hello_plugin",
+      "Logs a hello world message every five seconds.",
+      openhd_plugin_type::UNKNOWN,
+      0,
+  };
+  return &kInfo;
+}
+
+struct openhd_plugin_context *openhd_plugin_init(void * /*host_context*/) {
+  auto *context = new openhd_plugin_context();
+  context->impl.logger = openhd::log::create_or_get("dummy_plugin");
+  context->impl.logger->set_level(spdlog::level::debug);
+  context->impl.logger->debug("Initializing dummy plugin");
+  context->impl.running.store(true, std::memory_order_release);
+  context->impl.worker = std::thread(run_worker, &context->impl);
+  return context;
+}
+
+void openhd_plugin_shutdown(struct openhd_plugin_context *context) {
+  if (!context) {
+    return;
+  }
+  context->impl.logger->debug("Shutting down dummy plugin");
+  context->impl.running.store(false, std::memory_order_release);
+  if (context->impl.worker.joinable()) {
+    context->impl.worker.join();
+  }
+  delete context;
+}
+
+}  // extern "C"


### PR DESCRIPTION
## Summary
- add build infrastructure for plugins and compile a dummy hello-world plugin
- load the dummy plugin at runtime through the plugin manager with configurable search paths
- build OHDCommon with PIC to allow linking into shared plugins

## Testing
- cmake --build OpenHD/build --target openhd_dummy_plugin
- cmake --build OpenHD/build --target openhd

------
https://chatgpt.com/codex/tasks/task_e_68d87d957924832f8b00e7873d9c158a