### PR TITLE
Adjust channel scan widths by chipset

### DIFF
--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -1364,10 +1364,15 @@ void WBLink::perform_channel_scan(
   //   m_console->warn("No channel_widths to scan, return early");
   //   return;
   // }
-  //  We only scan 40Mhz, this way we get both 20Mhz and 40Mhz air unit(s)
-
-  // add 10mhz scan
-  const std::vector<uint16_t> channel_widths_to_scan = {40, 10};
+  // We primarily scan at 40Mhz since this allows detecting both 20Mhz and
+  // 40Mhz air units. Only devices based on the rtl8812eu chipset can also make
+  // use of 10Mhz and 80Mhz operation during a scan - for all other chipsets we
+  // skip those channel widths to avoid unnecessary tuning attempts.
+  std::vector<uint16_t> channel_widths_to_scan{40};
+  if (card.is_rtl88x2eu()) {
+    channel_widths_to_scan.push_back(10);
+    channel_widths_to_scan.push_back(80);
+  }
 
   auto stats_current = openhd::LinkActionHandler::instance().get_link_stats();
   stats_current.gnd_operating_mode.operating_mode = 1;


### PR DESCRIPTION
## Summary
- limit channel scan widths to 40 MHz by default to avoid unsupported widths
- retain 10 MHz and 80 MHz scanning only for rtl8812eu devices where it is needed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ed4d318c9c832fa7bf3bd31f3a4b30