### PR TITLE
Disable direct UART paths and add startup MAVLink tests

### DIFF
--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -24,12 +24,38 @@
 #include "AirTelemetry.h"
 
 #include <chrono>
+#include <thread>
 
 #include "mav_helper.h"
 #include "mavsdk_temporary/XMavlinkParamProvider.h"
 #include "openhd_temporary_air_or_ground.h"
 #include "openhd_util.h"
 #include "openhd_util_time.h"
+
+namespace {
+
+std::vector<MavlinkMessage> create_uart_debug_messages(uint8_t sys_id) {
+  std::vector<MavlinkMessage> messages;
+  messages.reserve(3);
+  messages.push_back(
+      OHDMessages::createHeartbeat(sys_id, MAV_COMP_ID_ONBOARD_COMPUTER));
+
+  constexpr char kStatusText[] = "OpenHD UART link check";
+  MavlinkMessage statustext{};
+  mavlink_msg_statustext_pack(sys_id, MAV_COMP_ID_ONBOARD_COMPUTER,
+                              &statustext.m, MAV_SEVERITY_INFO, kStatusText);
+  messages.push_back(statustext);
+
+  MavlinkMessage ping{};
+  const uint64_t now = static_cast<uint64_t>(get_time_microseconds());
+  mavlink_msg_ping_pack(sys_id, MAV_COMP_ID_ONBOARD_COMPUTER, &ping.m, now, 0,
+                        0, 0);
+  messages.push_back(ping);
+
+  return messages;
+}
+
+}  // namespace
 
 AirTelemetry::AirTelemetry() : MavlinkSystem(OHD_SYS_ID_AIR) {
   m_console = openhd::log::create_or_get("air_tele");
@@ -292,20 +318,15 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
 // existing uart connection if set.
 void AirTelemetry::setup_uart() {
   assert(m_air_settings);
-  using namespace openhd::telemetry;
-  const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
-      m_air_settings->get_settings().fc_uart_connection_type);
-  if (uart_linux_fd.has_value()) {
-    SerialEndpoint::HWOptions options{};
-    options.linux_filename = uart_linux_fd.value();
-    options.baud_rate = m_air_settings->get_settings().fc_uart_baudrate;
-    options.flow_control = m_air_settings->get_settings().fc_uart_flow_control;
-    options.enable_reading = true;
-    m_fc_serial->configure(options, "fc_ser",
-                           [this](std::vector<MavlinkMessage> messages) {
-                             this->on_messages_fc(messages);
-                           });
-  } else {
+  if (!m_logged_fc_uart_disabled_notice) {
+    m_console->info(
+        "Disabling dedicated FC UART telemetry input; relying on OpenHD UART telemetry instead");
+    m_logged_fc_uart_disabled_notice = true;
+  }
+  m_air_settings->unsafe_get_settings().fc_uart_connection_type =
+      openhd::telemetry::air::UART_CONNECTION_TYPE_DISABLE;
+  m_air_settings->persist();
+  if (m_fc_serial) {
     m_fc_serial->disable();
   }
 }
@@ -320,6 +341,7 @@ void AirTelemetry::setup_openhd_uart_telemetry() {
         "Disabling OpenHD UART telemetry - no valid device configured (value: {})",
         settings.openhd_uart_telemetry_connection);
     m_openhd_uart_serial->disable();
+    m_sent_openhd_uart_test_messages = false;
     return;
   }
   m_console->info(
@@ -353,6 +375,7 @@ void AirTelemetry::setup_openhd_uart_telemetry() {
             forwarded.size());
         this->on_messages_ground_unit(forwarded);
       });
+  send_openhd_uart_test_messages_once();
 }
 
 void AirTelemetry::configure_openhd_uart_telemetry(
@@ -368,6 +391,24 @@ void AirTelemetry::configure_openhd_uart_telemetry(
       device_path.value();
   m_air_settings->persist();
   setup_openhd_uart_telemetry();
+}
+
+void AirTelemetry::send_openhd_uart_test_messages_once() {
+  if (m_sent_openhd_uart_test_messages || !m_openhd_uart_serial) {
+    return;
+  }
+  auto messages = create_uart_debug_messages(_sys_id);
+  if (messages.empty()) {
+    return;
+  }
+  m_console->info(
+      "Sending {} MAVLink test message(s) via OpenHD UART telemetry",
+      messages.size());
+  for (int i = 0; i < 3; ++i) {
+    m_openhd_uart_serial->send_messages_if_enabled(messages);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  m_sent_openhd_uart_test_messages = true;
 }
 
 void AirTelemetry::set_link_handle(std::shared_ptr<OHDLink> link) {

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.h
@@ -104,6 +104,7 @@ class AirTelemetry : public MavlinkSystem {
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
   void setup_openhd_uart_telemetry();
+  void send_openhd_uart_test_messages_once();
 
  private:
   std::unique_ptr<openhd::telemetry::air::SettingsHolder> m_air_settings;
@@ -122,6 +123,8 @@ class AirTelemetry : public MavlinkSystem {
   std::shared_ptr<spdlog::logger> m_console;
   // EXP - always on TCP mavlink server
   std::unique_ptr<TCPEndpoint> m_tcp_server = nullptr;
+  bool m_logged_fc_uart_disabled_notice = false;
+  bool m_sent_openhd_uart_test_messages = false;
 };
 
 #endif  // OPENHD_TELEMETRY_AIRTELEMETRY_H

--- a/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
@@ -85,8 +85,10 @@ class SettingsHolder : public openhd::PersistentSettings<Settings> {
   }
   [[nodiscard]] Settings create_default() const override {
     Settings ret{};
-    // Default telemetry serial (for this platform)
-    ret.fc_uart_connection_type = "DEFAULT";
+    // Default to no dedicated FC UART input. The OpenHD UART telemetry bridge
+    // is used instead unless explicitly configured otherwise.
+    ret.fc_uart_connection_type =
+        openhd::telemetry::air::UART_CONNECTION_TYPE_DISABLE;
     return ret;
   }
   std::optional<Settings> impl_deserialize(

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -25,11 +25,37 @@
 
 #include <chrono>
 #include <iostream>
+#include <thread>
 
 #include "mav_helper.h"
 #include "openhd_temporary_air_or_ground.h"
 #include "openhd_util.h"
 #include "openhd_util_time.h"
+
+namespace {
+
+std::vector<MavlinkMessage> create_uart_debug_messages(uint8_t sys_id) {
+  std::vector<MavlinkMessage> messages;
+  messages.reserve(3);
+  messages.push_back(
+      OHDMessages::createHeartbeat(sys_id, MAV_COMP_ID_ONBOARD_COMPUTER));
+
+  constexpr char kStatusText[] = "OpenHD UART link check";
+  MavlinkMessage statustext{};
+  mavlink_msg_statustext_pack(sys_id, MAV_COMP_ID_ONBOARD_COMPUTER,
+                              &statustext.m, MAV_SEVERITY_INFO, kStatusText);
+  messages.push_back(statustext);
+
+  MavlinkMessage ping{};
+  const uint64_t now = static_cast<uint64_t>(get_time_microseconds());
+  mavlink_msg_ping_pack(sys_id, MAV_COMP_ID_ONBOARD_COMPUTER, &ping.m, now, 0,
+                        0, 0);
+  messages.push_back(ping);
+
+  return messages;
+}
+
+}  // namespace
 
 GroundTelemetry::GroundTelemetry() : MavlinkSystem(OHD_SYS_ID_GROUND) {
   m_console = openhd::log::create_or_get("ground_tele");
@@ -406,22 +432,15 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
 
 void GroundTelemetry::setup_uart() {
   assert(m_gnd_settings);
-  using namespace openhd::telemetry;
-  const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
-      m_gnd_settings->get_settings().gnd_uart_connection_type);
-  if (uart_linux_fd.has_value()) {
-    SerialEndpoint::HWOptions options{};
-    options.linux_filename = uart_linux_fd.value();
-    options.baud_rate = m_gnd_settings->get_settings().gnd_uart_baudrate;
-    options.flow_control = false;
-    options.enable_reading = false;
-    m_endpoint_tracker->configure(options, "gnd_ser",
-                                  [this](std::vector<MavlinkMessage> messages) {
-                                    // We ignore any incoming messages here for
-                                    // now, since it is only for mavlink out via
-                                    // serial
-                                  });
-  } else {
+  if (!m_logged_tracker_uart_disabled_notice) {
+    m_console->info(
+        "Disabling tracker UART output; relying on OpenHD UART telemetry instead");
+    m_logged_tracker_uart_disabled_notice = true;
+  }
+  m_gnd_settings->unsafe_get_settings().gnd_uart_connection_type =
+      openhd::telemetry::ground::UART_CONNECTION_TYPE_DISABLE;
+  m_gnd_settings->persist();
+  if (m_endpoint_tracker) {
     m_endpoint_tracker->disable();
   }
 }
@@ -435,6 +454,7 @@ void GroundTelemetry::setup_openhd_uart_telemetry() {
         "Disabling OpenHD UART telemetry - no valid device configured (value: {})",
         m_gnd_settings->get_settings().openhd_uart_telemetry_connection);
     m_openhd_uart_serial->disable();
+    m_sent_openhd_uart_test_messages = false;
     return;
   }
   m_console->info(
@@ -467,6 +487,7 @@ void GroundTelemetry::setup_openhd_uart_telemetry() {
             forwarded.size());
         on_messages_ground_station_clients(forwarded);
       });
+  send_openhd_uart_test_messages_once();
 }
 
 void GroundTelemetry::configure_openhd_uart_telemetry(
@@ -482,6 +503,24 @@ void GroundTelemetry::configure_openhd_uart_telemetry(
       device_path.value();
   m_gnd_settings->persist();
   setup_openhd_uart_telemetry();
+}
+
+void GroundTelemetry::send_openhd_uart_test_messages_once() {
+  if (m_sent_openhd_uart_test_messages || !m_openhd_uart_serial) {
+    return;
+  }
+  auto messages = create_uart_debug_messages(_sys_id);
+  if (messages.empty()) {
+    return;
+  }
+  m_console->info(
+      "Sending {} MAVLink test message(s) via OpenHD UART telemetry",
+      messages.size());
+  for (int i = 0; i < 3; ++i) {
+    m_openhd_uart_serial->send_messages_if_enabled(messages);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  m_sent_openhd_uart_test_messages = true;
 }
 
 void GroundTelemetry::set_link_handle(std::shared_ptr<OHDLink> link) {

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -103,6 +103,7 @@ class GroundTelemetry : public MavlinkSystem {
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
   void setup_openhd_uart_telemetry();
+  void send_openhd_uart_test_messages_once();
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
   void enable_joystick();
   void disable_joystick();
@@ -127,6 +128,8 @@ class GroundTelemetry : public MavlinkSystem {
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
   std::unique_ptr<RcJoystickSender> m_rc_joystick_sender = nullptr;
 #endif
+  bool m_logged_tracker_uart_disabled_notice = false;
+  bool m_sent_openhd_uart_test_messages = false;
 };
 
 #endif  // OPENHD_TELEMETRY_GROUNDTELEMETRY_H


### PR DESCRIPTION
## Summary
- disable the air-unit FC UART endpoint and the ground tracker UART output so that only the shared OpenHD UART telemetry bridge is active
- emit a burst of heartbeat/statustext/ping messages on the OpenHD UART after configuration to help MAVLink UART Debugger validate the link
- default the FC UART telemetry setting to disabled to reflect the new reliance on the OpenHD UART bridge

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e17af641d8832f98cda6cc09003faa