### PR TITLE
Filter illegal frequencies on 88x2bu

### DIFF
--- a/OpenHD/ohd_interface/inc/wifi_channel.h
+++ b/OpenHD/ohd_interface/inc/wifi_channel.h
@@ -24,9 +24,12 @@
 #ifndef OPENHD_OPENHD_OHD_INTERFACE_INC_WIFI_CHANNEL_H_
 #define OPENHD_OPENHD_OHD_INTERFACE_INC_WIFI_CHANNEL_H_
 
+#include <algorithm>
 #include <cstdint>
 #include <sstream>
 #include <vector>
+
+#include <unordered_set>
 
 #include "openhd_spdlog.h"
 
@@ -223,6 +226,23 @@ static std::vector<WifiChannel> get_channels_5G_legal_at_least_one_country() {
     }
   }
   return ret;
+}
+// Some drivers (like 88x2bu) cannot handle explicitly illegal frequencies.
+// Filter out the frequencies that are known to be problematic for those cards
+// while still exposing all channels that are legal in at least one country.
+static std::vector<WifiChannel>
+get_channels_5G_legal_at_least_one_country_without_illegal() {
+  static const std::unordered_set<uint32_t> illegal_frequencies{
+      5080, 5100, 5120, 5140, 5160, 5885, 5905, 5925, 5945,
+      5965, 5985, 6005, 6025, 6045, 6065, 6085,
+  };
+  auto channels = get_channels_5G_legal_at_least_one_country();
+  channels.erase(
+      std::remove_if(channels.begin(), channels.end(), [](const auto& channel) {
+        return illegal_frequencies.count(channel.frequency) > 0;
+      }),
+      channels.end());
+  return channels;
 }
 // Returns all Wi-Fi channels 2.4G that are legal in at least one country
 static std::vector<WifiChannel> get_channels_2G_legal_at_least_one_country() {

--- a/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
+++ b/OpenHD/ohd_interface/src/wifi_card_discovery.cpp
@@ -223,7 +223,6 @@ std::optional<WiFiCard> DWifiCards::process_card(
   // RTL8812AU - since the openhd driver change, it reliably supports all wifi
   // frequencies, no matter what CRDA has to say
   if (card.type == WiFiCardType::OPENHD_RTL_88X2AU ||
-      card.type == WiFiCardType::OPENHD_RTL_88X2BU ||
       card.type == WiFiCardType::OPENHD_RTL_88X2CU ||
       card.type == WiFiCardType::OPENHD_RTL_88X2EU ||
       card.type == WiFiCardType::OPENHD_RTL_8852BU) {
@@ -231,6 +230,11 @@ std::optional<WiFiCard> DWifiCards::process_card(
         openhd::get_channels_2G_legal_at_least_one_country());
     card.supported_frequencies_5G = openhd::get_all_channel_frequencies(
         openhd::get_channels_5G_legal_at_least_one_country());
+  } else if (card.type == WiFiCardType::OPENHD_RTL_88X2BU) {
+    card.supported_frequencies_2G = openhd::get_all_channel_frequencies(
+        openhd::get_channels_2G_legal_at_least_one_country());
+    card.supported_frequencies_5G = openhd::get_all_channel_frequencies(
+        openhd::get_channels_5G_legal_at_least_one_country_without_illegal());
   } else {
     // Ask CRDA
     card.supported_frequencies_2G =


### PR DESCRIPTION
## Summary
- add a helper to filter out explicitly illegal 5GHz channels
- ensure rtl88x2bu cards only expose 5GHz frequencies that avoid those illegal entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d99131b74832f97f7f9dc478364f3)