### PR TITLE
Record flight controller MAVLink telemetry

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_telemetry_recorder.h
+++ b/OpenHD/ohd_common/inc/openhd_telemetry_recorder.h
@@ -25,10 +25,14 @@
 #define OPENHD_OPENHD_OHD_COMMON_OPENHD_TELEMETRY_RECORDER_H_
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <mutex>
 #include <string>
+
+#include <nlohmann/json.hpp>
 
 #include "openhd_link_statistics.hpp"
 
@@ -49,6 +53,9 @@ class TelemetryRecorder {
   static TelemetryRecorder& instance();
 
   void record(const link_statistics::StatsAirGround& stats);
+  void record_fc_mavlink_message(uint8_t sysid, uint8_t compid, uint32_t msgid,
+                                 uint8_t sequence, const uint8_t* payload,
+                                 std::size_t payload_length);
 
  private:
   [[nodiscard]] std::string create_filename_timestamp(
@@ -56,9 +63,12 @@ class TelemetryRecorder {
   [[nodiscard]] std::string create_entry_timestamp(
       std::chrono::system_clock::time_point tp) const;
   void ensure_stream_is_ready();
-  [[nodiscard]] std::string stats_to_json_string(
+  [[nodiscard]] nlohmann::json stats_to_json(
       const link_statistics::StatsAirGround& stats,
       const std::string& timestamp) const;
+  [[nodiscard]] std::string bytes_to_hex(const uint8_t* data,
+                                         std::size_t length) const;
+  void write_json_line(const nlohmann::json& json_line);
 
   std::mutex m_mutex;
   std::ofstream m_stream;

--- a/OpenHD/ohd_common/src/openhd_telemetry_recorder.cpp
+++ b/OpenHD/ohd_common/src/openhd_telemetry_recorder.cpp
@@ -258,11 +258,12 @@ void TelemetryRecorder::ensure_stream_is_ready() {
   }
 }
 
-std::string TelemetryRecorder::stats_to_json_string(
+nlohmann::json TelemetryRecorder::stats_to_json(
     const link_statistics::StatsAirGround& stats,
     const std::string& timestamp) const {
   nlohmann::json j;
   j["timestamp"] = timestamp;
+  j["type"] = "link_stats";
   j["is_air"] = stats.is_air;
   j["ready"] = stats.ready;
   j["monitor_mode_link"] = monitor_link_to_json(stats.monitor_mode_link);
@@ -289,7 +290,7 @@ std::string TelemetryRecorder::stats_to_json_string(
   j["gnd_fec_performance"] = video_ground_fec_to_json(stats.gnd_fec_performance);
   j["gnd_operating_mode"] = ground_operating_mode_to_json(stats.gnd_operating_mode);
 
-  return j.dump();
+  return j;
 }
 
 void TelemetryRecorder::record(const link_statistics::StatsAirGround& stats) {
@@ -298,14 +299,51 @@ void TelemetryRecorder::record(const link_statistics::StatsAirGround& stats) {
   }
   const auto now = std::chrono::system_clock::now();
   const auto timestamp = create_entry_timestamp(now);
-  const auto json_line = stats_to_json_string(stats, timestamp);
+  const auto json_line = stats_to_json(stats, timestamp);
+  write_json_line(json_line);
+}
+
+std::string TelemetryRecorder::bytes_to_hex(const uint8_t* data,
+                                           std::size_t length) const {
+  if (data == nullptr || length == 0) {
+    return "";
+  }
+  static constexpr char HEX_DIGITS[] = "0123456789ABCDEF";
+  std::string hex;
+  hex.reserve(length * 2);
+  for (std::size_t i = 0; i < length; ++i) {
+    const auto value = data[i];
+    hex.push_back(HEX_DIGITS[(value >> 4) & 0x0F]);
+    hex.push_back(HEX_DIGITS[value & 0x0F]);
+  }
+  return hex;
+}
+
+void TelemetryRecorder::write_json_line(const nlohmann::json& json_line) {
   std::lock_guard<std::mutex> lock(m_mutex);
   ensure_stream_is_ready();
   if (!m_stream_ready || !m_stream.is_open()) {
     return;
   }
-  m_stream << json_line << '\n';
+  m_stream << json_line.dump() << '\n';
   m_stream.flush();
+}
+
+void TelemetryRecorder::record_fc_mavlink_message(
+    uint8_t sysid, uint8_t compid, uint32_t msgid, uint8_t sequence,
+    const uint8_t* payload, std::size_t payload_length) {
+  const auto now = std::chrono::system_clock::now();
+  const auto timestamp = create_entry_timestamp(now);
+  nlohmann::json entry;
+  entry["timestamp"] = timestamp;
+  entry["type"] = "fc_mavlink";
+  entry["sysid"] = sysid;
+  entry["compid"] = compid;
+  entry["msgid"] = msgid;
+  entry["sequence"] = sequence;
+  entry["payload_length"] = payload_length;
+  entry["payload_hex"] = bytes_to_hex(payload, payload_length);
+  write_json_line(entry);
 }
 
 }  // namespace openhd

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -27,6 +27,7 @@
 
 #include "mav_helper.h"
 #include "mavsdk_temporary/XMavlinkParamProvider.h"
+#include "openhd_telemetry_recorder.h"
 #include "openhd_temporary_air_or_ground.h"
 #include "openhd_util.h"
 #include "openhd_util_time.h"
@@ -103,6 +104,17 @@ void AirTelemetry::on_messages_fc(std::vector<MavlinkMessage>& messages) {
   //  Note: No OpenHD component ever talks to the FC, FC is completely passed
   //  through
   // debugMavlinkMessages(messages,"FC");
+  if (!messages.empty()) {
+    auto& recorder = openhd::TelemetryRecorder::instance();
+    for (const auto& msg : messages) {
+      const mavlink_message_t& mav_msg = msg.m;
+      const auto* payload =
+          reinterpret_cast<const uint8_t*>(_MAV_PAYLOAD(&mav_msg));
+      recorder.record_fc_mavlink_message(mav_msg.sysid, mav_msg.compid,
+                                         mav_msg.msgid, mav_msg.seq, payload,
+                                         mav_msg.len);
+    }
+  }
   send_messages_ground_unit(messages);
   m_ohd_main_component->check_fc_messages_for_actions(messages);
 }


### PR DESCRIPTION
## Summary
- extend the telemetry recorder interface to accept flight controller MAVLink packets and emit typed JSON lines
- log MAVLink payload metadata alongside existing link statistics in the recorder output
- hook AirTelemetry FC message handling to forward incoming messages to the recorder

## Testing
- `cmake --build build --target OHDTelemetryLib`
- `/tmp/test_recorder`


------
https://chatgpt.com/codex/tasks/task_e_68e6d4670568832f8bab6d54b304fa34