### PR TITLE
Add periodic heartbeat for OpenHD UART telemetry

### DIFF
--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -24,6 +24,7 @@
 #include "AirTelemetry.h"
 
 #include <chrono>
+#include <thread>
 
 #include "mav_helper.h"
 #include "mavsdk_temporary/XMavlinkParamProvider.h"
@@ -64,7 +65,7 @@ AirTelemetry::AirTelemetry() : MavlinkSystem(OHD_SYS_ID_AIR) {
   m_console->debug("Created AirTelemetry");
 }
 
-AirTelemetry::~AirTelemetry() {}
+AirTelemetry::~AirTelemetry() { stop_openhd_uart_heartbeat(); }
 
 void AirTelemetry::send_messages_fc(std::vector<MavlinkMessage>& messages) {
   auto [generic, local_only] =
@@ -312,6 +313,7 @@ void AirTelemetry::setup_uart() {
 
 void AirTelemetry::setup_openhd_uart_telemetry() {
   if (!m_openhd_uart_serial) return;
+  stop_openhd_uart_heartbeat();
   const auto& settings = m_air_settings->get_settings();
   const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
       settings.openhd_uart_telemetry_connection);
@@ -353,6 +355,49 @@ void AirTelemetry::setup_openhd_uart_telemetry() {
             forwarded.size());
         this->on_messages_ground_unit(forwarded);
       });
+  start_openhd_uart_heartbeat();
+}
+
+void AirTelemetry::start_openhd_uart_heartbeat() {
+  if (!m_openhd_uart_serial) return;
+  stop_openhd_uart_heartbeat();
+  m_openhd_uart_heartbeat_stop = false;
+  auto send_heartbeat = [this]() {
+    std::vector<MavlinkMessage> heartbeat{
+        OHDMessages::createHeartbeat(_sys_id, MAV_COMP_ID_ONBOARD_COMPUTER)};
+    m_console->debug("Sending OpenHD UART heartbeat");
+    m_openhd_uart_serial->send_messages_if_enabled(heartbeat);
+  };
+  send_heartbeat();
+  m_openhd_uart_heartbeat_thread = std::make_unique<std::thread>([this, send_heartbeat]() {
+    const auto interval = std::chrono::minutes(1);
+    while (!m_openhd_uart_heartbeat_stop.load()) {
+      auto remaining = interval;
+      const auto sleep_step = std::chrono::seconds(1);
+      while (remaining > std::chrono::milliseconds::zero()) {
+        if (m_openhd_uart_heartbeat_stop.load()) {
+          return;
+        }
+        const auto step = remaining > sleep_step ? sleep_step : remaining;
+        std::this_thread::sleep_for(step);
+        remaining -= step;
+      }
+      if (m_openhd_uart_heartbeat_stop.load()) {
+        return;
+      }
+      send_heartbeat();
+    }
+  });
+}
+
+void AirTelemetry::stop_openhd_uart_heartbeat() {
+  m_openhd_uart_heartbeat_stop = true;
+  if (m_openhd_uart_heartbeat_thread &&
+      m_openhd_uart_heartbeat_thread->joinable()) {
+    m_openhd_uart_heartbeat_thread->join();
+  }
+  m_openhd_uart_heartbeat_thread.reset();
+  m_openhd_uart_heartbeat_stop = false;
 }
 
 void AirTelemetry::configure_openhd_uart_telemetry(

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.h
@@ -24,8 +24,10 @@
 #ifndef OPENHD_TELEMETRY_AIRTELEMETRY_H
 #define OPENHD_TELEMETRY_AIRTELEMETRY_H
 
+#include <atomic>
 #include <optional>
 #include <string>
+#include <thread>
 
 #include "endpoints/SerialEndpoint.h"
 #include "internal/OHDMainComponent.h"
@@ -104,6 +106,8 @@ class AirTelemetry : public MavlinkSystem {
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
   void setup_openhd_uart_telemetry();
+  void start_openhd_uart_heartbeat();
+  void stop_openhd_uart_heartbeat();
 
  private:
   std::unique_ptr<openhd::telemetry::air::SettingsHolder> m_air_settings;
@@ -122,6 +126,8 @@ class AirTelemetry : public MavlinkSystem {
   std::shared_ptr<spdlog::logger> m_console;
   // EXP - always on TCP mavlink server
   std::unique_ptr<TCPEndpoint> m_tcp_server = nullptr;
+  std::unique_ptr<std::thread> m_openhd_uart_heartbeat_thread;
+  std::atomic<bool> m_openhd_uart_heartbeat_stop{false};
 };
 
 #endif  // OPENHD_TELEMETRY_AIRTELEMETRY_H

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -25,6 +25,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <thread>
 
 #include "mav_helper.h"
 #include "openhd_temporary_air_or_ground.h"
@@ -92,9 +93,9 @@ GroundTelemetry::GroundTelemetry() : MavlinkSystem(OHD_SYS_ID_GROUND) {
 }
 
 GroundTelemetry::~GroundTelemetry() {
+  stop_openhd_uart_heartbeat();
   // first, stop all the endpoints that have their own threads
   m_wb_endpoint = nullptr;
-  m_gcs_endpoint = nullptr;
   if (m_gcs_endpoint) {
     m_gcs_endpoint = nullptr;
   }
@@ -420,6 +421,7 @@ void GroundTelemetry::setup_uart() {
 
 void GroundTelemetry::setup_openhd_uart_telemetry() {
   if (!m_openhd_uart_serial) return;
+  stop_openhd_uart_heartbeat();
   const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
       m_gnd_settings->get_settings().openhd_uart_telemetry_connection);
   if (!uart_linux_fd.has_value()) {
@@ -459,6 +461,49 @@ void GroundTelemetry::setup_openhd_uart_telemetry() {
             forwarded.size());
         on_messages_ground_station_clients(forwarded);
       });
+  start_openhd_uart_heartbeat();
+}
+
+void GroundTelemetry::start_openhd_uart_heartbeat() {
+  if (!m_openhd_uart_serial) return;
+  stop_openhd_uart_heartbeat();
+  m_openhd_uart_heartbeat_stop = false;
+  auto send_heartbeat = [this]() {
+    std::vector<MavlinkMessage> heartbeat{
+        OHDMessages::createHeartbeat(_sys_id, MAV_COMP_ID_ONBOARD_COMPUTER)};
+    m_console->debug("Sending OpenHD UART heartbeat");
+    m_openhd_uart_serial->send_messages_if_enabled(heartbeat);
+  };
+  send_heartbeat();
+  m_openhd_uart_heartbeat_thread = std::make_unique<std::thread>([this, send_heartbeat]() {
+    const auto interval = std::chrono::minutes(1);
+    while (!m_openhd_uart_heartbeat_stop.load()) {
+      auto remaining = interval;
+      const auto sleep_step = std::chrono::seconds(1);
+      while (remaining > std::chrono::milliseconds::zero()) {
+        if (m_openhd_uart_heartbeat_stop.load()) {
+          return;
+        }
+        const auto step = remaining > sleep_step ? sleep_step : remaining;
+        std::this_thread::sleep_for(step);
+        remaining -= step;
+      }
+      if (m_openhd_uart_heartbeat_stop.load()) {
+        return;
+      }
+      send_heartbeat();
+    }
+  });
+}
+
+void GroundTelemetry::stop_openhd_uart_heartbeat() {
+  m_openhd_uart_heartbeat_stop = true;
+  if (m_openhd_uart_heartbeat_thread &&
+      m_openhd_uart_heartbeat_thread->joinable()) {
+    m_openhd_uart_heartbeat_thread->join();
+  }
+  m_openhd_uart_heartbeat_thread.reset();
+  m_openhd_uart_heartbeat_stop = false;
 }
 
 void GroundTelemetry::configure_openhd_uart_telemetry(

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -24,7 +24,9 @@
 #ifndef OPENHD_TELEMETRY_GROUNDTELEMETRY_H
 #define OPENHD_TELEMETRY_GROUNDTELEMETRY_H
 
+#include <atomic>
 #include <optional>
+#include <thread>
 
 #include "GroundTelemetrySettings.h"
 #include "endpoints/SerialEndpoint.h"
@@ -103,6 +105,8 @@ class GroundTelemetry : public MavlinkSystem {
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
   void setup_openhd_uart_telemetry();
+  void start_openhd_uart_heartbeat();
+  void stop_openhd_uart_heartbeat();
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
   void enable_joystick();
   void disable_joystick();
@@ -127,6 +131,8 @@ class GroundTelemetry : public MavlinkSystem {
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
   std::unique_ptr<RcJoystickSender> m_rc_joystick_sender = nullptr;
 #endif
+  std::unique_ptr<std::thread> m_openhd_uart_heartbeat_thread;
+  std::atomic<bool> m_openhd_uart_heartbeat_stop{false};
 };
 
 #endif  // OPENHD_TELEMETRY_GROUNDTELEMETRY_H


### PR DESCRIPTION
## Summary
- send an initial heartbeat when the OpenHD UART telemetry serial endpoint is configured on both air and ground telemetry services
- keep sending a heartbeat roughly once per minute while the UART telemetry endpoint remains enabled and stop when it is disabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e157d02474832f98d41e1c823ba844