### PR TITLE
Bump OpenHD version to 2.7.0

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_global_constants.hpp
+++ b/OpenHD/ohd_common/inc/openhd_global_constants.hpp
@@ -60,8 +60,8 @@ static_assert(VIDEO_GROUND_VIDEO_STREAM_1_UDP !=
               "Must be different");
 
 static constexpr uint8_t MAJOR_VERSION = 2;
-static constexpr uint8_t MINOR_VERSION = 6;
-static constexpr uint8_t PATCH_VERSION = 4;
+static constexpr uint8_t MINOR_VERSION = 7;
+static constexpr uint8_t PATCH_VERSION = 0;
 static constexpr uint8_t RELEASE_TYPE = 0;
 static std::string ohd_version_as_string(uint8_t major, uint8_t minor,
                                          uint8_t patch, uint8_t release_type) {

--- a/package.sh
+++ b/package.sh
@@ -29,7 +29,7 @@ PACKAGE_ARCH="${2:-}"
 OS="${3:-}"
 
 PKGDIR="/out/openhd-installdir/"
-VERSION="2.6.4-$(date '+%Y%m%d%H%M')-$(git rev-parse --short HEAD)"
+VERSION="2.7.0-$(date '+%Y%m%d%H%M')-$(git rev-parse --short HEAD)"
 
 # Function to create the package directory structure
 create_package_directory() {


### PR DESCRIPTION
## Summary
- update the OpenHD version constants to 2.7.0
- align packaging script to emit artifacts with the new 2.7.0 version prefix

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f49454054832f9af6c0ef21fdae7c)