### PR TITLE
Improve MAVLink logger filtering UI and defaults

### DIFF
--- a/OpenHD/tools/mavlink_uart_logger/main.cpp
+++ b/OpenHD/tools/mavlink_uart_logger/main.cpp
@@ -12,11 +12,13 @@
 #include <optional>
 #include <sstream>
 #include <ctime>
+#include <set>
 #include <string>
 #include <termios.h>
 #include <thread>
 #include <unistd.h>
 #include <vector>
+#include <filesystem>
 
 #include <ncurses.h>
 
@@ -67,8 +69,55 @@ std::optional<speed_t> baudrate_to_constant(int baudrate) {
 
 void print_usage(const char *program) {
     std::cerr << "Usage: " << program
-              << " --device <path> --baud <baudrate> [--output <file>]"
+              << " [--device <path>] [--baud <baudrate>] [--output <file>]"
               << " [--sysid <id> --compid <id> --target-sys <id> --target-comp <id>]" << std::endl;
+    std::cerr << "Defaults: baud=115200, device=/dev/serialX (first available)" << std::endl;
+}
+
+std::optional<std::string> find_default_serial_device() {
+    namespace fs = std::filesystem;
+    const fs::path dev_dir{"/dev"};
+
+    std::error_code ec;
+    if (!fs::exists(dev_dir, ec) || ec || !fs::is_directory(dev_dir, ec) || ec) {
+        return std::nullopt;
+    }
+
+    std::vector<fs::path> candidates;
+    for (const auto &entry : fs::directory_iterator(dev_dir, ec)) {
+        if (ec) {
+            break;
+        }
+
+        const auto &path = entry.path();
+        const auto filename = path.filename().string();
+        if (filename.rfind("serial", 0) != 0) {
+            continue;
+        }
+
+        std::error_code status_ec;
+        const auto status = entry.symlink_status(status_ec);
+        if (status_ec) {
+            continue;
+        }
+
+        if (fs::is_directory(status)) {
+            continue;
+        }
+
+        if (!fs::is_character_file(status) && !fs::is_symlink(status)) {
+            continue;
+        }
+
+        candidates.push_back(path);
+    }
+
+    if (ec || candidates.empty()) {
+        return std::nullopt;
+    }
+
+    std::sort(candidates.begin(), candidates.end());
+    return candidates.front().string();
 }
 
 bool configure_serial(int fd, speed_t speed_constant) {
@@ -135,7 +184,18 @@ std::string message_name(const mavlink_message_t &message) {
     return std::string(info->name);
 }
 
-}  // namespace
+using MessageKey = uint64_t;
+
+MessageKey make_message_key(uint8_t sysid, uint8_t compid, uint32_t msgid) {
+    return (static_cast<MessageKey>(sysid) << 40) | (static_cast<MessageKey>(compid) << 32) |
+           static_cast<MessageKey>(msgid);
+}
+
+struct FilterState {
+    std::optional<uint8_t> sysid;
+    std::optional<uint8_t> compid;
+    std::optional<uint32_t> msgid;
+};
 
 struct MessageEntry {
     uint64_t count = 0;
@@ -145,7 +205,116 @@ struct MessageEntry {
     uint8_t sysid = 0;
     uint8_t compid = 0;
     uint8_t len = 0;
+    uint32_t msgid = 0;
 };
+
+std::vector<uint8_t> collect_sysids(const std::map<MessageKey, MessageEntry> &messages) {
+    std::set<uint8_t> sysids;
+    for (const auto &kv : messages) {
+        sysids.insert(kv.second.sysid);
+    }
+    return std::vector<uint8_t>(sysids.begin(), sysids.end());
+}
+
+std::vector<uint8_t> collect_compids(const std::map<MessageKey, MessageEntry> &messages, uint8_t sysid) {
+    std::set<uint8_t> compids;
+    for (const auto &kv : messages) {
+        if (kv.second.sysid == sysid) {
+            compids.insert(kv.second.compid);
+        }
+    }
+    return std::vector<uint8_t>(compids.begin(), compids.end());
+}
+
+std::vector<uint32_t> collect_msgids(const std::map<MessageKey, MessageEntry> &messages, uint8_t sysid,
+                                     uint8_t compid) {
+    std::set<uint32_t> msgids;
+    for (const auto &kv : messages) {
+        if (kv.second.sysid == sysid && kv.second.compid == compid) {
+            msgids.insert(kv.second.msgid);
+        }
+    }
+    return std::vector<uint32_t>(msgids.begin(), msgids.end());
+}
+
+int render_table(int start_row, int max_y, int max_x, const std::string &title,
+                 const std::vector<const MessageEntry *> &entries) {
+    if (start_row >= max_y) {
+        return max_y;
+    }
+
+    mvprintw(start_row++, 0, "%s", title.c_str());
+    if (start_row >= max_y) {
+        return max_y;
+    }
+
+    mvprintw(start_row++, 0, "%-5s %-5s %-6s %-20s %-8s %-4s %-27s %s", "SYS", "COMP", "MSG", "NAME",
+             "COUNT", "LEN", "LAST UPDATE", "PAYLOAD (hex)");
+    if (start_row >= max_y) {
+        return max_y;
+    }
+
+    int available_rows = max_y - start_row - 1;
+    if (available_rows < 0) {
+        available_rows = 0;
+    }
+
+    int displayed = 0;
+    for (const auto *entry : entries) {
+        if (displayed >= available_rows) {
+            break;
+        }
+
+        std::string payload = entry->payload_hex;
+        const int payload_start_col = 5 + 1 + 5 + 1 + 6 + 1 + 20 + 1 + 8 + 1 + 4 + 1 + 27 + 1;
+        const int available_width = std::max(0, max_x - payload_start_col);
+        if (static_cast<int>(payload.size()) > available_width && available_width > 3) {
+            payload = payload.substr(0, available_width - 3) + "...";
+        }
+
+        mvprintw(start_row + displayed, 0, "%-5u %-5u %-6u %-20s %-8lu %-4u %-27s %s",
+                 static_cast<unsigned>(entry->sysid), static_cast<unsigned>(entry->compid),
+                 static_cast<unsigned>(entry->msgid), entry->name.c_str(),
+                 static_cast<unsigned long>(entry->count), static_cast<unsigned>(entry->len),
+                 entry->last_timestamp.c_str(), payload.c_str());
+        ++displayed;
+    }
+
+    if (displayed == 0) {
+        mvprintw(start_row, 0, "<no entries>");
+        start_row += 1;
+    } else {
+        start_row += displayed;
+    }
+
+    if (start_row < max_y) {
+        ++start_row;
+    }
+
+    return start_row;
+}
+
+template <typename T>
+std::optional<T> cycle_optional(const std::vector<T> &values, const std::optional<T> &current) {
+    if (values.empty()) {
+        return std::nullopt;
+    }
+
+    if (!current.has_value()) {
+        return values.front();
+    }
+
+    auto it = std::find(values.begin(), values.end(), *current);
+    if (it == values.end()) {
+        return values.front();
+    }
+
+    ++it;
+    if (it == values.end()) {
+        return std::nullopt;
+    }
+    return *it;
+}
 
 bool write_message(int fd, const mavlink_message_t &message) {
     uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
@@ -181,8 +350,9 @@ bool send_ping(int fd, uint8_t sysid, uint8_t compid, uint8_t target_sys, uint8_
     return write_message(fd, msg);
 }
 
-void render_ui(const std::string &device_path, int baudrate, const std::map<uint32_t, MessageEntry> &messages,
-               const std::string &output_path, const std::string &status_message) {
+void render_ui(const std::string &device_path, int baudrate,
+               const std::map<MessageKey, MessageEntry> &messages, const std::string &output_path,
+               const std::string &status_message, const FilterState &filter) {
     erase();
 
     int max_y = 0;
@@ -193,54 +363,82 @@ void render_ui(const std::string &device_path, int baudrate, const std::map<uint
     mvprintw(1, 0, "Logging to: %s", output_path.empty() ? "<disabled>" : output_path.c_str());
     mvprintw(2, 0, "Controls: q=quit | h=send heartbeat | r=send reboot command | p=send ping");
     mvprintw(3, 0, "Status: %s", status_message.c_str());
+    mvprintw(4, 0, "Filter controls: s=cycle sysid | c=cycle comp | m=cycle message | f=clear filters");
 
-    const int header_row = 5;
-    mvprintw(header_row, 0, "%-6s %-20s %-8s %-4s %-6s %-6s %-27s %s", "MSGID", "NAME", "COUNT", "LEN",
-             "SYS", "COMP", "LAST UPDATE", "PAYLOAD (hex)");
+    const std::string sys_str = filter.sysid ? std::to_string(*filter.sysid) : std::string("All");
+    const std::string comp_str = filter.compid ? std::to_string(*filter.compid) : std::string("All");
+    const std::string msg_str = filter.msgid ? std::to_string(*filter.msgid) : std::string("All");
+    mvprintw(5, 0, "Active filter: sys=%s comp=%s msg=%s", sys_str.c_str(), comp_str.c_str(),
+             msg_str.c_str());
 
-    int row = header_row + 1;
-    const int max_rows = max_y - row - 1;
+    int row = 7;
 
-    std::vector<std::pair<uint32_t, const MessageEntry *>> sorted_entries;
-    sorted_entries.reserve(messages.size());
+    std::vector<const MessageEntry *> all_entries;
+    all_entries.reserve(messages.size());
     for (const auto &kv : messages) {
-        sorted_entries.emplace_back(kv.first, &kv.second);
-    }
-    std::sort(sorted_entries.begin(), sorted_entries.end(),
-              [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
-
-    int displayed = 0;
-    for (const auto &[msgid, entry_ptr] : sorted_entries) {
-        if (displayed >= max_rows) {
-            break;
-        }
-
-        const auto &entry = *entry_ptr;
-        std::string payload = entry.payload_hex;
-        const int payload_start_col = 6 + 1 + 20 + 1 + 8 + 1 + 4 + 1 + 6 + 1 + 6 + 1 + 27 + 1;
-        const int available_width = std::max(0, max_x - payload_start_col);
-        if (static_cast<int>(payload.size()) > available_width && available_width > 3) {
-            payload = payload.substr(0, available_width - 3) + "...";
-        }
-
-        mvprintw(row + displayed, 0, "%-6u %-20s %-8lu %-4u %-6u %-6u %-27s %s", msgid, entry.name.c_str(),
-                 static_cast<unsigned long>(entry.count), static_cast<unsigned>(entry.len),
-                 static_cast<unsigned>(entry.sysid), static_cast<unsigned>(entry.compid),
-                 entry.last_timestamp.c_str(), payload.c_str());
-        ++displayed;
+        all_entries.push_back(&kv.second);
     }
 
-    if (displayed == 0) {
-        mvprintw(row, 0, "Waiting for MAVLink traffic...");
+    std::sort(all_entries.begin(), all_entries.end(), [](const auto *lhs, const auto *rhs) {
+        if (lhs->sysid != rhs->sysid) {
+            return lhs->sysid < rhs->sysid;
+        }
+        if (lhs->compid != rhs->compid) {
+            return lhs->compid < rhs->compid;
+        }
+        if (lhs->msgid != rhs->msgid) {
+            return lhs->msgid < rhs->msgid;
+        }
+        return lhs->name < rhs->name;
+    });
+
+    row = render_table(row, max_y, max_x, "All Messages", all_entries);
+
+    if (row >= max_y) {
+        refresh();
+        return;
+    }
+
+    std::vector<const MessageEntry *> filtered_entries;
+    filtered_entries.reserve(all_entries.size());
+    for (const auto *entry : all_entries) {
+        if (filter.sysid && entry->sysid != *filter.sysid) {
+            continue;
+        }
+        if (filter.compid && entry->compid != *filter.compid) {
+            continue;
+        }
+        if (filter.msgid && entry->msgid != *filter.msgid) {
+            continue;
+        }
+        filtered_entries.push_back(entry);
+    }
+
+    if (!filter.sysid && !filter.compid && !filter.msgid) {
+        if (row < max_y) {
+            mvprintw(row, 0, "Filtered Messages: (press s/c/m to apply filters)");
+            if (row + 1 < max_y) {
+                row += 2;
+            } else {
+                row = max_y;
+            }
+        }
+    } else if (row < max_y) {
+        row = render_table(row, max_y, max_x, "Filtered Messages", filtered_entries);
     }
 
     refresh();
 }
 
+}  // namespace
+
 int main(int argc, char **argv) {
     std::string device_path;
     std::string output_path;
     int baudrate = 0;
+    constexpr int kDefaultBaudrate = 115200;
+    bool device_user_specified = false;
+    bool baud_user_specified = false;
     uint8_t sysid = 1;
     uint8_t compid = 1;
     uint8_t target_sys = 1;
@@ -250,8 +448,10 @@ int main(int argc, char **argv) {
         std::string arg = argv[i];
         if (arg == "--device" && i + 1 < argc) {
             device_path = argv[++i];
+            device_user_specified = true;
         } else if (arg == "--baud" && i + 1 < argc) {
             baudrate = std::stoi(argv[++i]);
+            baud_user_specified = true;
         } else if (arg == "--output" && i + 1 < argc) {
             output_path = argv[++i];
         } else if (arg == "--sysid" && i + 1 < argc) {
@@ -273,9 +473,20 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (device_path.empty() || baudrate == 0) {
-        print_usage(argv[0]);
-        return 1;
+    if (device_path.empty()) {
+        if (auto detected_device = find_default_serial_device()) {
+            device_path = *detected_device;
+            std::cerr << "No device specified, using " << device_path << std::endl;
+        } else {
+            std::cerr << "No device specified and unable to find a /dev/serialX device" << std::endl;
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (baudrate == 0) {
+        baudrate = kDefaultBaudrate;
+        std::cerr << "No baudrate specified, defaulting to " << kDefaultBaudrate << std::endl;
     }
 
     auto speed_constant = baudrate_to_constant(baudrate);
@@ -316,8 +527,24 @@ int main(int argc, char **argv) {
 
     mavlink_message_t message{};
     mavlink_status_t status{};
-    std::map<uint32_t, MessageEntry> messages;
+    std::map<MessageKey, MessageEntry> messages;
     std::string status_message = "Listening...";
+    FilterState filter;
+    if (!device_user_specified || !baud_user_specified) {
+        status_message += " (auto:";
+        bool need_separator = false;
+        if (!device_user_specified) {
+            status_message += " device=" + device_path;
+            need_separator = true;
+        }
+        if (!baud_user_specified) {
+            if (need_separator) {
+                status_message += ',';
+            }
+            status_message += " baud=" + std::to_string(baudrate);
+        }
+        status_message += ')';
+    }
 
     const auto start_time = std::chrono::steady_clock::now();
     auto last_ui_update = start_time - std::chrono::milliseconds(200);
@@ -337,7 +564,9 @@ int main(int argc, char **argv) {
                     const auto name = message_name(message);
                     const auto payload_hex = payload_to_hex(message);
 
-                    auto &entry = messages[message.msgid];
+                    const MessageKey key =
+                        make_message_key(message.sysid, message.compid, message.msgid);
+                    auto &entry = messages[key];
                     entry.name = name;
                     entry.count++;
                     entry.last_timestamp = timestamp;
@@ -345,6 +574,7 @@ int main(int argc, char **argv) {
                     entry.sysid = message.sysid;
                     entry.compid = message.compid;
                     entry.len = message.len;
+                    entry.msgid = message.msgid;
 
                     if (output.is_open()) {
                         output << timestamp << ", msgid=" << message.msgid << ", name=" << name
@@ -360,7 +590,7 @@ int main(int argc, char **argv) {
 
         const auto now = std::chrono::steady_clock::now();
         if (now - last_ui_update > std::chrono::milliseconds(100)) {
-            render_ui(device_path, baudrate, messages, output_path, status_message);
+            render_ui(device_path, baudrate, messages, output_path, status_message, filter);
             last_ui_update = now;
         }
 
@@ -380,13 +610,81 @@ int main(int argc, char **argv) {
                 status_message = send_ping(fd, sysid, compid, target_sys, target_comp)
                                      ? "Ping sent"
                                      : "Failed to send ping";
+            } else if (ch == 's' || ch == 'S') {
+                auto sysids = collect_sysids(messages);
+                if (sysids.empty()) {
+                    status_message = "No system IDs available to filter";
+                } else {
+                    auto next = cycle_optional(sysids, filter.sysid);
+                    if (!next.has_value()) {
+                        filter.sysid.reset();
+                        filter.compid.reset();
+                        filter.msgid.reset();
+                        status_message = "System ID filter cleared";
+                    } else {
+                        filter.sysid = next;
+                        filter.compid.reset();
+                        filter.msgid.reset();
+                        status_message = "Filtering system ID " + std::to_string(*filter.sysid);
+                    }
+                }
+            } else if (ch == 'c' || ch == 'C') {
+                if (!filter.sysid) {
+                    status_message = "Select a system ID first (press 's')";
+                } else {
+                    auto compids = collect_compids(messages, *filter.sysid);
+                    if (compids.empty()) {
+                        filter.compid.reset();
+                        filter.msgid.reset();
+                        status_message = "No component IDs for system " + std::to_string(*filter.sysid);
+                    } else {
+                        auto next = cycle_optional(compids, filter.compid);
+                        if (!next.has_value()) {
+                            filter.compid.reset();
+                            filter.msgid.reset();
+                            status_message = "Component ID filter cleared";
+                        } else {
+                            filter.compid = next;
+                            filter.msgid.reset();
+                            status_message = "Filtering system " + std::to_string(*filter.sysid) +
+                                             " component " + std::to_string(*filter.compid);
+                        }
+                    }
+                }
+            } else if (ch == 'm' || ch == 'M') {
+                if (!filter.sysid || !filter.compid) {
+                    status_message = "Select system and component filters first (press 's' then 'c')";
+                } else {
+                    auto msgids = collect_msgids(messages, *filter.sysid, *filter.compid);
+                    if (msgids.empty()) {
+                        filter.msgid.reset();
+                        status_message = "No messages for sys " + std::to_string(*filter.sysid) +
+                                         " comp " + std::to_string(*filter.compid);
+                    } else {
+                        auto next = cycle_optional(msgids, filter.msgid);
+                        if (!next.has_value()) {
+                            filter.msgid.reset();
+                            status_message = "Message filter cleared";
+                        } else {
+                            filter.msgid = next;
+                            status_message = "Filtering msgid " + std::to_string(*filter.msgid) +
+                                             " (sys " + std::to_string(*filter.sysid) + ", comp " +
+                                             std::to_string(*filter.compid) + ')';
+                        }
+                    }
+                }
+            } else if (ch == 'f' || ch == 'F') {
+                filter.sysid.reset();
+                filter.compid.reset();
+                filter.msgid.reset();
+                status_message = "Filters cleared";
             }
         }
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
-    render_ui(device_path, baudrate, messages, output_path, status_message);
+    render_ui(device_path, baudrate, messages, output_path, status_message, filter);
     endwin();
 
     if (output.is_open()) {


### PR DESCRIPTION
## Summary
- default the UART logger to 115200 baud while keeping the auto-detected serial port messaging
- show every MAVLink stream grouped by system/component/message ID with an "All" table plus a filterable view
- add interactive sysid/compid/msgid cycling so operators can focus the ncurses display without dropping traffic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e13ef33e00832fbdd7f438d4538b45