### PR TITLE
Add plugin-based Raspberry Pi rover motor control

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -49,6 +49,7 @@
 #include "openhd_temporary_air_or_ground.h"
 #include "openhd_config.h"
 #include "config_paths.h"
+#include "AirTelemetryPluginHost.h"
 #include "plugins/plugin_manager.h"
 
 namespace {
@@ -70,7 +71,8 @@ std::vector<std::filesystem::path> collect_plugin_directories() {
 }
 
 bool load_plugins(struct openhd_plugin_manager *manager,
-                  const std::shared_ptr<spdlog::logger> &logger) {
+                  const std::shared_ptr<spdlog::logger> &logger,
+                  void *host_context) {
   if (!manager) {
     return false;
   }
@@ -105,7 +107,7 @@ bool load_plugins(struct openhd_plugin_manager *manager,
     return false;
   }
 
-  const bool loaded_any = openhd_plugin_manager_load_all(manager, nullptr);
+  const bool loaded_any = openhd_plugin_manager_load_all(manager, host_context);
 
   if (!logger) {
     return loaded_any;
@@ -350,7 +352,12 @@ int main(int argc, char *argv[]) {
     openhd_plugin_manager_shutdown(&plugin_manager);
   };
 
-  load_plugins(&plugin_manager, m_console);
+  openhd::telemetry::AirTelemetryPluginHost &telemetry_plugin_host =
+      openhd::telemetry::AirTelemetryPluginHost::instance();
+  openhd_plugin_host_context plugin_host_context{};
+  plugin_host_context.air_telemetry = telemetry_plugin_host.c_interface();
+
+  load_plugins(&plugin_manager, m_console, &plugin_host_context);
 
   // not guaranteed, but better than nothing, check if openhd is already running
   // (kinda) and print warning if yes.

--- a/OpenHD/ohd_common/inc/plugins/air_telemetry_host.h
+++ b/OpenHD/ohd_common/inc/plugins/air_telemetry_host.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+#ifndef OPENHD_PLUGINS_AIR_TELEMETRY_HOST_H
+#define OPENHD_PLUGINS_AIR_TELEMETRY_HOST_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct openhd_rc_channels_override {
+  uint16_t channels[8];
+  size_t channel_count;
+};
+
+typedef void (*openhd_rc_channels_override_cb)(
+    const struct openhd_rc_channels_override *override_data,
+    void *user_data);
+
+struct openhd_air_telemetry_host_interface {
+  void *context;
+  void (*register_rc_override_callback)(
+      void *context, void *user_data,
+      openhd_rc_channels_override_cb callback);
+  void (*unregister_rc_override_callback)(
+      void *context, void *user_data,
+      openhd_rc_channels_override_cb callback);
+};
+
+struct openhd_plugin_host_context {
+  const struct openhd_air_telemetry_host_interface *air_telemetry;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENHD_PLUGINS_AIR_TELEMETRY_HOST_H

--- a/OpenHD/ohd_telemetry/CMakeLists.txt
+++ b/OpenHD/ohd_telemetry/CMakeLists.txt
@@ -85,6 +85,8 @@ SET(sources
 
     "src/AirTelemetry.cpp"
     "src/AirTelemetry.h"
+    "src/AirTelemetryPluginHost.cpp"
+    "src/AirTelemetryPluginHost.h"
     "src/AirTelemetrySettings.h"
     "src/GroundTelemetry.cpp"
     "src/GroundTelemetry.h"

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -25,6 +25,7 @@
 
 #include <chrono>
 
+#include "AirTelemetryPluginHost.h"
 #include "mav_helper.h"
 #include "mavsdk_temporary/XMavlinkParamProvider.h"
 #include "openhd_temporary_air_or_ground.h"
@@ -114,6 +115,12 @@ void AirTelemetry::on_messages_ground_unit(
         m.sysid == OHD_SYS_ID_GROUND)
       continue;
     filtered_messages_fc.push_back(msg);
+    if (static_cast<int>(m.msgid) == MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE) {
+      mavlink_rc_channels_override_t rc_override{};
+      mavlink_msg_rc_channels_override_decode(&m, &rc_override);
+      openhd::telemetry::AirTelemetryPluginHost::instance()
+          .notify_rc_override(rc_override);
+    }
   }
   send_messages_fc(filtered_messages_fc);
   // any data created by an OpenHD component on the air pi only needs to be sent

--- a/OpenHD/ohd_telemetry/src/AirTelemetryPluginHost.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetryPluginHost.cpp
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+#include "AirTelemetryPluginHost.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include "mav_include.h"
+
+namespace openhd::telemetry {
+namespace {
+constexpr size_t kRcChannelCount = 8;
+}
+
+AirTelemetryPluginHost &AirTelemetryPluginHost::instance() {
+  static AirTelemetryPluginHost host;
+  return host;
+}
+
+AirTelemetryPluginHost::AirTelemetryPluginHost() {
+  interface_.context = this;
+  interface_.register_rc_override_callback = &AirTelemetryPluginHost::register_listener_c;
+  interface_.unregister_rc_override_callback = &AirTelemetryPluginHost::unregister_listener_c;
+}
+
+AirTelemetryPluginHost::~AirTelemetryPluginHost() = default;
+
+const openhd_air_telemetry_host_interface *
+AirTelemetryPluginHost::c_interface() const {
+  return &interface_;
+}
+
+void AirTelemetryPluginHost::register_listener(
+    openhd_rc_channels_override_cb callback, void *user_data) {
+  if (!callback) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  listeners_.emplace_back(callback, user_data);
+}
+
+void AirTelemetryPluginHost::unregister_listener(
+    openhd_rc_channels_override_cb callback, void *user_data) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  listeners_.erase(std::remove_if(listeners_.begin(), listeners_.end(),
+                                  [callback, user_data](const Listener &entry) {
+                                    return entry.first == callback &&
+                                           entry.second == user_data;
+                                  }),
+                   listeners_.end());
+}
+
+void AirTelemetryPluginHost::notify_rc_override(
+    const mavlink_rc_channels_override_t &message) {
+  openhd_rc_channels_override payload{};
+  payload.channel_count = kRcChannelCount;
+  uint16_t raw[kRcChannelCount] = {message.chan1_raw, message.chan2_raw,
+                                   message.chan3_raw, message.chan4_raw,
+                                   message.chan5_raw, message.chan6_raw,
+                                   message.chan7_raw, message.chan8_raw};
+  std::memcpy(payload.channels, raw, sizeof(raw));
+
+  std::vector<Listener> listeners_copy;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    listeners_copy = listeners_;
+  }
+
+  for (const auto &listener : listeners_copy) {
+    if (listener.first) {
+      listener.first(&payload, listener.second);
+    }
+  }
+}
+
+void AirTelemetryPluginHost::register_listener_c(
+    void *context, void *user_data, openhd_rc_channels_override_cb callback) {
+  if (!context) {
+    return;
+  }
+  auto *host = static_cast<AirTelemetryPluginHost *>(context);
+  host->register_listener(callback, user_data);
+}
+
+void AirTelemetryPluginHost::unregister_listener_c(
+    void *context, void *user_data, openhd_rc_channels_override_cb callback) {
+  if (!context) {
+    return;
+  }
+  auto *host = static_cast<AirTelemetryPluginHost *>(context);
+  host->unregister_listener(callback, user_data);
+}
+
+}  // namespace openhd::telemetry

--- a/OpenHD/ohd_telemetry/src/AirTelemetryPluginHost.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetryPluginHost.h
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+#ifndef OPENHD_AIR_TELEMETRY_PLUGIN_HOST_H
+#define OPENHD_AIR_TELEMETRY_PLUGIN_HOST_H
+
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include "plugins/air_telemetry_host.h"
+
+struct mavlink_rc_channels_override_t;
+
+namespace openhd::telemetry {
+
+class AirTelemetryPluginHost {
+ public:
+  static AirTelemetryPluginHost &instance();
+
+  const openhd_air_telemetry_host_interface *c_interface() const;
+
+  void notify_rc_override(const mavlink_rc_channels_override_t &message);
+
+ private:
+  AirTelemetryPluginHost();
+  ~AirTelemetryPluginHost();
+
+  using Listener = std::pair<openhd_rc_channels_override_cb, void *>;
+
+  void register_listener(openhd_rc_channels_override_cb callback,
+                         void *user_data);
+  void unregister_listener(openhd_rc_channels_override_cb callback,
+                           void *user_data);
+
+  static void register_listener_c(void *context, void *user_data,
+                                  openhd_rc_channels_override_cb callback);
+  static void unregister_listener_c(void *context, void *user_data,
+                                    openhd_rc_channels_override_cb callback);
+
+  mutable std::mutex mutex_;
+  std::vector<Listener> listeners_;
+  openhd_air_telemetry_host_interface interface_{};
+};
+
+}  // namespace openhd::telemetry
+
+#endif  // OPENHD_AIR_TELEMETRY_PLUGIN_HOST_H

--- a/OpenHD/plugins/CMakeLists.txt
+++ b/OpenHD/plugins/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(dummy_plugin)
+add_subdirectory(rpi_rover_motors)

--- a/OpenHD/plugins/rpi_rover_motors/CMakeLists.txt
+++ b/OpenHD/plugins/rpi_rover_motors/CMakeLists.txt
@@ -1,0 +1,35 @@
+find_library(PIGPIO_LIB pigpio)
+
+if (NOT PIGPIO_LIB)
+    message(WARNING "pigpio library not found; skipping Raspberry Pi rover motors plugin")
+    return()
+endif()
+
+add_library(openhd_rpi_rover_motors_plugin SHARED
+    rpi_rover_motors_plugin.cpp
+    RaspberryPiRoverMotors.cpp)
+
+set_target_properties(openhd_rpi_rover_motors_plugin PROPERTIES
+    OUTPUT_NAME "openhd_rpi_rover_motors"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins"
+    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set_target_properties(openhd_rpi_rover_motors_plugin PROPERTIES PREFIX "")
+endif()
+
+target_include_directories(openhd_rpi_rover_motors_plugin
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/ohd_common/inc
+        ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(openhd_rpi_rover_motors_plugin
+    PRIVATE
+        OHDCommonLib
+        ${PIGPIO_LIB})
+
+install(TARGETS openhd_rpi_rover_motors_plugin
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/openhd/plugins"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}/openhd/plugins"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}/openhd/plugins")

--- a/OpenHD/plugins/rpi_rover_motors/RaspberryPiRoverMotors.cpp
+++ b/OpenHD/plugins/rpi_rover_motors/RaspberryPiRoverMotors.cpp
@@ -1,0 +1,109 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+#include "RaspberryPiRoverMotors.h"
+
+#include <algorithm>
+
+#include <pigpio.h>
+
+namespace {
+int clamp_pwm(int value) {
+  return std::clamp(value, 0, 255);
+}
+}  // namespace
+
+RaspberryPiRoverMotors::RaspberryPiRoverMotors(int in1, int in2, int in3,
+                                               int in4, int pwm_pin)
+    : in1_(in1), in2_(in2), in3_(in3), in4_(in4), pwm_pin_(pwm_pin) {
+  if (gpioInitialise() < 0) {
+    return;
+  }
+  initialized_ = true;
+
+  gpioSetMode(in1_, PI_OUTPUT);
+  gpioSetMode(in2_, PI_OUTPUT);
+  gpioSetMode(in3_, PI_OUTPUT);
+  gpioSetMode(in4_, PI_OUTPUT);
+  gpioSetMode(pwm_pin_, PI_OUTPUT);
+
+  gpioWrite(in1_, 0);
+  gpioWrite(in2_, 0);
+  gpioWrite(in3_, 0);
+  gpioWrite(in4_, 0);
+  gpioPWM(pwm_pin_, 0);
+}
+
+RaspberryPiRoverMotors::~RaspberryPiRoverMotors() {
+  if (!initialized_) {
+    return;
+  }
+  stop();
+  gpioTerminate();
+}
+
+void RaspberryPiRoverMotors::set_speed(int speed) {
+  if (!initialized_) {
+    return;
+  }
+  gpioPWM(pwm_pin_, clamp_pwm(speed));
+}
+
+void RaspberryPiRoverMotors::set_direction_motor_a(bool forward) {
+  if (!initialized_) {
+    return;
+  }
+  gpioWrite(in1_, forward ? 1 : 0);
+  gpioWrite(in2_, forward ? 0 : 1);
+}
+
+void RaspberryPiRoverMotors::set_direction_motor_b(bool forward) {
+  if (!initialized_) {
+    return;
+  }
+  gpioWrite(in3_, forward ? 1 : 0);
+  gpioWrite(in4_, forward ? 0 : 1);
+}
+
+void RaspberryPiRoverMotors::stop() {
+  if (!initialized_) {
+    return;
+  }
+  gpioWrite(in1_, 0);
+  gpioWrite(in2_, 0);
+  gpioWrite(in3_, 0);
+  gpioWrite(in4_, 0);
+  gpioPWM(pwm_pin_, 0);
+}
+
+int RaspberryPiRoverMotors::map_speed(int speed) const {
+  constexpr int kInputMin = -500;
+  constexpr int kInputMax = 500;
+  constexpr int kOutputMax = 255;
+  if (speed < kInputMin) {
+    speed = kInputMin;
+  } else if (speed > kInputMax) {
+    speed = kInputMax;
+  }
+  // Scale from [-500, 500] to [-255, 255].
+  return (speed * kOutputMax) / kInputMax;
+}

--- a/OpenHD/plugins/rpi_rover_motors/RaspberryPiRoverMotors.h
+++ b/OpenHD/plugins/rpi_rover_motors/RaspberryPiRoverMotors.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+#ifndef OPENHD_PLUGINS_RPI_ROVER_MOTORS_H
+#define OPENHD_PLUGINS_RPI_ROVER_MOTORS_H
+
+#include <cstdint>
+
+class RaspberryPiRoverMotors {
+ public:
+  RaspberryPiRoverMotors(int in1, int in2, int in3, int in4, int pwm_pin);
+  ~RaspberryPiRoverMotors();
+
+  RaspberryPiRoverMotors(const RaspberryPiRoverMotors &) = delete;
+  RaspberryPiRoverMotors &operator=(const RaspberryPiRoverMotors &) = delete;
+
+  bool initialized() const { return initialized_; }
+
+  void set_speed(int speed);
+  void set_direction_motor_a(bool forward);
+  void set_direction_motor_b(bool forward);
+  void stop();
+  int map_speed(int speed) const;
+
+ private:
+  int in1_;
+  int in2_;
+  int in3_;
+  int in4_;
+  int pwm_pin_;
+  bool initialized_ = false;
+};
+
+#endif  // OPENHD_PLUGINS_RPI_ROVER_MOTORS_H

--- a/OpenHD/plugins/rpi_rover_motors/rpi_rover_motors_plugin.cpp
+++ b/OpenHD/plugins/rpi_rover_motors/rpi_rover_motors_plugin.cpp
@@ -1,0 +1,159 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+#include "plugins/plugins.h"
+
+#include "RaspberryPiRoverMotors.h"
+#include "openhd_spdlog.h"
+#include "plugins/air_telemetry_host.h"
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+
+#include <spdlog/spdlog.h>
+
+namespace {
+
+constexpr uint16_t kMavlinkChannelUnset = UINT16_MAX;
+constexpr int kNeutralPwm = 1500;
+constexpr int kTurnRightThreshold = 1600;
+constexpr int kTurnLeftThreshold = 1400;
+
+struct MotorPluginContext {
+  std::shared_ptr<spdlog::logger> logger;
+  std::unique_ptr<RaspberryPiRoverMotors> motors;
+  const openhd_air_telemetry_host_interface *host_interface = nullptr;
+  bool callback_registered = false;
+};
+
+int decode_channel(uint16_t raw_value, int fallback) {
+  return raw_value == kMavlinkChannelUnset ? fallback
+                                           : static_cast<int>(raw_value);
+}
+
+void handle_rc_override(const openhd_rc_channels_override *override_data,
+                        void *user_data) {
+  if (!override_data || !user_data) {
+    return;
+  }
+  auto *context = static_cast<MotorPluginContext *>(user_data);
+  if (!context->motors || !context->motors->initialized()) {
+    return;
+  }
+  if (override_data->channel_count < 4) {
+    return;
+  }
+
+  const int raw_x = decode_channel(override_data->channels[0], kNeutralPwm);
+  const int raw_y = decode_channel(override_data->channels[3], kNeutralPwm);
+
+  const int mapped_speed = context->motors->map_speed(raw_y - kNeutralPwm);
+  const int pwm_value = std::abs(mapped_speed);
+
+  if (pwm_value == 0) {
+    context->motors->stop();
+    return;
+  }
+
+  context->motors->set_speed(pwm_value);
+
+  if (raw_x > kTurnRightThreshold) {
+    context->motors->set_direction_motor_a(true);
+    context->motors->set_direction_motor_b(false);
+  } else if (raw_x < kTurnLeftThreshold) {
+    context->motors->set_direction_motor_a(false);
+    context->motors->set_direction_motor_b(true);
+  } else {
+    context->motors->stop();
+  }
+}
+
+}  // namespace
+
+extern "C" {
+
+struct openhd_plugin_context {
+  MotorPluginContext impl;
+};
+
+const struct openhd_plugin_info *openhd_plugin_get_info() {
+  static const struct openhd_plugin_info kInfo = {
+      OPENHD_PLUGIN_API_VERSION,
+      "rpi_rover_motors",
+      "Drives differential rover motors using MAVLink RC override messages.",
+      openhd_plugin_type::UNKNOWN,
+      0,
+  };
+  return &kInfo;
+}
+
+struct openhd_plugin_context *openhd_plugin_init(void *host_context) {
+  auto *context = new openhd_plugin_context();
+  context->impl.logger = openhd::log::create_or_get("rpi_rover_motors");
+  if (context->impl.logger) {
+    context->impl.logger->set_level(spdlog::level::info);
+    context->impl.logger->info("Initializing Raspberry Pi rover motors plugin");
+  }
+
+  context->impl.motors = std::make_unique<RaspberryPiRoverMotors>(22, 27, 23, 24, 18);
+  if (!context->impl.motors || !context->impl.motors->initialized()) {
+    if (context->impl.logger) {
+      context->impl.logger->error("Failed to initialize pigpio – disabling plugin");
+    }
+    delete context;
+    return nullptr;
+  }
+
+  const auto *host = static_cast<const openhd_plugin_host_context *>(host_context);
+  if (host && host->air_telemetry) {
+    context->impl.host_interface = host->air_telemetry;
+    context->impl.host_interface->register_rc_override_callback(
+        context->impl.host_interface->context, &context->impl, handle_rc_override);
+    context->impl.callback_registered = true;
+    if (context->impl.logger) {
+      context->impl.logger->info("Registered RC override listener");
+    }
+  } else if (context->impl.logger) {
+    context->impl.logger->warn(
+        "Air telemetry host interface unavailable – motor control disabled");
+  }
+
+  return context;
+}
+
+void openhd_plugin_shutdown(struct openhd_plugin_context *context) {
+  if (!context) {
+    return;
+  }
+  if (context->impl.callback_registered && context->impl.host_interface) {
+    context->impl.host_interface->unregister_rc_override_callback(
+        context->impl.host_interface->context, &context->impl, handle_rc_override);
+  }
+  if (context->impl.logger) {
+    context->impl.logger->info("Shutting down Raspberry Pi rover motors plugin");
+  }
+  context->impl.motors.reset();
+  delete context;
+}
+
+}  // extern "C"


### PR DESCRIPTION
## Summary
- expose a C ABI for air telemetry RC override callbacks and notify plugins when overrides arrive
- pass the new host context into the plugin manager so plugins can subscribe to air telemetry events
- add a Raspberry Pi rover motor control plugin that drives motors via pigpio using RC override data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d896158dc0832f8718644cb500689a