### PR TITLE
Add interactive TUI to MAVLink UART debugger

### DIFF
--- a/OpenHD/tools/mavlink_uart_logger/CMakeLists.txt
+++ b/OpenHD/tools/mavlink_uart_logger/CMakeLists.txt
@@ -5,10 +5,17 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+find_package(Curses REQUIRED)
+
 add_executable(mavlink_uart_logger
     main.cpp
 )
 
 target_include_directories(mavlink_uart_logger PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../ohd_telemetry/lib/mavlink-headers
+    ${CURSES_INCLUDE_DIR}
+)
+
+target_link_libraries(mavlink_uart_logger PRIVATE
+    ${CURSES_LIBRARIES}
 )

--- a/OpenHD/tools/mavlink_uart_logger/README.md
+++ b/OpenHD/tools/mavlink_uart_logger/README.md
@@ -1,6 +1,6 @@
-# MAVLink UART Logger
+# MAVLink UART Debugger
 
-Small standalone utility that reads MAVLink frames from a serial port using the OpenHD dialect and stores a textual log on disk.
+Interactive utility that reads MAVLink frames from a serial port using the OpenHD dialect and displays them in a curses based table similar to `htop`. The tool tracks the latest payload per message ID, keeps a running count, and can optionally store a textual log on disk.
 
 ## Building
 
@@ -14,7 +14,21 @@ This will produce the `mavlink_uart_logger` executable inside the `build` direct
 ## Usage
 
 ```bash
-./mavlink_uart_logger --device /dev/ttyUSB0 --baud 115200 --output log.txt
+./mavlink_uart_logger --device /dev/ttyUSB0 --baud 115200 \
+    --sysid 1 --compid 1 --target-sys 1 --target-comp 1 --output log.txt
 ```
 
-The utility prints every decoded message to `stdout` and appends the same information to the provided text file. Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop the logger.
+* `--output` is optional. When set, the decoded messages are appended to the given file.
+* `--sysid`/`--compid` specify the IDs used for locally generated messages.
+* `--target-sys`/`--target-comp` specify the destination of outgoing commands.
+
+While running, the TUI updates each time a MAVLink message is received. Use the following shortcuts:
+
+| Key | Action |
+| --- | ------ |
+| `h` | Send a MAVLink heartbeat |
+| `p` | Send a MAVLink ping |
+| `r` | Send a `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN` command |
+| `q` | Quit the debugger |
+
+The status line at the top reports the outcome of the most recent command and whether logging is enabled.

--- a/OpenHD/tools/mavlink_uart_logger/main.cpp
+++ b/OpenHD/tools/mavlink_uart_logger/main.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <csignal>
 #include <cstdint>
@@ -13,7 +14,11 @@
 #include <ctime>
 #include <string>
 #include <termios.h>
+#include <thread>
 #include <unistd.h>
+#include <vector>
+
+#include <ncurses.h>
 
 #define MAVLINK_USE_MESSAGE_INFO
 extern "C" {
@@ -62,7 +67,8 @@ std::optional<speed_t> baudrate_to_constant(int baudrate) {
 
 void print_usage(const char *program) {
     std::cerr << "Usage: " << program
-              << " --device <path> --baud <baudrate> --output <file>" << std::endl;
+              << " --device <path> --baud <baudrate> [--output <file>]"
+              << " [--sysid <id> --compid <id> --target-sys <id> --target-comp <id>]" << std::endl;
 }
 
 bool configure_serial(int fd, speed_t speed_constant) {
@@ -131,10 +137,114 @@ std::string message_name(const mavlink_message_t &message) {
 
 }  // namespace
 
+struct MessageEntry {
+    uint64_t count = 0;
+    std::string name;
+    std::string last_timestamp;
+    std::string payload_hex;
+    uint8_t sysid = 0;
+    uint8_t compid = 0;
+    uint8_t len = 0;
+};
+
+bool write_message(int fd, const mavlink_message_t &message) {
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    const auto length = mavlink_msg_to_send_buffer(buffer, &message);
+    ssize_t written = ::write(fd, buffer, length);
+    return written == static_cast<ssize_t>(length);
+}
+
+bool send_heartbeat(int fd, uint8_t sysid, uint8_t compid, uint8_t target_sys, uint8_t target_comp) {
+    (void)target_sys;
+    (void)target_comp;
+    mavlink_message_t msg{};
+    mavlink_msg_heartbeat_pack(sysid, compid, &msg, MAV_TYPE_GENERIC, MAV_AUTOPILOT_INVALID,
+                               MAV_MODE_FLAG_CUSTOM_MODE_ENABLED, 0, MAV_STATE_ACTIVE);
+    return write_message(fd, msg);
+}
+
+bool send_reboot(int fd, uint8_t sysid, uint8_t compid, uint8_t target_sys, uint8_t target_comp) {
+    mavlink_message_t msg{};
+    constexpr float kParam1RebootAutopilot = 1.0f;
+    mavlink_msg_command_long_pack(sysid, compid, &msg, target_sys, target_comp,
+                                  MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN, 0, kParam1RebootAutopilot,
+                                  0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
+    return write_message(fd, msg);
+}
+
+bool send_ping(int fd, uint8_t sysid, uint8_t compid, uint8_t target_sys, uint8_t target_comp) {
+    static uint32_t sequence = 0;
+    mavlink_message_t msg{};
+    const auto now = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now().time_since_epoch());
+    mavlink_msg_ping_pack(sysid, compid, &msg, now.count(), target_sys, target_comp, sequence++);
+    return write_message(fd, msg);
+}
+
+void render_ui(const std::string &device_path, int baudrate, const std::map<uint32_t, MessageEntry> &messages,
+               const std::string &output_path, const std::string &status_message) {
+    erase();
+
+    int max_y = 0;
+    int max_x = 0;
+    getmaxyx(stdscr, max_y, max_x);
+
+    mvprintw(0, 0, "MAVLink UART Debugger - device: %s @ %d baud", device_path.c_str(), baudrate);
+    mvprintw(1, 0, "Logging to: %s", output_path.empty() ? "<disabled>" : output_path.c_str());
+    mvprintw(2, 0, "Controls: q=quit | h=send heartbeat | r=send reboot command | p=send ping");
+    mvprintw(3, 0, "Status: %s", status_message.c_str());
+
+    const int header_row = 5;
+    mvprintw(header_row, 0, "%-6s %-20s %-8s %-4s %-6s %-6s %-27s %s", "MSGID", "NAME", "COUNT", "LEN",
+             "SYS", "COMP", "LAST UPDATE", "PAYLOAD (hex)");
+
+    int row = header_row + 1;
+    const int max_rows = max_y - row - 1;
+
+    std::vector<std::pair<uint32_t, const MessageEntry *>> sorted_entries;
+    sorted_entries.reserve(messages.size());
+    for (const auto &kv : messages) {
+        sorted_entries.emplace_back(kv.first, &kv.second);
+    }
+    std::sort(sorted_entries.begin(), sorted_entries.end(),
+              [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+    int displayed = 0;
+    for (const auto &[msgid, entry_ptr] : sorted_entries) {
+        if (displayed >= max_rows) {
+            break;
+        }
+
+        const auto &entry = *entry_ptr;
+        std::string payload = entry.payload_hex;
+        const int payload_start_col = 6 + 1 + 20 + 1 + 8 + 1 + 4 + 1 + 6 + 1 + 6 + 1 + 27 + 1;
+        const int available_width = std::max(0, max_x - payload_start_col);
+        if (static_cast<int>(payload.size()) > available_width && available_width > 3) {
+            payload = payload.substr(0, available_width - 3) + "...";
+        }
+
+        mvprintw(row + displayed, 0, "%-6u %-20s %-8lu %-4u %-6u %-6u %-27s %s", msgid, entry.name.c_str(),
+                 static_cast<unsigned long>(entry.count), static_cast<unsigned>(entry.len),
+                 static_cast<unsigned>(entry.sysid), static_cast<unsigned>(entry.compid),
+                 entry.last_timestamp.c_str(), payload.c_str());
+        ++displayed;
+    }
+
+    if (displayed == 0) {
+        mvprintw(row, 0, "Waiting for MAVLink traffic...");
+    }
+
+    refresh();
+}
+
 int main(int argc, char **argv) {
     std::string device_path;
     std::string output_path;
     int baudrate = 0;
+    uint8_t sysid = 1;
+    uint8_t compid = 1;
+    uint8_t target_sys = 1;
+    uint8_t target_comp = 1;
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -144,8 +254,18 @@ int main(int argc, char **argv) {
             baudrate = std::stoi(argv[++i]);
         } else if (arg == "--output" && i + 1 < argc) {
             output_path = argv[++i];
+        } else if (arg == "--sysid" && i + 1 < argc) {
+            sysid = static_cast<uint8_t>(std::stoi(argv[++i]));
+        } else if (arg == "--compid" && i + 1 < argc) {
+            compid = static_cast<uint8_t>(std::stoi(argv[++i]));
+        } else if (arg == "--target-sys" && i + 1 < argc) {
+            target_sys = static_cast<uint8_t>(std::stoi(argv[++i]));
+        } else if (arg == "--target-comp" && i + 1 < argc) {
+            target_comp = static_cast<uint8_t>(std::stoi(argv[++i]));
         } else if (arg == "--help" || arg == "-h") {
             print_usage(argv[0]);
+            std::cerr << "Additional options: --sysid <id> --compid <id> --target-sys <id> --target-comp <id>"
+                      << std::endl;
             return 0;
         } else {
             print_usage(argv[0]);
@@ -153,7 +273,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (device_path.empty() || output_path.empty() || baudrate == 0) {
+    if (device_path.empty() || baudrate == 0) {
         print_usage(argv[0]);
         return 1;
     }
@@ -164,7 +284,7 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    int fd = ::open(device_path.c_str(), O_RDONLY | O_NOCTTY | O_NONBLOCK);
+    int fd = ::open(device_path.c_str(), O_RDWR | O_NOCTTY | O_NONBLOCK);
     if (fd < 0) {
         perror("open");
         return 1;
@@ -175,58 +295,104 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    std::ofstream output(output_path, std::ios::out | std::ios::app);
-    if (!output.is_open()) {
-        std::cerr << "Failed to open output file: " << output_path << std::endl;
-        ::close(fd);
-        return 1;
+    std::ofstream output;
+    if (!output_path.empty()) {
+        output.open(output_path, std::ios::out | std::ios::app);
+        if (!output.is_open()) {
+            std::cerr << "Failed to open output file: " << output_path << std::endl;
+            ::close(fd);
+            return 1;
+        }
     }
 
     std::signal(SIGINT, signal_handler);
     std::signal(SIGTERM, signal_handler);
 
+    initscr();
+    noecho();
+    curs_set(0);
+    nodelay(stdscr, TRUE);
+    keypad(stdscr, TRUE);
+
     mavlink_message_t message{};
     mavlink_status_t status{};
+    std::map<uint32_t, MessageEntry> messages;
+    std::string status_message = "Listening...";
 
-    std::cout << "Listening on " << device_path << " @ " << baudrate << " baud. Press Ctrl+C to exit." << std::endl;
+    const auto start_time = std::chrono::steady_clock::now();
+    auto last_ui_update = start_time - std::chrono::milliseconds(200);
 
     while (!g_should_exit) {
         uint8_t buffer[256];
         ssize_t nread = ::read(fd, buffer, sizeof(buffer));
         if (nread < 0) {
-            if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                usleep(10000);
-                continue;
+            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                status_message = std::string("read error: ") + std::strerror(errno);
+                break;
             }
-            perror("read");
-            break;
-        } else if (nread == 0) {
-            usleep(10000);
-            continue;
+        } else if (nread > 0) {
+            for (ssize_t i = 0; i < nread; ++i) {
+                if (mavlink_parse_char(MAVLINK_COMM_0, buffer[i], &message, &status)) {
+                    const auto timestamp = current_timestamp_string();
+                    const auto name = message_name(message);
+                    const auto payload_hex = payload_to_hex(message);
+
+                    auto &entry = messages[message.msgid];
+                    entry.name = name;
+                    entry.count++;
+                    entry.last_timestamp = timestamp;
+                    entry.payload_hex = payload_hex;
+                    entry.sysid = message.sysid;
+                    entry.compid = message.compid;
+                    entry.len = message.len;
+
+                    if (output.is_open()) {
+                        output << timestamp << ", msgid=" << message.msgid << ", name=" << name
+                               << ", sys=" << static_cast<int>(message.sysid)
+                               << ", comp=" << static_cast<int>(message.compid)
+                               << ", len=" << static_cast<int>(message.len)
+                               << ", payload=" << payload_hex << '\n';
+                        output.flush();
+                    }
+                }
+            }
         }
 
-        for (ssize_t i = 0; i < nread; ++i) {
-            if (mavlink_parse_char(MAVLINK_COMM_0, buffer[i], &message, &status)) {
-                const auto timestamp = current_timestamp_string();
-                const auto name = message_name(message);
-                const auto payload_hex = payload_to_hex(message);
+        const auto now = std::chrono::steady_clock::now();
+        if (now - last_ui_update > std::chrono::milliseconds(100)) {
+            render_ui(device_path, baudrate, messages, output_path, status_message);
+            last_ui_update = now;
+        }
 
-                std::ostringstream line;
-                line << timestamp << ", msgid=" << message.msgid << ", name=" << name
-                     << ", sys=" << static_cast<int>(message.sysid)
-                     << ", comp=" << static_cast<int>(message.compid)
-                     << ", len=" << static_cast<int>(message.len)
-                     << ", payload=" << payload_hex;
-
-                const std::string output_line = line.str();
-                output << output_line << '\n';
-                output.flush();
-                std::cout << output_line << std::endl;
+        int ch = getch();
+        if (ch != ERR) {
+            if (ch == 'q' || ch == 'Q') {
+                g_should_exit = 1;
+            } else if (ch == 'h' || ch == 'H') {
+                status_message = send_heartbeat(fd, sysid, compid, target_sys, target_comp)
+                                     ? "Heartbeat sent"
+                                     : "Failed to send heartbeat";
+            } else if (ch == 'r' || ch == 'R') {
+                status_message = send_reboot(fd, sysid, compid, target_sys, target_comp)
+                                     ? "Reboot command sent"
+                                     : "Failed to send reboot command";
+            } else if (ch == 'p' || ch == 'P') {
+                status_message = send_ping(fd, sysid, compid, target_sys, target_comp)
+                                     ? "Ping sent"
+                                     : "Failed to send ping";
             }
         }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
-    std::cout << "Exiting." << std::endl;
+    render_ui(device_path, baudrate, messages, output_path, status_message);
+    endwin();
+
+    if (output.is_open()) {
+        output.flush();
+    }
+
     ::close(fd);
     return 0;
 }


### PR DESCRIPTION
## Summary
- replace the UART logger console output with a curses-based table that keeps the latest MAVLink frame per message id
- add key bindings to send heartbeat, ping, and reboot commands along with configurable ids and optional logging
- link against ncurses and refresh the README with updated usage instructions

## Testing
- cmake -S OpenHD/tools/mavlink_uart_logger -B OpenHD/tools/mavlink_uart_logger/build
- cmake --build OpenHD/tools/mavlink_uart_logger/build


------
https://chatgpt.com/codex/tasks/task_e_68e1235446f8832fa1189b0cc5a4cf88