### PR TITLE
Improve channel scanning robustness and rtl88x2eu tuning

### DIFF
--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -1384,99 +1384,127 @@ void WBLink::perform_channel_scan(
     int channel_width = 0;
   };
   ScanResult result{false, 0, 0};
-  // Note: We intentionally do not modify the persistent settings here
-  m_console->debug(
-      "Channel scan N channels to scan:{} N channel widths to scan:{}",
-      channels_to_scan.size(), channel_widths_to_scan.size());
-  bool done_early = false;
-  // We need to loop through all possible channels
-  for (int i = 0; i < channels_to_scan.size(); i++) {
-    const auto& channel = channels_to_scan[i];
-    if (done_early) break;
-    // and all possible channel widths (20 or 40Mhz only right now)
-    for (const auto& channel_width : channel_widths_to_scan) {
-      // Return early in some cases (e.g. when we have a low loss and are quite
-      // certain about a frequency)
+  bool passive_mode_enabled = false;
+  auto handle_scan_exception = [&](const std::string& reason) {
+    m_console->error("Channel scan failed: {}", reason);
+    if (passive_mode_enabled) {
+      re_enable_injection_unless_user_passive_mode_enabled();
+      passive_mode_enabled = false;
+    }
+    m_console->warn("Channel scan failure, restore local settings");
+    apply_frequency_and_channel_width_from_settings();
+    openhd::LinkActionHandler::ScanChannelsProgress tmp{};
+    tmp.channel_mhz = 0;
+    tmp.channel_width_mhz = 0;
+    tmp.success = false;
+    tmp.progress = 100;
+    openhd::LinkActionHandler::instance().add_scan_channels_progress(tmp);
+  };
+  try {
+    // Note: We intentionally do not modify the persistent settings here
+    m_console->debug(
+        "Channel scan N channels to scan:{} N channel widths to scan:{}",
+        channels_to_scan.size(), channel_widths_to_scan.size());
+    bool done_early = false;
+    // We need to loop through all possible channels
+    for (int i = 0; i < channels_to_scan.size(); i++) {
+      const auto& channel = channels_to_scan[i];
       if (done_early) break;
-      // Skip channels / frequencies the card doesn't support anyways
-      if (!openhd::wb::any_card_support_frequency(
-              channel.frequency, m_broadcast_cards, m_console)) {
-        continue;
-      }
-      // set new frequency, reset the packet count, sleep, then check if any
-      // openhd packets have been received
-      const bool freq_success = apply_frequency_and_channel_width(
-          channel.frequency, channel_width, channel_width);
-      if (!freq_success) {
-        m_console->warn("Cannot scan [{}] {}Mhz@{}Mhz", channel.channel,
-                        channel.frequency, channel_width);
-        continue;
-      }
-      openhd::LinkActionHandler::ScanChannelsProgress tmp{};
-      tmp.channel_mhz = (int)channel.frequency;
-      tmp.channel_width_mhz = channel_width;
-      tmp.success = false;
-      tmp.progress =
-          OHDUtil::calculate_progress_perc(i, (int)channels_to_scan.size());
-      openhd::LinkActionHandler::instance().add_scan_channels_progress(tmp);
-      // Disable injection during scan
-      m_wb_txrx->set_passive_mode(true);
-      // sleeep a bit - some cards /drivers might need time switching
-      std::this_thread::sleep_for(std::chrono::milliseconds(200));
-      m_console->debug("Scanning [{}] {}Mhz@{}Mhz", channel.channel,
-                       channel.frequency, channel_width);
-      reset_all_rx_stats();
-      m_management_gnd->m_air_reported_curr_frequency = -1;
-      m_management_gnd->m_air_reported_curr_channel_width = -1;
-      std::this_thread::sleep_for(std::chrono::seconds(2));
-      const auto n_likely_openhd_packets =
-          m_wb_txrx->get_rx_stats().curr_n_likely_openhd_packets;
-      // If we got what looks to be openhd packets, sleep a bit more such that
-      // we can reliably get a management frame
-      if (n_likely_openhd_packets > 0) {
-        m_console->debug("Got {} likely openhd packets, sleep a bit more",
-                         n_likely_openhd_packets);
-        const auto begin_long_listen = std::chrono::steady_clock::now();
-        while (std::chrono::steady_clock::now() - begin_long_listen <
-               std::chrono::seconds(5)) {
-          const int air_center_frequency =
-              m_management_gnd->m_air_reported_curr_frequency;
-          const int air_tx_channel_width =
-              m_management_gnd->m_air_reported_curr_channel_width;
-          const bool has_received_management =
-              air_center_frequency > 0 && air_tx_channel_width > 0;
-          if (has_received_management) {
-            break;
+      // and all possible channel widths (20 or 40Mhz only right now)
+      for (const auto& channel_width : channel_widths_to_scan) {
+        // Return early in some cases (e.g. when we have a low loss and are quite
+        // certain about a frequency)
+        if (done_early) break;
+        // Skip channels / frequencies the card doesn't support anyways
+        if (!openhd::wb::any_card_support_frequency(
+                channel.frequency, m_broadcast_cards, m_console)) {
+          continue;
+        }
+        // set new frequency, reset the packet count, sleep, then check if any
+        // openhd packets have been received
+        const bool freq_success = apply_frequency_and_channel_width(
+            channel.frequency, channel_width, channel_width);
+        if (!freq_success) {
+          m_console->warn("Cannot scan [{}] {}Mhz@{}Mhz", channel.channel,
+                          channel.frequency, channel_width);
+          continue;
+        }
+        openhd::LinkActionHandler::ScanChannelsProgress tmp{};
+        tmp.channel_mhz = (int)channel.frequency;
+        tmp.channel_width_mhz = channel_width;
+        tmp.success = false;
+        tmp.progress =
+            OHDUtil::calculate_progress_perc(i, (int)channels_to_scan.size());
+        openhd::LinkActionHandler::instance().add_scan_channels_progress(tmp);
+        // Disable injection during scan
+        m_wb_txrx->set_passive_mode(true);
+        passive_mode_enabled = true;
+        // sleeep a bit - some cards /drivers might need time switching
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        m_console->debug("Scanning [{}] {}Mhz@{}Mhz", channel.channel,
+                         channel.frequency, channel_width);
+        reset_all_rx_stats();
+        m_management_gnd->m_air_reported_curr_frequency = -1;
+        m_management_gnd->m_air_reported_curr_channel_width = -1;
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        const auto n_likely_openhd_packets =
+            m_wb_txrx->get_rx_stats().curr_n_likely_openhd_packets;
+        // If we got what looks to be openhd packets, sleep a bit more such that
+        // we can reliably get a management frame
+        if (n_likely_openhd_packets > 0) {
+          m_console->debug("Got {} likely openhd packets, sleep a bit more",
+                           n_likely_openhd_packets);
+          const auto begin_long_listen = std::chrono::steady_clock::now();
+          while (std::chrono::steady_clock::now() - begin_long_listen <
+                 std::chrono::seconds(5)) {
+            const int air_center_frequency =
+                m_management_gnd->m_air_reported_curr_frequency;
+            const int air_tx_channel_width =
+                m_management_gnd->m_air_reported_curr_channel_width;
+            const bool has_received_management =
+                air_center_frequency > 0 && air_tx_channel_width > 0;
+            if (has_received_management) {
+              break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
           }
-          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        const auto packet_loss =
+            m_wb_txrx->get_rx_stats().curr_lowest_packet_loss;
+        const auto n_valid_packets = m_wb_txrx->get_rx_stats().count_p_valid;
+        const int air_center_frequency =
+            m_management_gnd->m_air_reported_curr_frequency;
+        const int air_tx_channel_width =
+            m_management_gnd->m_air_reported_curr_channel_width;
+        m_console->debug(
+            "Got {} packets on {}@{} air_reports:[{}@{}] with loss {}%",
+            n_valid_packets, channel.frequency, channel_width,
+            air_center_frequency, air_tx_channel_width, packet_loss);
+        if (n_valid_packets > 0 && air_center_frequency > 0 &&
+            (air_tx_channel_width == 10 || air_tx_channel_width == 20 ||
+             air_tx_channel_width == 40) &&
+            channel.frequency == air_center_frequency) {
+          m_console->debug("Found air unit");
+          result.frequency = channel.frequency;
+          result.channel_width = air_tx_channel_width;
+          result.success = true;
+          m_console->debug("Air unit detected: {} MHz @ {} MHz width",
+                           result.frequency, result.channel_width);
+          done_early = true;
         }
       }
-      const auto packet_loss =
-          m_wb_txrx->get_rx_stats().curr_lowest_packet_loss;
-      const auto n_valid_packets = m_wb_txrx->get_rx_stats().count_p_valid;
-      const int air_center_frequency =
-          m_management_gnd->m_air_reported_curr_frequency;
-      const int air_tx_channel_width =
-          m_management_gnd->m_air_reported_curr_channel_width;
-      m_console->debug(
-          "Got {} packets on {}@{} air_reports:[{}@{}] with loss {}%",
-          n_valid_packets, channel.frequency, channel_width,
-          air_center_frequency, air_tx_channel_width, packet_loss);
-      if (n_valid_packets > 0 && air_center_frequency > 0 &&
-          (air_tx_channel_width == 10 || air_tx_channel_width == 20 ||
-           air_tx_channel_width == 40) &&
-          channel.frequency == air_center_frequency) {
-        m_console->debug("Found air unit");
-        result.frequency = channel.frequency;
-        result.channel_width = air_tx_channel_width;
-        result.success = true;
-        m_console->debug("Air unit detected: {} MHz @ {} MHz width",
-                         result.frequency, result.channel_width);
-        done_early = true;
-      }
     }
+    if (passive_mode_enabled) {
+      re_enable_injection_unless_user_passive_mode_enabled();
+      passive_mode_enabled = false;
+    }
+  } catch (const std::exception& e) {
+    handle_scan_exception(e.what());
+    return;
+  } catch (...) {
+    handle_scan_exception("unknown exception");
+    return;
   }
-  re_enable_injection_unless_user_passive_mode_enabled();
   if (!result.success) {
     m_console->warn("Channel scan failure, restore local settings");
     apply_frequency_and_channel_width_from_settings();

--- a/OpenHD/ohd_interface/src/wb_link_helper.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_helper.cpp
@@ -96,8 +96,12 @@ bool openhd::wb::set_frequency_and_channel_width_for_all_cards(
         card.type == WiFiCardType::OPENHD_RTL_88X2CU ||
         card.type == WiFiCardType::OPENHD_RTL_88X2EU ||
         card.type == WiFiCardType::OPENHD_RTL_8852BU) {
-      wifi::commandhelper::openhd_driver_set_frequency_and_channel_width(
-          card.type, card.device_name, frequency, channel_width);
+      const bool success =
+          wifi::commandhelper::openhd_driver_set_frequency_and_channel_width(
+              card.type, card.device_name, frequency, channel_width);
+      if (!success) {
+        ret = false;
+      }
     } else {
       // Handle other card types with a different function
       const bool success =

--- a/OpenHD/ohd_interface/src/wifi_command_helper.cpp
+++ b/OpenHD/ohd_interface/src/wifi_command_helper.cpp
@@ -60,13 +60,13 @@
  }
  
  // use_ht40_plus: Only in 40Mhz mode
- static std::string channel_width_as_iw_string(uint32_t channel_width,
-                                               bool use_ht40_plus = true) {
-   if (channel_width == 5) {
-     return "5MHz";
-   } else if (channel_width == 10) {
-     return "10Mhz";
-   } else if (channel_width == 20) {
+static std::string channel_width_as_iw_string(uint32_t channel_width,
+                                              bool use_ht40_plus = true) {
+  if (channel_width == 5) {
+    return "5MHz";
+  } else if (channel_width == 10) {
+    return "10Mhz";
+  } else if (channel_width == 20) {
      return "HT20";
    } else if (channel_width == 40) {
      return use_ht40_plus ? "HT40+" : "HT40-";
@@ -104,9 +104,42 @@
    // Generic logic for other devices
    const std::string iw_channel_width =
        channel_width_as_iw_string(channel_width);
-   return iw_set_frequency_and_channel_width2(device, freq_mhz,
+  return iw_set_frequency_and_channel_width2(device, freq_mhz,
                                               iw_channel_width);
- }
+}
+
+static bool try_set_rtl88x2eu_monitor_override(const std::string &device,
+                                               uint32_t freq_mhz,
+                                               uint32_t channel_width) {
+  const std::string monitor_override_path =
+      fmt::format("/proc/net/rtl88x2eu_ohd/{}/monitor_chan_override", device);
+  if (!OHDFilesystemUtil::exists(monitor_override_path)) {
+    openhd::log::get_default()->debug(
+        "rtl88x2eu monitor override file [{}] missing", monitor_override_path);
+    return false;
+  }
+
+  if (!(channel_width == 10 || channel_width == 20 || channel_width == 40 ||
+        channel_width == 80)) {
+    openhd::log::get_default()->warn(
+        "rtl88x2eu monitor override unsupported bandwidth {}", channel_width);
+    return false;
+  }
+
+  const auto channel_opt = openhd::channel_from_frequency(freq_mhz);
+  if (!channel_opt.has_value()) {
+    openhd::log::get_default()->warn(
+        "rtl88x2eu monitor override cannot map frequency {}", freq_mhz);
+    return false;
+  }
+  const auto channel_value = channel_opt->channel;
+  const std::string content =
+      fmt::format("{} {}\n", channel_value, channel_width);
+  openhd::log::get_default()->debug(
+      "rtl88x2eu monitor override {} -> {}", monitor_override_path, content);
+  OHDFilesystemUtil::write_file(monitor_override_path, content);
+  return true;
+}
  
  bool wifi::commandhelper::iw_set_frequency_and_channel_width2(
      const std::string &device, uint32_t freq_mhz, const std::string &ht_mode,
@@ -317,100 +350,116 @@
  static char *OPENHD_DRIVER_RTL88xxEU_TX_POWER_MW_OVERRIDE =
      "/sys/module/88x2eu_ohd/parameters/openhd_override_tx_power_mbm";
  
- bool wifi::commandhelper::openhd_driver_set_frequency_and_channel_width(
-     WiFiCardType type, const std::string &device, uint32_t freq_mhz,
-     uint32_t channel_width) {
-   const auto channel_opt = openhd::channel_from_frequency(freq_mhz);
-   if (!channel_opt.has_value()) {
-     openhd::log::get_default()->warn("Cannot find channel {}Mhz", freq_mhz);
-   }
-   const auto channel =
-       channel_opt.value_or(openhd::channel_from_frequency(5100).value());
-   const std::string rtl8812au_channel = fmt::format("{}", channel.channel);
-   openhd::log::get_default()->debug(
-       "openhd_driver_set_frequency_and_channel_width wanted:{}@{}Mhz, using "
-       "channel override:{}",
-       freq_mhz, channel_width, rtl8812au_channel);
-   char *CHANNEL_OVERRIDE_FILENAME;
-   switch (type) {
-     case (WiFiCardType::OPENHD_RTL_88X2AU):
-       CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL8812AU_CHANNEL_OVERRIDE;
-       break;
-     case (WiFiCardType::OPENHD_RTL_88X2BU):
-       CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL88xxBU_CHANNEL_OVERRIDE;
-       break;
-     case (WiFiCardType::OPENHD_RTL_88X2CU):
-       CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL88xxCU_CHANNEL_OVERRIDE;
-       break;
-     case (WiFiCardType::OPENHD_RTL_88X2EU):
-       CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL88xxEU_CHANNEL_OVERRIDE;
-       break;
-     default:
-       openhd::log::get_default()->error(
-           "INVALID DRIVER TYPE; CHANNEL WON'T WORK");
-       break;
-   }
- 
-   if (!OHDFilesystemUtil::exists(CHANNEL_OVERRIDE_FILENAME)) {
-     openhd::log::get_default()->error(
-         "YOU ARE USING THE WRONG DRIVER; CHANNEL WON'T WORK");
-     // hope this works
-     wifi::commandhelper::iw_set_frequency_and_channel_width(device, freq_mhz,
-                                                             channel_width);
-     return true;
-   }
-   // /etc/modprobe.d
-   // options 88XXau_ohd openhd_override_channel=165
-   // openhd_override_channel_width=1 rmmod 88XXau_ohd
-   OHDFilesystemUtil::write_file(CHANNEL_OVERRIDE_FILENAME, rtl8812au_channel);
-   // Override stuff is set, now we just change to a channel that is always okay
-   // in crda such that the method is called - ! the actually applied channel
-   // will be the overridden one !
-   const bool use_40mhz = channel_width == 40;
-   const bool use_ht40_plus = channel.in_40Mhz_ht40_plus;  // only in 40Mhz mode
-   int dummy_frequency = -1;
-   if (channel.space == openhd::WifiSpace::G2_4) {
-     dummy_frequency = use_40mhz ? (use_ht40_plus ? 2412 : 2432) : 2412;
-   } else {
-     dummy_frequency = use_40mhz ? (use_ht40_plus ? 5180 : 5200) : 5180;
-   }
-   if (channel_width == 10 && type == WiFiCardType::OPENHD_RTL_88X2EU) {
-     // Special handling for 10MHz on RTL88X2EU
-     openhd::log::get_default()->info(
-         "Using special 10MHz iw set command for 88x2eu: wlan={} chan={} "
-         "width=10MHZ",
-         device, channel.channel);
-     const std::string cmd =
-         fmt::format("iw {} set channel {} 10MHZ", device, channel.channel);
-     int ret = std::system(cmd.c_str());
-     if (ret != 0) {
-       openhd::log::get_default()->error("Failed to run: {}", cmd);
-     }
-   } else if (channel_width == 40 && type == WiFiCardType::OPENHD_RTL_88X2EU) {
-     // Special handling for 40MHz on RTL88X2EU
-     openhd::log::get_default()->info(
-         "Using special 40MHz iw set command for 88x2eu: wlan={} chan={} "
-         "width=40MHZ",
-         device, channel.channel);
-     const std::string cmd =
-         fmt::format("iw {} set channel {} 80MHZ", device, channel.channel);
-     int ret = std::system(cmd.c_str());
-     if (ret != 0) {
-       openhd::log::get_default()->error("Failed to run: {}", cmd);
-     }
-   } else {
-     // Standard bandwidth logic
-     const std::string bw_mode =
-         channel_width == 20 ? "HT20" : (use_ht40_plus ? "HT40+" : "HT40-");
-     wifi::commandhelper::iw_set_frequency_and_channel_width2(
-         device, dummy_frequency, bw_mode, true);
-     openhd::log::get_default()->info(
-          "Using normal 40MHz iw set command for: wlan={} chan={} "
-          "width=40MHZ",
-          device, channel.channel);
-   }
-   return true;
- }
+bool wifi::commandhelper::openhd_driver_set_frequency_and_channel_width(
+    WiFiCardType type, const std::string &device, uint32_t freq_mhz,
+    uint32_t channel_width) {
+  const auto channel_opt = openhd::channel_from_frequency(freq_mhz);
+  if (!channel_opt.has_value()) {
+    openhd::log::get_default()->warn("Cannot find channel {}Mhz", freq_mhz);
+  }
+  const auto channel =
+      channel_opt.value_or(openhd::channel_from_frequency(5100).value());
+  const std::string rtl8812au_channel = fmt::format("{}", channel.channel);
+  openhd::log::get_default()->debug(
+      "openhd_driver_set_frequency_and_channel_width wanted:{}@{}Mhz, using "
+      "channel override:{}",
+      freq_mhz, channel_width, rtl8812au_channel);
+
+  if (type == WiFiCardType::OPENHD_RTL_88X2EU) {
+    const bool monitor_success =
+        try_set_rtl88x2eu_monitor_override(device, freq_mhz, channel_width);
+    if (!monitor_success) {
+      openhd::log::get_default()->warn(
+          "rtl88x2eu monitor override failed for {}@{}Mhz", freq_mhz,
+          channel_width);
+    }
+  }
+
+  char *CHANNEL_OVERRIDE_FILENAME = nullptr;
+  switch (type) {
+    case (WiFiCardType::OPENHD_RTL_88X2AU):
+      CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL8812AU_CHANNEL_OVERRIDE;
+      break;
+    case (WiFiCardType::OPENHD_RTL_88X2BU):
+      CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL88xxBU_CHANNEL_OVERRIDE;
+      break;
+    case (WiFiCardType::OPENHD_RTL_88X2CU):
+      CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL88xxCU_CHANNEL_OVERRIDE;
+      break;
+    case (WiFiCardType::OPENHD_RTL_88X2EU):
+      CHANNEL_OVERRIDE_FILENAME = OPENHD_DRIVER_RTL88xxEU_CHANNEL_OVERRIDE;
+      break;
+    default:
+      openhd::log::get_default()->error(
+          "INVALID DRIVER TYPE; CHANNEL WON'T WORK");
+      return false;
+  }
+
+  bool success = true;
+  if (!OHDFilesystemUtil::exists(CHANNEL_OVERRIDE_FILENAME)) {
+    openhd::log::get_default()->error(
+        "YOU ARE USING THE WRONG DRIVER; CHANNEL WON'T WORK");
+    const bool fallback = wifi::commandhelper::iw_set_frequency_and_channel_width(
+        device, freq_mhz, channel_width);
+    return fallback;
+  }
+  // /etc/modprobe.d
+  // options 88XXau_ohd openhd_override_channel=165
+  // openhd_override_channel_width=1 rmmod 88XXau_ohd
+  OHDFilesystemUtil::write_file(CHANNEL_OVERRIDE_FILENAME, rtl8812au_channel);
+  // Override stuff is set, now we just change to a channel that is always okay
+  // in crda such that the method is called - ! the actually applied channel
+  // will be the overridden one !
+  const bool use_40mhz = channel_width == 40;
+  const bool use_ht40_plus = channel.in_40Mhz_ht40_plus;  // only in 40Mhz mode
+  int dummy_frequency = -1;
+  if (channel.space == openhd::WifiSpace::G2_4) {
+    dummy_frequency = use_40mhz ? (use_ht40_plus ? 2412 : 2432) : 2412;
+  } else {
+    dummy_frequency = use_40mhz ? (use_ht40_plus ? 5180 : 5200) : 5180;
+  }
+  if (channel_width == 10 && type == WiFiCardType::OPENHD_RTL_88X2EU) {
+    // Special handling for 10MHz on RTL88X2EU
+    openhd::log::get_default()->info(
+        "Using special 10MHz iw set command for 88x2eu: wlan={} chan={} "
+        "width=10MHZ",
+        device, channel.channel);
+    const std::string cmd =
+        fmt::format("iw {} set channel {} 10MHZ", device, channel.channel);
+    int ret = std::system(cmd.c_str());
+    if (ret != 0) {
+      openhd::log::get_default()->error("Failed to run: {}", cmd);
+      success = false;
+    }
+  } else if (channel_width == 40 && type == WiFiCardType::OPENHD_RTL_88X2EU) {
+    // Special handling for 40MHz on RTL88X2EU
+    openhd::log::get_default()->info(
+        "Using special 40MHz iw set command for 88x2eu: wlan={} chan={} "
+        "width=40MHZ",
+        device, channel.channel);
+    const std::string cmd =
+        fmt::format("iw {} set channel {} 80MHZ", device, channel.channel);
+    int ret = std::system(cmd.c_str());
+    if (ret != 0) {
+      openhd::log::get_default()->error("Failed to run: {}", cmd);
+      success = false;
+    }
+  } else {
+    // Standard bandwidth logic
+    const std::string bw_mode =
+        channel_width == 20 ? "HT20" : (use_ht40_plus ? "HT40+" : "HT40-");
+    const bool iw_success = wifi::commandhelper::iw_set_frequency_and_channel_width2(
+        device, dummy_frequency, bw_mode, true);
+    if (!iw_success) {
+      success = false;
+    }
+    openhd::log::get_default()->info(
+        "Using normal 40MHz iw set command for: wlan={} chan={} "
+        "width=40MHZ",
+        device, channel.channel);
+  }
+  return success;
+}
  
  bool wifi::commandhelper::openhd_driver_set_tx_power(WiFiCardType type,
                                                       const std::string &device,


### PR DESCRIPTION
## Summary
- guard channel scanning against runtime failures so injection is restored, settings are reapplied, and progress is reported even on error
- add a rtl88x2eu monitor override helper and integrate it into driver frequency setting while propagating success back to callers
- bubble up driver frequency-setting failures to the caller so scan workflows can continue safely

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed591354b0832fa417b86df6a5c3db