### PR TITLE
Include config paths implementation in OHDCommonLib

### DIFF
--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(OHDCommonLib PUBLIC Threads::Threads)
 set(sources
     "src/openhd_util.cpp"
     "src/openhd_util_filesystem.cpp"
+    "src/config_paths.cpp"
     "src/openhd_settings_persistent.cpp"
     "src/openhd_profile.cpp"
     "src/openhd_platform.cpp"


### PR DESCRIPTION
## Summary
- add the config_paths.cpp translation unit to the OHDCommonLib build so exported symbols are available to plugins

## Testing
- cmake -S OpenHD -B build/test
- cmake --build build/test --target openhd_dummy_plugin

------
https://chatgpt.com/codex/tasks/task_e_68d892a182d4832f8732e01350c1b0c9