### PR TITLE
Improve plugin discovery and loading

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -37,6 +37,7 @@
 #include <cstdlib>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <system_error>
 #include <vector>
 
@@ -68,44 +69,67 @@ std::vector<std::filesystem::path> collect_plugin_directories() {
   return directories;
 }
 
-bool load_dummy_plugin(struct openhd_plugin_manager *manager,
-                       const std::shared_ptr<spdlog::logger> &logger) {
+bool load_plugins(struct openhd_plugin_manager *manager,
+                  const std::shared_ptr<spdlog::logger> &logger) {
   if (!manager) {
     return false;
   }
 
   const auto directories = collect_plugin_directories();
-  bool loaded = false;
+  bool added_search_path = false;
   for (const auto &directory : directories) {
     if (directory.empty()) {
       continue;
     }
     std::error_code dir_ec;
-    if (!std::filesystem::exists(directory, dir_ec)) {
-      continue;
-    }
-    std::filesystem::path candidate = directory / OPENHD_DUMMY_PLUGIN_FILENAME;
-    std::error_code candidate_ec;
-    if (!std::filesystem::exists(candidate, candidate_ec)) {
-      continue;
-    }
-    const auto candidate_str = candidate.string();
-    if (openhd_plugin_manager_load(manager, candidate_str.c_str(), nullptr)) {
+    if (!std::filesystem::exists(directory, dir_ec) ||
+        !std::filesystem::is_directory(directory, dir_ec)) {
       if (logger) {
-        logger->debug("Loaded dummy plugin from {}", candidate_str);
+        logger->debug("Skipping plugin directory {}", directory.string());
       }
-      loaded = true;
-      break;
+      continue;
     }
-    if (logger) {
-      logger->warn("Failed to load dummy plugin from {}", candidate_str);
+    const auto dir_str = directory.string();
+    if (openhd_plugin_manager_add_search_path(manager, dir_str.c_str())) {
+      added_search_path = true;
+      if (logger) {
+        logger->debug("Added plugin search path {}", dir_str);
+      }
     }
   }
 
-  if (!loaded && logger) {
-    logger->debug("Dummy plugin was not loaded");
+  if (!added_search_path) {
+    if (logger) {
+      logger->debug("No plugin directories available");
+    }
+    return false;
   }
-  return loaded;
+
+  const bool loaded_any = openhd_plugin_manager_load_all(manager, nullptr);
+
+  if (!logger) {
+    return loaded_any;
+  }
+
+  if (loaded_any) {
+    logger->info("Loaded {} plugin(s)", manager->plugin_count);
+    openhd_plugin_manager_foreach(
+        manager,
+        [](struct openhd_loaded_plugin *plugin, void *userdata) {
+          auto *log = static_cast<spdlog::logger *>(userdata);
+          if (!plugin || !plugin->initialized || !log) {
+            return true;
+          }
+          const char *name = plugin->info.name ? plugin->info.name : "<unnamed>";
+          log->debug("Loaded plugin '{}'", name);
+          return true;
+        },
+        logger.get());
+  } else {
+    logger->debug("No plugins were loaded from the plugin directories");
+  }
+
+  return loaded_any;
 }
 
 }  // namespace
@@ -326,7 +350,7 @@ int main(int argc, char *argv[]) {
     openhd_plugin_manager_shutdown(&plugin_manager);
   };
 
-  load_dummy_plugin(&plugin_manager, m_console);
+  load_plugins(&plugin_manager, m_console);
 
   // not guaranteed, but better than nothing, check if openhd is already running
   // (kinda) and print warning if yes.

--- a/OpenHD/ohd_common/inc/plugins/plugin_manager.h
+++ b/OpenHD/ohd_common/inc/plugins/plugin_manager.h
@@ -40,6 +40,9 @@ bool openhd_plugin_manager_add_search_path(struct openhd_plugin_manager *mgr,
 bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr,
                                 const char *file_path, void *host_context);
 
+bool openhd_plugin_manager_load_all(struct openhd_plugin_manager *mgr,
+                                    void *host_context);
+
 void openhd_plugin_manager_foreach(struct openhd_plugin_manager *mgr,
                                    openhd_plugin_iterate_fn fn, void *userdata);
 

--- a/OpenHD/ohd_common/src/plugins/plugin_manager.cpp
+++ b/OpenHD/ohd_common/src/plugins/plugin_manager.cpp
@@ -4,12 +4,72 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
 struct openhd_plugin_symbol_table {
   openhd_plugin_get_info_fn get_info;
   openhd_plugin_init_fn init;
   openhd_plugin_shutdown_fn shutdown;
   openhd_plugin_query_vtable_fn query_vtable;
 };
+
+namespace {
+
+void log_loader_error(const char *message, const char *detail = nullptr) {
+  if (!message) {
+    return;
+  }
+  if (detail) {
+    std::fprintf(stderr, "[OpenHD][plugins] %s: %s\n", message, detail);
+  } else {
+    std::fprintf(stderr, "[OpenHD][plugins] %s\n", message);
+  }
+}
+
+bool has_shared_library_extension(const std::filesystem::path &path) {
+  const auto filename = path.filename().string();
+#if defined(_WIN32)
+  const std::string suffix = ".dll";
+  if (filename.size() < suffix.size()) {
+    return false;
+  }
+  const auto tail = filename.substr(filename.size() - suffix.size());
+  std::string lower_tail;
+  lower_tail.resize(tail.size());
+  std::transform(tail.begin(), tail.end(), lower_tail.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return lower_tail == suffix;
+#elif defined(__APPLE__)
+  static const char *const kSuffixes[] = {".dylib", ".so"};
+  for (const auto *suffix : kSuffixes) {
+    const auto len = std::strlen(suffix);
+    if (filename.size() >= len &&
+        filename.compare(filename.size() - len, len, suffix) == 0) {
+      return true;
+    }
+  }
+  return false;
+#else
+  static const char *const kSuffixes[] = {".so"};
+  for (const auto *suffix : kSuffixes) {
+    const auto len = std::strlen(suffix);
+    if (filename.size() >= len &&
+        filename.compare(filename.size() - len, len, suffix) == 0) {
+      return true;
+    }
+  }
+  const auto so_pos = filename.find(".so.");
+  return so_pos != std::string::npos;
+#endif
+}
+
+}  // namespace
 
 static void openhd_loaded_plugin_reset(struct openhd_loaded_plugin *plugin) {
   if (!plugin) {
@@ -42,7 +102,7 @@ static bool openhd_plugin_manager_ensure_plugin_capacity(
         mgr->plugins, new_capacity * sizeof(*new_plugins));
   }
   if (!new_plugins) {
-    // TODO: Replace with OpenHD logging when available.
+    log_loader_error("Failed to allocate memory for plugin table");
     return false;
   }
 
@@ -72,7 +132,7 @@ static bool openhd_plugin_manager_ensure_path_capacity(
         (char **)realloc(mgr->search_paths, new_capacity * sizeof(*new_paths));
   }
   if (!new_paths) {
-    // TODO: Replace with OpenHD logging when available.
+    log_loader_error("Failed to allocate memory for plugin search paths");
     return false;
   }
 
@@ -120,7 +180,7 @@ static bool openhd_plugin_manager_load_symbols(
       handle, "openhd_plugin_query_vtable");
 
   if (!out_symbols->get_info || !out_symbols->init || !out_symbols->shutdown) {
-    // TODO: Replace with OpenHD logging when available.
+    log_loader_error("Plugin is missing required entry points");
     return false;
   }
 
@@ -165,6 +225,12 @@ bool openhd_plugin_manager_add_search_path(struct openhd_plugin_manager *mgr,
     return false;
   }
 
+  for (size_t i = 0; i < mgr->search_path_count; ++i) {
+    if (mgr->search_paths[i] && std::strcmp(mgr->search_paths[i], path) == 0) {
+      return true;
+    }
+  }
+
   if (!openhd_plugin_manager_ensure_path_capacity(mgr)) {
     return false;
   }
@@ -187,7 +253,8 @@ bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr,
 
   void *handle = dlopen(file_path, RTLD_NOW);
   if (!handle) {
-    // TODO: Replace with OpenHD logging when available.
+    const char *error = dlerror();
+    log_loader_error("dlopen failed", error ? error : file_path);
     return false;
   }
 
@@ -199,20 +266,20 @@ bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr,
 
   const struct openhd_plugin_info *info = symbols.get_info();
   if (!info) {
-    // TODO: Replace with OpenHD logging when available.
+    log_loader_error("Plugin did not return metadata", file_path);
     dlclose(handle);
     return false;
   }
 
   if (info->abi_version != OPENHD_PLUGIN_API_VERSION) {
-    // TODO: Replace with OpenHD logging when available.
+    log_loader_error("Plugin ABI version mismatch", file_path);
     dlclose(handle);
     return false;
   }
 
   struct openhd_plugin_context *instance = symbols.init(host_context);
   if (!instance) {
-    // TODO: Replace with OpenHD logging when available.
+    log_loader_error("Plugin failed to initialise", file_path);
     dlclose(handle);
     return false;
   }
@@ -222,7 +289,7 @@ bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr,
 
   if (symbols.query_vtable) {
     if (!symbols.query_vtable(instance, &vtable)) {
-      // TODO: Replace with OpenHD logging when available.
+      log_loader_error("Plugin rejected vtable query", file_path);
       symbols.shutdown(instance);
       dlclose(handle);
       return false;
@@ -250,6 +317,52 @@ bool openhd_plugin_manager_load(struct openhd_plugin_manager *mgr,
 
   mgr->plugin_count += 1;
   return true;
+}
+
+bool openhd_plugin_manager_load_all(struct openhd_plugin_manager *mgr,
+                                    void *host_context) {
+  if (!mgr) {
+    return false;
+  }
+
+  bool loaded_any = false;
+  for (size_t i = 0; i < mgr->search_path_count; ++i) {
+    const char *raw_path = mgr->search_paths[i];
+    if (!raw_path || raw_path[0] == '\0') {
+      continue;
+    }
+
+    const std::filesystem::path directory(raw_path);
+    std::error_code ec;
+    if (!std::filesystem::exists(directory, ec) ||
+        !std::filesystem::is_directory(directory, ec)) {
+      continue;
+    }
+
+    for (std::filesystem::directory_iterator it(directory, ec);
+         !ec && it != std::filesystem::directory_iterator(); ++it) {
+      const std::filesystem::path &entry_path = it->path();
+      std::error_code type_ec;
+      if (!it->is_regular_file(type_ec)) {
+        continue;
+      }
+
+      if (!has_shared_library_extension(entry_path)) {
+        continue;
+      }
+
+      const std::string candidate = entry_path.string();
+      if (openhd_plugin_manager_load(mgr, candidate.c_str(), host_context)) {
+        loaded_any = true;
+      }
+    }
+
+    if (ec) {
+      log_loader_error("Failed to iterate plugin directory", raw_path);
+    }
+  }
+
+  return loaded_any;
 }
 
 void openhd_plugin_manager_foreach(struct openhd_plugin_manager *mgr,


### PR DESCRIPTION
## Summary
- collect configured plugin directories at startup and automatically load every available plugin
- extend the plugin manager to scan search paths, avoid duplicate entries, and report detailed load failures

## Testing
- cmake -S OpenHD -B build

------
https://chatgpt.com/codex/tasks/task_e_68d889550f4c832f82e7a62404f050d4