### PR TITLE
Add workflow to cross-compile OpenHD with Orqa SDK

### DIFF
--- a/.github/workflows/crosscompile-orqa.yml
+++ b/.github/workflows/crosscompile-orqa.yml
@@ -1,0 +1,82 @@
+name: Cross-compile OpenHD with Orqa SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdk-installer-url:
+        description: URL to download the Orqa SDK installer script. Leave empty to use a repository-provided script.
+        required: false
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      SDK_INSTALL_DIR: ${{ runner.temp }}/orqa-sdk
+      SDK_INSTALLER_URL: ${{ github.event.inputs.sdk-installer-url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ninja-build \
+            pkg-config \
+            autoconf \
+            automake \
+            libtool \
+            curl \
+            xz-utils
+
+      - name: Retrieve Orqa SDK installer
+        run: |
+          set -euo pipefail
+          installer_path="${GITHUB_WORKSPACE}/OpenHD/SDK-DTK_GCB_working_usb_and_88x2eu.sh"
+          url="${SDK_INSTALLER_URL:-}"
+          if [[ -n "$url" ]]; then
+            echo "Downloading SDK installer from $url"
+            curl --fail --location --retry 5 --output "$installer_path" "$url"
+          fi
+          if [[ ! -f "$installer_path" ]]; then
+            echo "SDK installer was not found at $installer_path" >&2
+            echo "Provide the script in the repository or set the sdk-installer-url workflow input." >&2
+            exit 1
+          fi
+
+      - name: Install Orqa SDK
+        run: |
+          set -euo pipefail
+          mkdir -p "$SDK_INSTALL_DIR"
+          sh OpenHD/SDK-DTK_GCB_working_usb_and_88x2eu.sh -y -d "$SDK_INSTALL_DIR"
+
+      - name: Bootstrap SDK dependencies
+        run: |
+          set -euo pipefail
+          OpenHD/scripts/setup_orqa_sdk.sh "$SDK_INSTALL_DIR"
+
+      - name: Configure OpenHD (Release)
+        run: |
+          set -euo pipefail
+          source "$SDK_INSTALL_DIR/environment-setup-armv8a-poky-linux"
+          cmake -S OpenHD -B build-sdk -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build OpenHD
+        run: |
+          set -euo pipefail
+          source "$SDK_INSTALL_DIR/environment-setup-armv8a-poky-linux"
+          cmake --build build-sdk --parallel
+
+      - name: Package cross-compiled binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: openhd-aarch64
+          path: build-sdk/openhd

--- a/OpenHD/scripts/setup_orqa_sdk.sh
+++ b/OpenHD/scripts/setup_orqa_sdk.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <sdk-root>" >&2
+  exit 1
+fi
+
+sdk_root="$1"
+shift || true
+
+if [[ ! -d "$sdk_root" ]]; then
+  echo "SDK root '$sdk_root' does not exist" >&2
+  exit 1
+fi
+
+setup_script="$sdk_root/environment-setup-armv8a-poky-linux"
+if [[ ! -f "$setup_script" ]]; then
+  echo "Unable to find Yocto environment setup script at '$setup_script'" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$setup_script"
+
+work_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+jobs="$(nproc)"
+
+download() {
+  local url="$1"
+  local destination="$2"
+  curl --fail --location --retry 5 --output "$destination" "$url"
+}
+
+build_libsodium() {
+  local version="1.0.19"
+  local tarball="libsodium-${version}.tar.gz"
+  local url="https://download.libsodium.org/libsodium/releases/${tarball}"
+  local archive="$work_dir/$tarball"
+
+  download "$url" "$archive"
+  tar -xf "$archive" -C "$work_dir"
+  local src_dir
+  if [[ -d "$work_dir/libsodium-${version}" ]]; then
+    src_dir="$work_dir/libsodium-${version}"
+  else
+    src_dir="$work_dir/libsodium-stable"
+  fi
+  pushd "$src_dir" >/dev/null
+  ./configure --host="${OECORE_TARGET_ARCH}-poky-linux" --prefix="$SDKTARGETSYSROOT/usr"
+  make -j"$jobs"
+  make install
+  popd >/dev/null
+}
+
+build_poco() {
+  local version="1.12.4-release"
+  local tarball="poco-${version}.tar.gz"
+  local url="https://github.com/pocoproject/poco/archive/refs/tags/${tarball}"
+  local archive="$work_dir/$tarball"
+
+  download "$url" "$archive"
+  tar -xf "$archive" -C "$work_dir"
+  local src_dir
+  src_dir="$(find "$work_dir" -maxdepth 1 -type d -name 'poco-*' -print | head -n 1)"
+  if [[ -z "$src_dir" ]]; then
+    echo "Failed to locate extracted Poco sources" >&2
+    exit 1
+  fi
+  pushd "$src_dir" >/dev/null
+  cmake -B build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$SDKTARGETSYSROOT/usr" \
+    -DENABLE_APACHECONNECTOR=OFF \
+    -DENABLE_DATA=OFF \
+    -DENABLE_DATA_SQLITE=OFF \
+    -DENABLE_DATA_MYSQL=OFF \
+    -DENABLE_DATA_ODBC=OFF \
+    -DENABLE_DATA_POSTGRESQL=OFF \
+    -DENABLE_JSON=OFF \
+    -DENABLE_JWT=OFF \
+    -DENABLE_MONGODB=OFF \
+    -DENABLE_NETSSL=OFF \
+    -DENABLE_PDF=OFF \
+    -DENABLE_PROMETHEUS=OFF \
+    -DENABLE_REDIS=OFF \
+    -DENABLE_SEVENZIP=OFF \
+    -DENABLE_TESTS=OFF \
+    -DENABLE_ZIP=OFF \
+    -DENABLE_ENCODINGS=OFF \
+    -DENABLE_ACTIVERECORD=OFF \
+    -DENABLE_ACTIVERECORD_COMPILER=OFF
+  cmake --build build -j"$jobs"
+  cmake --install build
+  popd >/dev/null
+}
+
+build_libsodium
+build_poco


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that prepares the Orqa SDK via its installer and cross-compiles OpenHD
- add a helper script to build the missing libsodium and Poco dependencies inside the SDK sysroot

## Testing
- bash -n OpenHD/scripts/setup_orqa_sdk.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691275bff850832f915dca52423ecd8f)