### PR TITLE
Add missing spdlog includes

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_tcp.h
+++ b/OpenHD/ohd_common/inc/openhd_tcp.h
@@ -26,6 +26,7 @@
 
 #include <deque>
 #include <thread>
+#include <string>
 
 #include "openhd_spdlog.h"
 

--- a/OpenHD/ohd_common/src/openhd_action_handler.cpp
+++ b/OpenHD/ohd_common/src/openhd_action_handler.cpp
@@ -25,6 +25,8 @@
 
 #include "openhd_util_time.h"
 
+#include <spdlog/spdlog.h>
+
 #include <cassert>
 
 openhd::ArmingStateHelper &openhd::ArmingStateHelper::instance() {

--- a/OpenHD/ohd_common/src/openhd_action_handler.cpp
+++ b/OpenHD/ohd_common/src/openhd_action_handler.cpp
@@ -25,6 +25,8 @@
 
 #include "openhd_util_time.h"
 
+#include <cassert>
+
 openhd::ArmingStateHelper &openhd::ArmingStateHelper::instance() {
   static openhd::ArmingStateHelper instance;
   return instance;

--- a/OpenHD/ohd_common/src/openhd_bitrate.cpp
+++ b/OpenHD/ohd_common/src/openhd_bitrate.cpp
@@ -23,6 +23,8 @@
 
 #include "openhd_bitrate.h"
 
+#include <cassert>
+
 openhd::BitrateDebugger::BitrateDebugger(std::string tag, bool debug_pps)
     : m_debug_pps(debug_pps) {
   m_console = openhd::log::create_or_get(tag);

--- a/OpenHD/ohd_common/src/openhd_bitrate.cpp
+++ b/OpenHD/ohd_common/src/openhd_bitrate.cpp
@@ -23,6 +23,8 @@
 
 #include "openhd_bitrate.h"
 
+#include <spdlog/spdlog.h>
+
 #include <cassert>
 
 openhd::BitrateDebugger::BitrateDebugger(std::string tag, bool debug_pps)

--- a/OpenHD/ohd_common/src/openhd_buttons.cpp
+++ b/OpenHD/ohd_common/src/openhd_buttons.cpp
@@ -25,6 +25,8 @@
 
 #include <thread>
 
+#include <spdlog/spdlog.h>
+
 #include "openhd_platform.h"
 #include "openhd_spdlog.h"
 #include "openhd_util.h"

--- a/OpenHD/ohd_common/src/openhd_external_device.cpp
+++ b/OpenHD/ohd_common/src/openhd_external_device.cpp
@@ -28,6 +28,8 @@
 #include "openhd_spdlog.h"
 #include "openhd_util.h"
 
+#include <spdlog/spdlog.h>
+
 #include <cassert>
 
 openhd::ExternalDeviceManager::ExternalDeviceManager() {

--- a/OpenHD/ohd_common/src/openhd_external_device.cpp
+++ b/OpenHD/ohd_common/src/openhd_external_device.cpp
@@ -28,6 +28,8 @@
 #include "openhd_spdlog.h"
 #include "openhd_util.h"
 
+#include <cassert>
+
 openhd::ExternalDeviceManager::ExternalDeviceManager() {
   // Here one can manually declare any IP addresses openhd should forward video
   // / telemetry to

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -28,6 +28,8 @@
 #include <regex>
 #include <set>
 
+#include <spdlog/spdlog.h>
+
 #include "openhd_spdlog.h"
 #include "openhd_util.h"
 #include "openhd_util_filesystem.h"

--- a/OpenHD/ohd_common/src/openhd_settings_imp.cpp
+++ b/OpenHD/ohd_common/src/openhd_settings_imp.cpp
@@ -28,6 +28,8 @@
 #include <map>
 #include <sstream>
 
+#include <spdlog/spdlog.h>
+
 #include "openhd_spdlog.h"
 
 std::vector<openhd::Setting> openhd::testing::create_dummy_camera_settings() {

--- a/OpenHD/ohd_common/src/openhd_tcp.cpp
+++ b/OpenHD/ohd_common/src/openhd_tcp.cpp
@@ -24,8 +24,10 @@
 #include "openhd_tcp.h"
 
 #include <arpa/inet.h>
+#include <errno.h>
 #include <unistd.h>
 
+#include <cassert>
 #include <csignal>
 #include <queue>
 #include <utility>

--- a/OpenHD/ohd_common/src/openhd_tcp.cpp
+++ b/OpenHD/ohd_common/src/openhd_tcp.cpp
@@ -25,6 +25,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <spdlog/spdlog.h>
 #include <unistd.h>
 
 #include <cassert>

--- a/OpenHD/ohd_common/src/openhd_udp.cpp
+++ b/OpenHD/ohd_common/src/openhd_udp.cpp
@@ -24,6 +24,7 @@
 #include "openhd_udp.h"
 
 #include <arpa/inet.h>
+#include <spdlog/spdlog.h>
 #include <unistd.h>
 
 #include <algorithm>

--- a/OpenHD/ohd_common/src/openhd_util.cpp
+++ b/OpenHD/ohd_common/src/openhd_util.cpp
@@ -24,6 +24,7 @@
 #include "openhd_util.h"
 
 #include <arpa/inet.h>
+#include <spdlog/spdlog.h>
 #include <unistd.h>
 
 #include <cctype>

--- a/OpenHD/ohd_common/src/openhd_util.cpp
+++ b/OpenHD/ohd_common/src/openhd_util.cpp
@@ -28,6 +28,7 @@
 
 #include <cctype>
 #include <chrono>
+#include <cmath>
 #include <csignal>
 #include <cstdlib>
 #include <optional>

--- a/OpenHD/ohd_common/src/openhd_util_async.cpp
+++ b/OpenHD/ohd_common/src/openhd_util_async.cpp
@@ -29,6 +29,8 @@
 #include "openhd_spdlog.h"
 #include "openhd_util.h"
 
+#include <spdlog/spdlog.h>
+
 openhd::AsyncHandle::AsyncHandle() {
   m_watchdog_run = true;
   m_watchdog_thread =

--- a/OpenHD/ohd_common/src/openhd_util_async.cpp
+++ b/OpenHD/ohd_common/src/openhd_util_async.cpp
@@ -23,6 +23,7 @@
 
 #include "openhd_util_async.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "openhd_spdlog.h"

--- a/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
+++ b/OpenHD/ohd_common/src/openhd_util_filesystem.cpp
@@ -25,6 +25,7 @@
 
 #include <openhd_spdlog.h>
 #include <openhd_util.h>
+#include <spdlog/spdlog.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/OpenHD/ohd_common/src/openhd_util_time.cpp
+++ b/OpenHD/ohd_common/src/openhd_util_time.cpp
@@ -23,6 +23,7 @@
 
 #include "openhd_util_time.h"
 
+#include <mutex>
 #include <sstream>
 
 std::string openhd::util::verbose_timespan(


### PR DESCRIPTION
After #1242 (Same as https://github.com/OpenHD/OpenHD/pull/1220 which was closed for no reason.)

When packaging this with Nix, I want to avoid compiling nlohmann_json and spdlog by avoiding to use the submodules pinned in this repository. Nix provides pre-compiled, cached libraries.

To achieve this, I had to patch the ohd_common/CMakeLists.txt:
```patch
--- a/ohd_common/CMakeLists.txt
+++ b/ohd_common/CMakeLists.txt
@@ -28,23 +28,9 @@ endif()
 #----------------------------------------------------------------------------------------------------------------------
 # Dependencies: spdlog and nlohmann::json
 #----------------------------------------------------------------------------------------------------------------------
-set(SPDLOG_MASTER_PROJECT OFF)
-set(SPDLOG_PROJECT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib/spdlog)
-set(SPDLOG_SOURCES_DIRECTORY ${SPDLOG_PROJECT_DIRECTORY}/src)
-
-set(spdlog_sources
-    "${SPDLOG_SOURCES_DIRECTORY}/bundled_fmtlib_format.cpp"
-)
-
-target_precompile_headers(OHDCommonLib PRIVATE ${SPDLOG_PROJECT_DIRECTORY}/include/spdlog/spdlog.h)
-target_include_directories(OHDCommonLib PUBLIC ${SPDLOG_PROJECT_DIRECTORY}/include)
-
-# Add nlohmann::json
-add_subdirectory(lib/json)
-target_link_libraries(OHDCommonLib PUBLIC nlohmann_json::nlohmann_json)
-
-# Add pthread support
-find_package(Threads REQUIRED)
+find_package(spdlog CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
+target_link_libraries(OHDCommonLib PUBLIC spdlog::spdlog nlohmann_json::nlohmann_json)
 target_link_libraries(OHDCommonLib PUBLIC Threads::Threads)

```

This then caused errors of the following to arise:
```
/nix/store/13dxcy8kwcvvg765hj01kf29j3l0qmr3-spdlog-1.15.2-dev/include/spdlog/fwd.h:7:7: note: forward declaration of 'using std::__shared_ptr_access<spdlog::logger, __gnu_cxx::_S_atomic, false, false>::element_type = class spdlog::logger'>
    7 | class logger;
      |       ^~~~~~
/build/source/OpenHD/ohd_common/src/openhd_util_filesystem.cpp:180:31: error: invalid use of incomplete type 'using std::__shared_ptr_access<spdlog::logger, __gnu_cxx::_S_atomic, false, false>::element_type = class spdlog::logger' {aka 'c>
  180 |     openhd::log::get_default()->warn("Cannot change file {} rw anybody, ret:{}",

```

In order to fix this I had to explicitly include spdlog.