### PR TITLE
Add configurable hostname and hotspot suffix

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -31,6 +31,7 @@
 #include <ohd_video_ground.h>
 
 #include <csignal>
+#include <exception>
 #include <iostream>
 #include <memory>
 #include <cstdlib>
@@ -42,6 +43,8 @@
 #include "openhd_spdlog.h"
 #include "openhd_temporary_air_or_ground.h"
 #include "openhd_config.h"
+#include "openhd_naming.h"
+#include "openhd_util_filesystem.h"
 #include "config_paths.h"
 
 // |-------------------------------------------------------------------------------|
@@ -190,6 +193,21 @@ static OHDRunOptions parse_run_parameters(int argc, char *argv[]) {
   return ret;
 }
 
+static void set_unit_hostname(const bool run_as_air) {
+  const auto hostname = openhd::naming::build_unit_name(run_as_air);
+  // Update the runtime hostname for the current session
+  const auto hostname_result = OHDUtil::run_command("hostname", {hostname}, false);
+  if (hostname_result != 0) {
+    std::cerr << "Failed to set hostname to " << hostname << std::endl;
+  }
+  // Persist hostname for subsequent reboots
+  try {
+    OHDFilesystemUtil::write_file("/etc/hostname", hostname + "\n");
+  } catch (const std::exception& ex) {
+    std::cerr << "Failed to persist hostname: " << ex.what() << std::endl;
+  }
+}
+
 int main(int argc, char *argv[]) {
   // OpenHD needs to be run as root!
   OHDUtil::terminate_if_not_root();
@@ -200,6 +218,7 @@ int main(int argc, char *argv[]) {
   if (options.hardware_config_file.has_value()) {
     openhd::set_config_file(options.hardware_config_file.value());
   }
+  set_unit_hostname(options.run_as_air);
   {  // Print all the arguments the OHD main executable is started with
  bool validLicense=false;
  if (OHDFilesystemUtil::exists("/usr/local/share/openhd/license")) {

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(OHDCommonLib PUBLIC Threads::Threads)
 set(sources
     "src/openhd_util.cpp"
     "src/openhd_util_filesystem.cpp"
+    "src/openhd_naming.cpp"
     "src/openhd_settings_persistent.cpp"
     "src/openhd_profile.cpp"
     "src/openhd_platform.cpp"

--- a/OpenHD/ohd_common/inc/openhd_naming.h
+++ b/OpenHD/ohd_common/inc/openhd_naming.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#ifndef OPENHD_OPENHD_OHD_COMMON_INC_OPENHD_NAMING_H_
+#define OPENHD_OPENHD_OHD_COMMON_INC_OPENHD_NAMING_H_
+
+#include <string>
+
+namespace openhd::naming {
+
+/**
+ * Returns the postfix configured by the user via name.txt (if available).
+ */
+std::string get_unit_name_postfix();
+
+/**
+ * Returns the default unit name (openhd_air or openhd_ground) with an optional
+ * postfix read from name.txt appended with an underscore.
+ */
+std::string build_unit_name(bool is_air);
+
+}  // namespace openhd::naming
+
+#endif  // OPENHD_OPENHD_OHD_COMMON_INC_OPENHD_NAMING_H_

--- a/OpenHD/ohd_common/src/openhd_naming.cpp
+++ b/OpenHD/ohd_common/src/openhd_naming.cpp
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#include "openhd_naming.h"
+
+#include <fmt/core.h>
+
+#include "config_paths.h"
+#include "openhd_util.h"
+#include "openhd_util_filesystem.h"
+
+namespace openhd::naming {
+
+static std::string get_name_file_path() {
+  return std::string(getConfigBasePath()) + "name.txt";
+}
+
+std::string get_unit_name_postfix() {
+  const auto name_file = get_name_file_path();
+  if (!OHDFilesystemUtil::exists(name_file)) {
+    return "";
+  }
+  auto postfix = OHDFilesystemUtil::read_file(name_file);
+  OHDUtil::trim(postfix);
+  return postfix;
+}
+
+std::string build_unit_name(const bool is_air) {
+  const std::string base_name = is_air ? "openhd_air" : "openhd_ground";
+  const auto postfix = get_unit_name_postfix();
+  if (postfix.empty()) {
+    return base_name;
+  }
+  return fmt::format("{}_{}", base_name, postfix);
+}
+
+}  // namespace openhd::naming

--- a/OpenHD/ohd_interface/src/wifi_hotspot.cpp
+++ b/OpenHD/ohd_interface/src/wifi_hotspot.cpp
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <utility>
 
+#include "openhd_naming.h"
 #include "openhd_spdlog.h"
 #include "openhd_util_async.h"
 
@@ -52,11 +53,12 @@ static bool create_hotspot_connection_file(const WiFiCard& card,
                          {"con", "delete", OHD_WIFI_HOTSPOT_CONNECTION_NAME});
   }
   // and create the hotspot one
+  const auto ssid = openhd::naming::build_unit_name(is_air);
   OHDUtil::run_command(
       "nmcli",
       {"con add type wifi ifname", card.device_name, "con-name",
        OHD_WIFI_HOTSPOT_CONNECTION_NAME, "autoconnect no",
-       fmt::format("ssid {}", is_air ? "openhd_air" : "openhd_ground")});
+       fmt::format("ssid {}", ssid)});
   OHDUtil::run_command("nmcli",
                        {"con modify ", OHD_WIFI_HOTSPOT_CONNECTION_NAME,
                         " 802-11-wireless.mode ap", "802-11-wireless.band",


### PR DESCRIPTION
## Summary
- add shared helper to build unit names using optional name.txt postfix
- apply postfix to wifi hotspot SSID generation
- set system hostname to the configured unit name at startup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f44dd3e98832fb174abdf30ee4377)