### PR TITLE
Expose RF link quality metrics via MAVLink telemetry

### DIFF
--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -1075,6 +1075,12 @@ void WBLink::wt_update_statistics() {
     card_stats.rx_noise_adapter = rf_rx_stats.adapter.noise_dbm;
     card_stats.rx_rssi_1 = rf_rx_stats.antenna1.rssi_dbm;
     card_stats.rx_rssi_2 = rf_rx_stats.antenna2.rssi_dbm;
+    card_stats.rx_noise_antenna1 = rf_rx_stats.antenna1.noise_dbm;
+    card_stats.rx_noise_antenna2 = rf_rx_stats.antenna2.noise_dbm;
+    card_stats.rx_signal_quality_antenna1 =
+        rf_rx_stats.antenna1.card_signal_quality_perc;
+    card_stats.rx_signal_quality_antenna2 =
+        rf_rx_stats.antenna2.card_signal_quality_perc;
     card_stats.count_p_received = rxStatsCard.count_p_valid;
     card_stats.count_p_injected = 0;
     card_stats.curr_rx_packet_loss_perc = rxStatsCard.curr_packet_loss;

--- a/OpenHD/ohd_telemetry/src/internal/OHDLinkStatisticsHelper.h
+++ b/OpenHD/ohd_telemetry/src/internal/OHDLinkStatisticsHelper.h
@@ -51,7 +51,11 @@ static MavlinkMessage pack_card(
   tmp.tx_power_disarmed = card_stats.tx_power_disarmed;
   tmp.curr_status = card_stats.curr_status;
   tmp.rx_signal_quality_adapter = card_stats.rx_signal_quality_adapter;
+  tmp.rx_signal_quality_antenna1 = card_stats.rx_signal_quality_antenna1;
+  tmp.rx_signal_quality_antenna2 = card_stats.rx_signal_quality_antenna2;
   tmp.rx_noise_adapter = card_stats.rx_noise_adapter;
+  tmp.rx_noise_antenna1 = card_stats.rx_noise_antenna1;
+  tmp.rx_noise_antenna2 = card_stats.rx_noise_antenna2;
   tmp.tx_active = card_stats.tx_active;
   // openhd::log::get_default()->debug("XX {}",card_stats.to_string(0));
   mavlink_msg_openhd_stats_monitor_mode_wifi_card_encode(


### PR DESCRIPTION
## Summary
- propagate per-antenna RSSI noise and signal quality readings into link statistics
- include the new link quality metrics when packing OpenHD Wi-Fi card MAVLink telemetry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69093259e8ec832fb3527e311f194d64