### PR TITLE
Fix fmt include for naming utility

### DIFF
--- a/OpenHD/ohd_common/src/openhd_naming.cpp
+++ b/OpenHD/ohd_common/src/openhd_naming.cpp
@@ -23,7 +23,7 @@
 
 #include "openhd_naming.h"
 
-#include <fmt/core.h>
+#include <spdlog/fmt/fmt.h>
 
 #include "config_paths.h"
 #include "openhd_util.h"


### PR DESCRIPTION
## Summary
- switch openhd_naming.cpp to use the bundled spdlog fmt header instead of an external fmt include

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4d514778832fad8e3a048a3ff047)