### PR TITLE
Enable bidirectional tracker UART telemetry

### DIFF
--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -123,7 +123,7 @@ void GroundTelemetry::on_messages_air_unit(
           filter_by_source_sys_id(messages, OHD_SYS_ID_FC_BETAFLIGHT);
     }
     if (!msges_from_fc.empty()) {
-      m_endpoint_tracker->send_messages_if_enabled(msges_from_fc);
+      send_messages_tracker(msges_from_fc);
     }
   }
   m_ohd_main_component->check_fc_messages_for_actions(messages);
@@ -174,7 +174,16 @@ void GroundTelemetry::on_messages_ground_station_clients(
     const auto responses = component->process_mavlink_messages(messages);
     // for now, send to the ground station clients only
     send_messages_ground_station_clients(responses);
+    send_messages_tracker(responses);
   }
+}
+
+void GroundTelemetry::on_messages_tracker(
+    std::vector<MavlinkMessage>& messages) {
+  if (messages.empty()) {
+    return;
+  }
+  on_messages_ground_station_clients(messages);
 }
 
 void GroundTelemetry::send_messages_ground_station_clients(
@@ -194,6 +203,14 @@ void GroundTelemetry::send_messages_air_unit(
   if (m_wb_endpoint) {
     m_wb_endpoint->sendMessages(messages);
   }
+}
+
+void GroundTelemetry::send_messages_tracker(
+    const std::vector<MavlinkMessage>& messages) {
+  if (!m_endpoint_tracker) {
+    return;
+  }
+  m_endpoint_tracker->send_messages_if_enabled(messages);
 }
 
 void GroundTelemetry::loop_infinite(bool& terminate,
@@ -224,6 +241,7 @@ void GroundTelemetry::loop_infinite(bool& terminate,
         assert(component);
         const auto messages = component->generate_mavlink_messages();
         send_messages_ground_station_clients(messages);
+        send_messages_tracker(messages);
         // exception: timesync
         for (const auto& msg : messages) {
           if (msg.m.msgid == MAVLINK_MSG_ID_TIMESYNC) {
@@ -389,13 +407,12 @@ void GroundTelemetry::setup_uart() {
     options.linux_filename = uart_linux_fd.value();
     options.baud_rate = m_gnd_settings->get_settings().gnd_uart_baudrate;
     options.flow_control = false;
-    options.enable_reading = false;
-    m_endpoint_tracker->configure(options, "gnd_ser",
-                                  [this](std::vector<MavlinkMessage> messages) {
-                                    // We ignore any incoming messages here for
-                                    // now, since it is only for mavlink out via
-                                    // serial
-                                  });
+    options.enable_reading = true;
+    m_endpoint_tracker->configure(
+        options, "gnd_ser",
+        [this](std::vector<MavlinkMessage> messages) {
+          this->on_messages_tracker(messages);
+        });
   } else {
     m_endpoint_tracker->disable();
   }

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -92,10 +92,14 @@ class GroundTelemetry : public MavlinkSystem {
   // connected to the Ground Station (For Example QOpenHD)
   void on_messages_ground_station_clients(
       const std::vector<MavlinkMessage>& messages);
+  // called when messages are received via the optional tracker UART
+  void on_messages_tracker(std::vector<MavlinkMessage>& messages);
   // send one or more messages to all clients connected to the ground station,
   // for example QOpenHD
   void send_messages_ground_station_clients(
       const std::vector<MavlinkMessage>& messages);
+  // send one or more messages over the optional tracker UART connection
+  void send_messages_tracker(const std::vector<MavlinkMessage>& messages);
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND


### PR DESCRIPTION
## Summary
- enable reading on the ground tracker UART endpoint and process inbound MAVLink messages
- forward component responses and generated telemetry to the tracker UART so it mirrors ground clients

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e122eb8358832fb64cd478d00f6af5