### PR TITLE
Enforce static Poco linkage

### DIFF
--- a/OpenHD/cmake/modules/FindPoco.cmake
+++ b/OpenHD/cmake/modules/FindPoco.cmake
@@ -1,24 +1,64 @@
-find_package(Poco COMPONENTS ${Poco_FIND_COMPONENTS} CONFIG QUIET)
-if(Poco_FOUND)
-  return()
+set(_poco_hint_roots)
+if(Poco_ROOT)
+  list(APPEND _poco_hint_roots ${Poco_ROOT})
+endif()
+if(DEFINED ENV{POCO_STATIC_ROOT})
+  list(APPEND _poco_hint_roots $ENV{POCO_STATIC_ROOT})
+endif()
+list(APPEND _poco_hint_roots /usr/local/poco-static /usr/local)
+
+find_path(Poco_INCLUDE_DIR Poco/Poco.h
+  HINTS ${_poco_hint_roots}
+  PATH_SUFFIXES include
+)
+mark_as_advanced(FORCE Poco_INCLUDE_DIR)
+
+find_package(Threads REQUIRED)
+if(UNIX AND NOT APPLE)
+  find_library(Poco_RT_LIBRARY rt)
 endif()
 
-find_path(Poco_INCLUDE_DIR Poco/Poco.h)
-mark_as_advanced(FORCE Poco_INCLUDE_DIR)
+set(_poco_common_deps Threads::Threads)
+if(CMAKE_DL_LIBS)
+  list(APPEND _poco_common_deps ${CMAKE_DL_LIBS})
+endif()
+if(Poco_RT_LIBRARY)
+  list(APPEND _poco_common_deps ${Poco_RT_LIBRARY})
+endif()
 
 foreach(component ${Poco_FIND_COMPONENTS})
   set(component_var "Poco_${component}_LIBRARY")
-  find_library(${component_var} Poco${component})
+
+  set(_poco_original_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  set(CMAKE_FIND_LIBRARY_SUFFIXES "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  find_library(${component_var} Poco${component}
+    HINTS ${_poco_hint_roots}
+    PATH_SUFFIXES lib
+  )
+  set(CMAKE_FIND_LIBRARY_SUFFIXES "${_poco_original_suffixes}")
   mark_as_advanced(FORCE ${component_var})
   if(${component_var})
     set(Poco_${component}_FOUND TRUE)
     list(APPEND Poco_LIBRARIES ${component})
     if(NOT TARGET Poco::${component})
-      add_library(Poco::${component} SHARED IMPORTED)
+      get_filename_component(_poco_library_ext "${${component_var}}" LAST_EXT)
+      if(NOT _poco_library_ext STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        message(FATAL_ERROR "Static Poco library for component ${component} not found")
+      endif()
+      add_library(Poco::${component} STATIC IMPORTED)
       set_target_properties(Poco::${component} PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${Poco_INCLUDE_DIR}
         IMPORTED_LOCATION ${${component_var}}
       )
+      if(component STREQUAL "Foundation")
+        set_property(TARGET Poco::${component} PROPERTY
+          INTERFACE_LINK_LIBRARIES "${_poco_common_deps}"
+        )
+      elseif(component STREQUAL "Net")
+        set_property(TARGET Poco::${component} PROPERTY
+          INTERFACE_LINK_LIBRARIES "Poco::Foundation;${_poco_common_deps}"
+        )
+      endif()
     endif()
   endif()
 endforeach()

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(OHDCommonLib PUBLIC Threads::Threads)
 # Sources
 #----------------------------------------------------------------------------------------------------------------------
 set(sources
+    "src/config_paths.cpp"
     "src/openhd_util.cpp"
     "src/openhd_util_filesystem.cpp"
     "src/openhd_settings_persistent.cpp"


### PR DESCRIPTION
## Summary
- update the custom FindPoco.cmake module to locate and require static Poco libraries, including dependency hints and thread/runtime link interfaces
- add config_paths.cpp to the OHDCommon source list so the interfaces link correctly when Poco is pulled in statically

## Testing
- cmake --build build_ninja --target test_interface

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69128ac4af04832f83f9667e7e6b10b2)