### PR TITLE
Adjust rtl88x2x channel width handling by role

### DIFF
--- a/OpenHD/ohd_interface/inc/wb_link_helper.h
+++ b/OpenHD/ohd_interface/inc/wb_link_helper.h
@@ -73,7 +73,7 @@ bool any_card_support_frequency(
 
 bool set_frequency_and_channel_width_for_all_cards(
     uint32_t frequency, uint32_t channel_width,
-    const std::vector<WiFiCard>& m_broadcast_cards);
+    const std::vector<WiFiCard>& m_broadcast_cards, bool is_air_unit);
 
 void set_tx_power_for_all_cards(int tx_power_mw,
                                 int rtl8812au_tx_power_index_override,

--- a/OpenHD/ohd_interface/inc/wifi_command_helper.h
+++ b/OpenHD/ohd_interface/inc/wifi_command_helper.h
@@ -123,7 +123,8 @@ bool iw_supports_monitor_mode(int phy_index);
 bool openhd_driver_set_frequency_and_channel_width(WiFiCardType type,
                                                    const std::string& device,
                                                    uint32_t freq_mhz,
-                                                   uint32_t channel_width);
+                                                   uint32_t channel_width,
+                                                   bool is_air_unit);
 
 // RTL8812bu driver only so far
 bool openhd_driver_set_tx_power(WiFiCardType type, const std::string& device,

--- a/OpenHD/ohd_interface/src/wb_link.cpp
+++ b/OpenHD/ohd_interface/src/wb_link.cpp
@@ -562,7 +562,7 @@ bool WBLink::apply_frequency_and_channel_width(int frequency,
   std::this_thread::sleep_for(std::chrono::milliseconds(
       100));  // Dirty - wait for any tx packets to drain
   const auto res = openhd::wb::set_frequency_and_channel_width_for_all_cards(
-      frequency, channel_width_rx, m_broadcast_cards);
+      frequency, channel_width_rx, m_broadcast_cards, m_profile.is_air);
   m_tx_header_1->update_channel_width(channel_width_tx);
   m_wb_txrx->tx_reset_stats();
   m_wb_txrx->rx_reset_stats();

--- a/OpenHD/ohd_interface/src/wb_link_helper.cpp
+++ b/OpenHD/ohd_interface/src/wb_link_helper.cpp
@@ -82,7 +82,7 @@ bool openhd::wb::any_card_support_frequency(
 
 bool openhd::wb::set_frequency_and_channel_width_for_all_cards(
     uint32_t frequency, uint32_t channel_width,
-    const std::vector<WiFiCard>& m_broadcast_cards) {
+    const std::vector<WiFiCard>& m_broadcast_cards, bool is_air_unit) {
   bool ret = true;  // Initialize return value to true
   for (const auto& card : m_broadcast_cards) {
     // Skip emulated cards
@@ -97,7 +97,7 @@ bool openhd::wb::set_frequency_and_channel_width_for_all_cards(
         card.type == WiFiCardType::OPENHD_RTL_88X2EU ||
         card.type == WiFiCardType::OPENHD_RTL_8852BU) {
       wifi::commandhelper::openhd_driver_set_frequency_and_channel_width(
-          card.type, card.device_name, frequency, channel_width);
+          card.type, card.device_name, frequency, channel_width, is_air_unit);
     } else {
       // Handle other card types with a different function
       const bool success =

--- a/OpenHD/ohd_interface/src/wifi_command_helper.cpp
+++ b/OpenHD/ohd_interface/src/wifi_command_helper.cpp
@@ -317,9 +317,9 @@ static constexpr char OPENHD_DRIVER_RTL88xxEU_CHANNEL_OVERRIDE[] =
 static constexpr char OPENHD_DRIVER_RTL88xxEU_TX_POWER_MW_OVERRIDE[] =
     "/sys/module/88x2eu_ohd/parameters/openhd_override_tx_power_mbm";
  
- bool wifi::commandhelper::openhd_driver_set_frequency_and_channel_width(
-     WiFiCardType type, const std::string &device, uint32_t freq_mhz,
-     uint32_t channel_width) {
+bool wifi::commandhelper::openhd_driver_set_frequency_and_channel_width(
+    WiFiCardType type, const std::string &device, uint32_t freq_mhz,
+    uint32_t channel_width, bool is_air_unit) {
    const auto channel_opt = openhd::channel_from_frequency(freq_mhz);
    if (!channel_opt.has_value()) {
      openhd::log::get_default()->warn("Cannot find channel {}Mhz", freq_mhz);
@@ -376,17 +376,17 @@ static constexpr char OPENHD_DRIVER_RTL88xxEU_TX_POWER_MW_OVERRIDE[] =
    }
    std::string bw_mode =
        channel_width_as_iw_string(channel_width, use_ht40_plus);
-  if ((type == WiFiCardType::OPENHD_RTL_88X2EU ||
-       type == WiFiCardType::OPENHD_RTL_88X2CU) &&
-      channel_width == 40) {
-    // rtl88x2eu / rtl88x2cu still require issuing an 80MHz request when 40MHz
-    // is desired
-    bw_mode = "80MHZ";
-    openhd::log::get_default()->info(
-        "{} requested 40MHz, issuing iw 80MHz command: wlan={} chan={}",
-        type == WiFiCardType::OPENHD_RTL_88X2EU ? "rtl88x2eu" : "rtl88x2cu",
-        device, channel.channel);
-  }
+   if (is_air_unit && (type == WiFiCardType::OPENHD_RTL_88X2EU ||
+                       type == WiFiCardType::OPENHD_RTL_88X2CU) &&
+       channel_width == 40) {
+     // rtl88x2eu / rtl88x2cu still require issuing an 80MHz request when 40MHz
+     // is desired on the air unit
+     bw_mode = "80MHZ";
+     openhd::log::get_default()->info(
+         "{} requested 40MHz on air, issuing iw 80MHz command: wlan={} chan={}",
+         type == WiFiCardType::OPENHD_RTL_88X2EU ? "rtl88x2eu" : "rtl88x2cu",
+         device, channel.channel);
+   }
    wifi::commandhelper::iw_set_frequency_and_channel_width2(
        device, dummy_frequency, bw_mode, true);
    return true;

--- a/OpenHD/ohd_interface/test/test_wifi_commands.cpp
+++ b/OpenHD/ohd_interface/test/test_wifi_commands.cpp
@@ -51,7 +51,7 @@ static void test_all_supported_frequencies(const WiFiCard& card,
     // success=wifi::commandhelper::iw_set_frequency_and_channel_width(card.device_name,frequency_mhz,20);
     const auto success =
         openhd::wb::set_frequency_and_channel_width_for_all_cards(
-            frequency_mhz, channel_width, {card});
+            frequency_mhz, channel_width, {card}, true);
     results.emplace_back(frequency_mhz, success);
     // Weird, otherwise we might get error resource busy
     std::this_thread::sleep_for(std::chrono::seconds(5));


### PR DESCRIPTION
## Summary
- add unit role awareness when setting frequencies for rtl88x2cu/eu devices
- propagate air/ground flag through helper APIs and tests
- keep ground devices on requested 40MHz while air still requests 80MHz workaround

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d8a066d84832fbcfaf427438a77c7)