### PR TITLE
Upload Poco archive artifact in ORQA workflow

### DIFF
--- a/.github/workflows/crosscompile-orqa.yml
+++ b/.github/workflows/crosscompile-orqa.yml
@@ -32,7 +32,8 @@ jobs:
             automake \
             libtool \
             curl \
-            xz-utils
+            xz-utils \
+            zip
 
       - name: Retrieve Orqa SDK installer
         run: |
@@ -51,9 +52,10 @@ jobs:
       - name: Bootstrap SDK dependencies
         env:
           SDK_INSTALL_DIR: ${{ runner.temp }}/orqa-sdk
+          POCO_ARCHIVE: ${{ runner.temp }}/poco-libraries.zip
         run: |
           set -euo pipefail
-          OpenHD/scripts/setup_orqa_sdk.sh "$SDK_INSTALL_DIR"
+          OpenHD/scripts/setup_orqa_sdk.sh "$SDK_INSTALL_DIR" "$POCO_ARCHIVE"
 
       - name: Configure OpenHD (Release)
         env:
@@ -76,3 +78,9 @@ jobs:
         with:
           name: openhd-aarch64
           path: build-sdk/openhd
+
+      - name: Upload Poco libraries archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: poco-libraries
+          path: ${{ runner.temp }}/poco-libraries.zip

--- a/OpenHD/scripts/setup_orqa_sdk.sh
+++ b/OpenHD/scripts/setup_orqa_sdk.sh
@@ -2,12 +2,32 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <sdk-root>" >&2
+  echo "Usage: $0 <sdk-root> [poco-archive]" >&2
   exit 1
 fi
 
 sdk_root="$1"
 shift || true
+
+make_absolute_path() {
+  local path="$1"
+  if [[ "$path" == /* ]]; then
+    printf '%s\n' "$path"
+  else
+    printf '%s/%s\n' "$(pwd)" "$path"
+  fi
+}
+
+sdk_root="$(make_absolute_path "$sdk_root")"
+
+output_archive="${1:-}"
+if [[ -n "$output_archive" ]]; then
+  shift || true
+else
+  output_archive="$sdk_root/poco-libraries.zip"
+fi
+
+output_archive="$(make_absolute_path "$output_archive")"
 
 if [[ ! -d "$sdk_root" ]]; then
   echo "SDK root '$sdk_root' does not exist" >&2
@@ -35,6 +55,46 @@ download() {
   local url="$1"
   local destination="$2"
   curl --fail --location --retry 5 --output "$destination" "$url"
+}
+
+package_poco_libs() {
+  if ! command -v zip >/dev/null 2>&1; then
+    echo "zip command not found; unable to package Poco libraries" >&2
+    exit 1
+  fi
+
+  local archive="$1"
+  local lib_dir="$SDKTARGETSYSROOT/usr/lib"
+  if [[ ! -d "$lib_dir" ]]; then
+    echo "Poco library directory '$lib_dir' does not exist" >&2
+    exit 1
+  fi
+
+  local libs=()
+  while IFS= read -r -d '' lib; do
+    libs+=("$lib")
+  done < <(find "$lib_dir" -maxdepth 1 \
+    \( -name 'libPoco*.so*' -o -name 'libPoco*.a' \) -print0)
+
+  if [[ ${#libs[@]} -eq 0 ]]; then
+    echo "No Poco libraries were found in '$lib_dir'" >&2
+    exit 1
+  fi
+
+  local staging_dir="$work_dir/poco_libs"
+  rm -rf "$staging_dir"
+  mkdir -p "$staging_dir"
+
+  for lib in "${libs[@]}"; do
+    cp -a "$lib" "$staging_dir/"
+  done
+
+  mkdir -p "$(dirname "$archive")"
+  rm -f "$archive"
+  pushd "$staging_dir" >/dev/null
+  zip -9 -r "$archive" ./* >/dev/null
+  popd >/dev/null
+  echo "Packaged Poco libraries into $archive"
 }
 
 build_libsodium() {
@@ -102,3 +162,4 @@ build_poco() {
 
 build_libsodium
 build_poco
+package_poco_libs "$output_archive"


### PR DESCRIPTION
## Summary
- install the zip utility in the cross-compile workflow environment
- pass a Poco archive destination to the SDK bootstrap script
- upload the generated Poco library archive as an Actions artifact alongside the binary

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128632d2f0832f9e60a873d4cabdb2)