### PR TITLE
Fix dynamic bitrate calculation for 10 MHz bandwidth

### DIFF
--- a/OpenHD/ohd_interface/inc/wb_link.h
+++ b/OpenHD/ohd_interface/inc/wb_link.h
@@ -227,6 +227,7 @@ class WBLink : public OHDLink {
   bool m_rate_adjustment_frequency_changed = false;
   // bitrate we recommend to the encoder / camera(s)
   int m_recommended_video_bitrate_kbits = 0;
+  std::atomic<int> m_last_announced_bitrate_kbits = -1;
   std::atomic<int> m_curr_n_rate_adjustments = 0;
   // Set to true when armed, disarmed by default
   // Used to differentiate between different tx power levels when armed /

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -1208,6 +1208,21 @@ void WBLink::recommend_bitrate_to_encoder(int recommended_video_bitrate_kbits) {
       m_console->debug("No action handler,cannot recommend bitrate to camera");
       return;
   }*/
+  if (recommended_video_bitrate_kbits <= 0) {
+    m_console->warn("Ignoring invalid bitrate recommendation: {} kBit/s",
+                    recommended_video_bitrate_kbits);
+    return;
+  }
+  const auto previous =
+      m_last_announced_bitrate_kbits.exchange(recommended_video_bitrate_kbits);
+  if (previous != recommended_video_bitrate_kbits) {
+    m_console->debug("Recommending encoder bitrate {} kBit/s (previous: {})",
+                     recommended_video_bitrate_kbits,
+                     previous < 0 ? 0 : previous);
+  } else {
+    m_console->trace("Recommending unchanged encoder bitrate {} kBit/s",
+                     recommended_video_bitrate_kbits);
+  }
   openhd::LinkActionHandler::LinkBitrateInformation lb{};
   lb.recommended_encoder_bitrate_kbits = recommended_video_bitrate_kbits;
   openhd::LinkActionHandler::instance().action_request_bitrate_change_handle(

--- a/OpenHD/ohd_interface/src/wb_link_helper.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_helper.cpp
@@ -377,8 +377,15 @@ int openhd::wb::calculate_bitrate_for_wifi_config_kbits(
   // taking mcs index, channel width, ... into account
   const auto wifi_space = openhd::get_space_from_frequency(frequency_mhz);
   const int max_rate_for_current_wifi_config_without_adjust =
-      get_max_rate_possible(card, wifi_space, mcs_index,
-                            channel_width_mhz == 40);
+      get_max_rate_possible(card, wifi_space, mcs_index, channel_width_mhz);
+  if (channel_width_mhz != 10 && channel_width_mhz != 20 &&
+      channel_width_mhz != 40) {
+    auto m_console = openhd::log::get_default();
+    m_console->warn(
+        "Unsupported channel width {}MHz for rate calculation, defaulting to {} "
+        "kBit/s",
+        channel_width_mhz, max_rate_for_current_wifi_config_without_adjust);
+  }
   const int max_rate_for_current_wifi_config = multiply_by_perc(
       max_rate_for_current_wifi_config_without_adjust, dev_adjustment_percent);
   if (debug_log) {

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -394,6 +394,9 @@ void GStreamerStream::handle_change_bitrate_request(
   //  We do some safety checks first - the link might recommend too much / too
   //  little
   auto bitrate_for_encoder_kbits = lb.recommended_encoder_bitrate_kbits;
+  m_console->debug(
+      "Received bitrate update request: {} kBit/s (current target: {} kBit/s)",
+      bitrate_for_encoder_kbits, m_curr_dynamic_bitrate_kbits.load());
   static auto MIN_BITRATE_KBITS = 1 * 1000;
   // RPi cannot do less than 2MBit/s
   if (OHDPlatform::instance().is_rpi()) {
@@ -402,6 +405,8 @@ void GStreamerStream::handle_change_bitrate_request(
   if (bitrate_for_encoder_kbits < MIN_BITRATE_KBITS) {
     // m_console->debug("Cam cannot do <{}",
     // kbits_per_second_to_string(MIN_BITRATE_KBITS));
+    m_console->debug("Clamping bitrate request from {} kBit/s to minimum {} kBit/s",
+                     bitrate_for_encoder_kbits, MIN_BITRATE_KBITS);
     bitrate_for_encoder_kbits = MIN_BITRATE_KBITS;
   }
   // The gst thread is responsible for changing the bitrate - it will be applied


### PR DESCRIPTION
## Summary
- use the configured channel width when calculating the maximum Wi-Fi bitrate and warn on unsupported widths
- add extra logging around bitrate recommendations and camera-side bitrate handling to aid debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eab1410c34832fbe8d28d0857b58e6