### PR TITLE
Add UART relay for OpenHD telemetry with CLI support

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <memory>
 #include <cstdlib>
+#include <optional>
 
 #include "openhd_buttons.h"
 #include "openhd_global_constants.hpp"
@@ -62,6 +63,7 @@ static const struct option long_options[] = {
     {"no-qt-autostart", no_argument, nullptr, 'w'},
     {"run-time-seconds", required_argument, nullptr, 'r'},
     {"hardware-config-file", required_argument, nullptr, 'h'},
+    {"openhd_uart_telemetry", optional_argument, nullptr, 0},
     {nullptr, 0, nullptr, 0},
 };
     const std::string red = "\033[31m";
@@ -78,6 +80,7 @@ struct OHDRunOptions {
   // the default location (and default values if no file exists at the default
   // location) is used
   std::optional<std::string> hardware_config_file;
+  std::optional<std::string> openhd_uart_telemetry_device;
 };
 
 static OHDRunOptions parse_run_parameters(int argc, char *argv[]) {
@@ -86,9 +89,22 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]) {
   // If this value gets set, we assume a developer is working on OpenHD and skip
   // the discovery via file(s).
   std::optional<bool> commandline_air = std::nullopt;
-  while ((c = getopt_long(argc, argv, optstr, long_options, NULL)) != -1) {
+  int option_index = 0;
+  while ((c = getopt_long(argc, argv, optstr, long_options, &option_index)) !=
+         -1) {
     const char *tmp_optarg = optarg;
     switch (c) {
+      case 0: {
+        const std::string option_name = long_options[option_index].name;
+        if (option_name == "openhd_uart_telemetry") {
+          if (optarg != nullptr) {
+            ret.openhd_uart_telemetry_device = optarg;
+          } else {
+            ret.openhd_uart_telemetry_device = "/dev/serial1";
+          }
+        }
+        break;
+      }
       case 'a':
         if (commandline_air != std::nullopt) {
           // Already set, e.g. --ground is already used
@@ -131,6 +147,8 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]) {
               "infinite),for debugging] \n";
         ss << "--hardware-config-file -h [specify path to hardware.config "
               "file]\n";
+        ss << "--openhd_uart_telemetry [optional serial device, default "
+              "/dev/serial1] \n";
         ss << "Use hardware.conf for more configuration\n";
         std::cout << ss.str() << std::flush;
       }
@@ -291,6 +309,10 @@ int main(int argc, char *argv[]) {
     // (transmission) it still picks up local log message(s) and forwards them
     // to any ground station clients (e.g. QOpenHD)
     auto ohdTelemetry = std::make_shared<OHDTelemetry>(profile);
+    if (options.openhd_uart_telemetry_device.has_value()) {
+      ohdTelemetry->configure_openhd_uart_telemetry(
+          options.openhd_uart_telemetry_device);
+    }
 
     // Then start ohdInterface, which discovers detected wifi cards and more.
     auto ohdInterface = std::make_shared<OHDInterface>( profile);

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -36,6 +36,7 @@ AirTelemetry::AirTelemetry() : MavlinkSystem(OHD_SYS_ID_AIR) {
   assert(m_console);
   m_air_settings = std::make_unique<openhd::telemetry::air::SettingsHolder>();
   m_fc_serial = std::make_unique<SerialEndpointManager>();
+  m_openhd_uart_serial = std::make_unique<SerialEndpointManager>();
   m_ohd_main_component = std::make_shared<OHDMainComponent>(_sys_id, true);
   m_components.push_back(m_ohd_main_component);
   //
@@ -59,6 +60,7 @@ AirTelemetry::AirTelemetry() : MavlinkSystem(OHD_SYS_ID_AIR) {
         });
   }
   setup_uart();
+  setup_openhd_uart_telemetry();
   m_console->debug("Created AirTelemetry");
 }
 
@@ -89,6 +91,9 @@ void AirTelemetry::send_messages_ground_unit(
   // Not technically correct, but works
   if (m_tcp_server) {
     m_tcp_server->sendMessages(messages);
+  }
+  if (m_openhd_uart_serial) {
+    m_openhd_uart_serial->send_messages_if_enabled(messages);
   }
 }
 
@@ -233,6 +238,13 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
     m_air_settings->persist(false);
     return true;
   };
+  auto c_openhd_uart_conn = [this](std::string, std::string value) {
+    m_air_settings->unsafe_get_settings().openhd_uart_telemetry_connection =
+        value;
+    m_air_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
   ret.push_back(openhd::Setting{
       air::FC_UART_CONNECTION_TYPE,
       openhd::StringSetting{
@@ -253,6 +265,11 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
       openhd::IntSetting{
           static_cast<int>(m_air_settings->get_settings().fc_battery_n_cells),
           c_fc_battery_n_cells}});
+  ret.push_back(openhd::Setting{
+      air::OPENHD_UART_TELEMETRY_PARAM,
+      openhd::StringSetting{
+          m_air_settings->get_settings().openhd_uart_telemetry_connection,
+          c_openhd_uart_conn}});
   // and this allows an advanced user to change its air unit to a ground unit
   // only expose this setting if OpenHD uses the file workaround to figure out
   // air or ground.
@@ -291,6 +308,40 @@ void AirTelemetry::setup_uart() {
   } else {
     m_fc_serial->disable();
   }
+}
+
+void AirTelemetry::setup_openhd_uart_telemetry() {
+  if (!m_openhd_uart_serial) return;
+  const auto& settings = m_air_settings->get_settings();
+  const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
+      settings.openhd_uart_telemetry_connection);
+  if (!uart_linux_fd.has_value()) {
+    m_openhd_uart_serial->disable();
+    return;
+  }
+  SerialEndpoint::HWOptions options{};
+  options.linux_filename = uart_linux_fd.value();
+  options.baud_rate = 115200;
+  options.enable_reading = true;
+  m_openhd_uart_serial->configure(
+      options, "openhd_uart",
+      [this](const std::vector<MavlinkMessage> messages) {
+        auto copy = messages;
+        this->on_messages_ground_unit(copy);
+      });
+}
+
+void AirTelemetry::configure_openhd_uart_telemetry(
+    const std::optional<std::string>& device_path) {
+  if (!device_path.has_value()) {
+    return;
+  }
+  m_console->info("CLI override for OpenHD UART telemetry: {}",
+                  device_path.value());
+  m_air_settings->unsafe_get_settings().openhd_uart_telemetry_connection =
+      device_path.value();
+  m_air_settings->persist();
+  setup_openhd_uart_telemetry();
 }
 
 void AirTelemetry::set_link_handle(std::shared_ptr<OHDLink> link) {

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.h
@@ -24,6 +24,7 @@
 #ifndef OPENHD_TELEMETRY_AIRTELEMETRY_H
 #define OPENHD_TELEMETRY_AIRTELEMETRY_H
 
+#include <optional>
 #include <string>
 
 #include "endpoints/SerialEndpoint.h"
@@ -85,6 +86,8 @@ class AirTelemetry : public MavlinkSystem {
    * messages from/to the ground unit are just discarded.
    */
   void set_link_handle(std::shared_ptr<OHDLink> link);
+  void configure_openhd_uart_telemetry(
+      const std::optional<std::string>& device_path);
 
  private:
   // send a mavlink message to the flight controller connected to the air unit
@@ -100,10 +103,12 @@ class AirTelemetry : public MavlinkSystem {
   // R.N only on air, and only FC uart settings
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
+  void setup_openhd_uart_telemetry();
 
  private:
   std::unique_ptr<openhd::telemetry::air::SettingsHolder> m_air_settings;
   std::unique_ptr<SerialEndpointManager> m_fc_serial;
+  std::unique_ptr<SerialEndpointManager> m_openhd_uart_serial;
   // send/receive data via wb
   std::unique_ptr<WBEndpoint> m_wb_endpoint;
   // shared because we also push it onto our components list

--- a/OpenHD/ohd_telemetry/src/AirTelemetrySettings.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetrySettings.cpp
@@ -29,7 +29,8 @@ namespace openhd::telemetry::air {
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Settings, fc_uart_connection_type,
                                    fc_uart_baudrate, fc_uart_flow_control,
-                                   fc_battery_n_cells);
+                                   fc_battery_n_cells,
+                                   openhd_uart_telemetry_connection);
 
 std::optional<Settings> SettingsHolder::impl_deserialize(
     const std::string &file_as_string) const {

--- a/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
@@ -61,6 +61,7 @@ struct Settings {
   // DANG ardupilot why do we have to make this an extra param ...
   // 0 means not configured (do not use)
   int fc_battery_n_cells = 0;
+  std::string openhd_uart_telemetry_connection = UART_CONNECTION_TYPE_DISABLE;
 };
 
 // 16 chars limit !
@@ -68,6 +69,7 @@ static constexpr auto FC_UART_CONNECTION_TYPE = "FC_UART_CONN";
 static constexpr auto FC_UART_BAUD_RATE = "FC_UART_BAUD";
 static constexpr auto FC_UART_FLOW_CONTROL = "FC_UART_FLWCTL";
 static constexpr auto FC_BATT_N_CELLS = "FC_BATT_N_CELLS";
+static constexpr auto OPENHD_UART_TELEMETRY_PARAM = "OHD_UART_TLM";
 
 class SettingsHolder : public openhd::PersistentSettings<Settings> {
  public:

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -37,6 +37,7 @@ GroundTelemetry::GroundTelemetry() : MavlinkSystem(OHD_SYS_ID_GROUND) {
   m_gnd_settings =
       std::make_unique<openhd::telemetry::ground::SettingsHolder>();
   m_endpoint_tracker = std::make_unique<SerialEndpointManager>();
+  m_openhd_uart_serial = std::make_unique<SerialEndpointManager>();
   m_gcs_endpoint = std::make_unique<UDPEndpoint>(
       "GroundStationUDP", OHD_GROUND_CLIENT_UDP_PORT_OUT,
       OHD_GROUND_CLIENT_UDP_PORT_IN,
@@ -76,6 +77,7 @@ GroundTelemetry::GroundTelemetry() : MavlinkSystem(OHD_SYS_ID_GROUND) {
   m_generic_mavlink_param_provider->add_params(get_all_settings());
   m_components.push_back(m_generic_mavlink_param_provider);
   setup_uart();
+  setup_openhd_uart_telemetry();
   openhd::ExternalDeviceManager::instance().register_listener(
       [this](openhd::ExternalDevice external_device, bool connected) {
         if (!external_device.discovered_by_mavlink_tcp_server) {
@@ -184,6 +186,9 @@ void GroundTelemetry::send_messages_ground_station_clients(
   }
   if (m_tcp_server) {
     m_tcp_server->sendMessages(messages);
+  }
+  if (m_openhd_uart_serial) {
+    m_openhd_uart_serial->send_messages_if_enabled(messages);
   }
 }
 
@@ -375,6 +380,18 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
             m_gnd_settings->get_settings().gnd_uart_connection_type,
             c_gnd_uart_connection_type}});
   }
+  auto c_openhd_uart_conn = [this](std::string, std::string value) {
+    m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_connection =
+        value;
+    m_gnd_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
+  ret.push_back(openhd::Setting{
+      openhd::telemetry::ground::OPENHD_UART_TELEMETRY_PARAM,
+      openhd::StringSetting{
+          m_gnd_settings->get_settings().openhd_uart_telemetry_connection,
+          c_openhd_uart_conn}});
   openhd::testing::append_dummy_if_empty(ret);
   return ret;
 }
@@ -399,6 +416,38 @@ void GroundTelemetry::setup_uart() {
   } else {
     m_endpoint_tracker->disable();
   }
+}
+
+void GroundTelemetry::setup_openhd_uart_telemetry() {
+  if (!m_openhd_uart_serial) return;
+  const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
+      m_gnd_settings->get_settings().openhd_uart_telemetry_connection);
+  if (!uart_linux_fd.has_value()) {
+    m_openhd_uart_serial->disable();
+    return;
+  }
+  SerialEndpoint::HWOptions options{};
+  options.linux_filename = uart_linux_fd.value();
+  options.baud_rate = 115200;
+  options.enable_reading = true;
+  m_openhd_uart_serial->configure(
+      options, "openhd_uart",
+      [this](const std::vector<MavlinkMessage> messages) {
+        on_messages_ground_station_clients(messages);
+      });
+}
+
+void GroundTelemetry::configure_openhd_uart_telemetry(
+    const std::optional<std::string>& device_path) {
+  if (!device_path.has_value()) {
+    return;
+  }
+  m_console->info("CLI override for OpenHD UART telemetry: {}",
+                  device_path.value());
+  m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_connection =
+      device_path.value();
+  m_gnd_settings->persist();
+  setup_openhd_uart_telemetry();
 }
 
 void GroundTelemetry::set_link_handle(std::shared_ptr<OHDLink> link) {

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -24,6 +24,8 @@
 #ifndef OPENHD_TELEMETRY_GROUNDTELEMETRY_H
 #define OPENHD_TELEMETRY_GROUNDTELEMETRY_H
 
+#include <optional>
+
 #include "GroundTelemetrySettings.h"
 #include "endpoints/SerialEndpoint.h"
 #include "endpoints/TCPEndpoint.h"
@@ -82,6 +84,8 @@ class GroundTelemetry : public MavlinkSystem {
    * messages from/to the air unit are just discarded.
    */
   void set_link_handle(std::shared_ptr<OHDLink> link);
+  void configure_openhd_uart_telemetry(
+      const std::optional<std::string>& device_path);
 
  private:
   // called every time one or more messages from the air unit are received
@@ -98,6 +102,7 @@ class GroundTelemetry : public MavlinkSystem {
       const std::vector<MavlinkMessage>& messages);
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
+  void setup_openhd_uart_telemetry();
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
   void enable_joystick();
   void disable_joystick();
@@ -109,6 +114,7 @@ class GroundTelemetry : public MavlinkSystem {
   std::unique_ptr<UDPEndpoint> m_gcs_endpoint = nullptr;
   // mavlink out via serial for tracker or similar
   std::unique_ptr<SerialEndpointManager> m_endpoint_tracker = nullptr;
+  std::unique_ptr<SerialEndpointManager> m_openhd_uart_serial = nullptr;
   // EXP - always on TCP mavlink server
   std::unique_ptr<TCPEndpoint> m_tcp_server = nullptr;
   // send/receive data via wb

--- a/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.cpp
@@ -30,7 +30,8 @@ namespace openhd::telemetry::ground {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Settings, enable_rc_over_joystick,
                                    rc_over_joystick_update_rate_hz,
                                    rc_channel_mapping, gnd_uart_connection_type,
-                                   gnd_uart_baudrate);
+                                   gnd_uart_baudrate,
+                                   openhd_uart_telemetry_connection);
 
 std::optional<Settings>
 openhd::telemetry::ground::SettingsHolder::impl_deserialize(

--- a/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.h
@@ -42,7 +42,10 @@ struct Settings {
   // This is for outputting FC mavlink data via serial on the ground station
   std::string gnd_uart_connection_type = UART_CONNECTION_TYPE_DISABLE;
   int gnd_uart_baudrate = 115200;
+  std::string openhd_uart_telemetry_connection = UART_CONNECTION_TYPE_DISABLE;
 };
+
+static constexpr auto OPENHD_UART_TELEMETRY_PARAM = "OHD_UART_TLM";
 
 static bool valid_joystick_update_rate(int value) {
   return value >= 1 && value <= 150;

--- a/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/OHDTelemetry.cpp
@@ -95,3 +95,15 @@ void OHDTelemetry::set_link_handle(std::shared_ptr<OHDLink> link) {
     m_ground_telemetry->set_link_handle(link);
   }
 }
+
+void OHDTelemetry::configure_openhd_uart_telemetry(
+    const std::optional<std::string>& device_path) {
+  if (!device_path.has_value()) {
+    return;
+  }
+  if (m_profile.is_air) {
+    m_air_telemetry->configure_openhd_uart_telemetry(device_path);
+  } else {
+    m_ground_telemetry->configure_openhd_uart_telemetry(device_path);
+  }
+}

--- a/OpenHD/ohd_telemetry/src/OHDTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/OHDTelemetry.h
@@ -25,6 +25,7 @@
 #define OPENHD_OHDTELEMETRY_H
 
 #include <memory>
+#include <optional>
 #include <thread>
 #include <utility>
 
@@ -74,6 +75,8 @@ class OHDTelemetry {
   // and also agnostic weather this link exists or not (since it is already
   // using a lossy link).
   void set_link_handle(std::shared_ptr<OHDLink> link);
+  void configure_openhd_uart_telemetry(
+      const std::optional<std::string>& device_path);
 
  private:
   // only either one of them both is active at a time.


### PR DESCRIPTION
## Summary
- add a `--openhd_uart_telemetry` CLI switch that can optionally select the serial device used for relaying OpenHD MAVLink traffic
- expose a new MAVLink string parameter on air and ground telemetry to configure or disable the OpenHD UART relay at runtime
- forward telemetry messages through a dedicated serial endpoint on both air and ground units, with CLI overrides wired through OHDTelemetry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e11c17cd30832f84a484579b5b683d