### PR TITLE
Fix AirTelemetryPluginHost mavlink type inclusion

### DIFF
--- a/OpenHD/ohd_telemetry/src/AirTelemetryPluginHost.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetryPluginHost.h
@@ -27,9 +27,8 @@
 #include <utility>
 #include <vector>
 
+#include "mav_include.h"
 #include "plugins/air_telemetry_host.h"
-
-struct mavlink_rc_channels_override_t;
 
 namespace openhd::telemetry {
 


### PR DESCRIPTION
## Summary
- include `mav_include.h` in `AirTelemetryPluginHost.h` so the mavlink rc override type is defined via the generated headers
- remove the incorrect forward declaration that redefined the type during compilation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89ce2106c832fa05a7bda16196149