### PR TITLE
Add IMX662 camera profile

### DIFF
--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -86,6 +86,7 @@ static constexpr int X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX462 = 43;
 static constexpr int X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX327 = 44;
 static constexpr int X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX290 = 45;
 static constexpr int X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX462_LOWLIGHT_MINI = 46;
+static constexpr int X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX662 = 47;
 // ... 13 reserved for future use
 static constexpr int X_CAM_TYPE_RPI_V4L2_VEYE_2MP = 60;
 static constexpr int X_CAM_TYPE_RPI_V4L2_VEYE_CSIMX307 = 61;
@@ -197,6 +198,8 @@ static std::string x_cam_type_to_string(int camera_type) {
       return "ARDUCAM_IMX290";
     case X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX462_LOWLIGHT_MINI:
       return "ARDUCAM_IMX462_LOWLIGHT_MINI";
+    case X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX662:
+      return "ARDUCAM_IMX662";
     case X_CAM_TYPE_RPI_V4L2_VEYE_2MP:
       return "VEYE_2MP";
     case X_CAM_TYPE_RPI_V4L2_VEYE_CSIMX307:
@@ -410,6 +413,9 @@ struct XCamera {
       } else if (camera_type == X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX327) {
         ret.push_back(ResolutionFramerate{640, 480, 60});
         ret.push_back(ResolutionFramerate{896, 504, 60});
+        ret.push_back(ResolutionFramerate{1280, 720, 60});
+        ret.push_back(ResolutionFramerate{1920, 1080, 30});
+      } else if (camera_type == X_CAM_TYPE_RPI_LIBCAMERA_ARDUCAM_IMX662) {
         ret.push_back(ResolutionFramerate{1280, 720, 60});
         ret.push_back(ResolutionFramerate{1920, 1080, 30});
       } else if (camera_type == X_CAM_TYPE_RPI_LIBCAMERA_RPIF_V1_OV5647) {
@@ -743,7 +749,8 @@ static std::vector<ManufacturerForPlatform> get_camera_choices_for_platform(
         CameraNameAndType{"IMX462", 43},
         CameraNameAndType{"IMX327", 44},
         CameraNameAndType{"IMX290", 45},
-        CameraNameAndType{"IMX462_LOWLIGHT_MINI", 46}};
+        CameraNameAndType{"IMX462_LOWLIGHT_MINI", 46},
+        CameraNameAndType{"IMX662", 47}};
     std::vector<CameraNameAndType> veye_cameras{
         CameraNameAndType{"2MP", 60},
         CameraNameAndType{"CSIMX307", 61},

--- a/OpenHD/ohd_video/inc/libcamera_detect.hpp
+++ b/OpenHD/ohd_video/inc/libcamera_detect.hpp
@@ -55,6 +55,9 @@ static std::string get_sensor_name_from_cam_id(const std::string& cam_id) {
   } else if (OHDUtil::contains(cam_id, "imx230")) {
     // arducam
     ret = "imx230";
+  } else if (OHDUtil::contains(cam_id, "imx662")) {
+    // arducam
+    ret = "imx662";
   } else if (OHDUtil::contains_after_uppercase(cam_id, "AR0234")) {
     ret = "AR0234";
   } else if (OHDUtil::contains_after_uppercase(cam_id, "AR1820HS")) {

--- a/OpenHD/ohd_video/z_other/rpi_libcamera_sensor_modii.txt
+++ b/OpenHD/ohd_video/z_other/rpi_libcamera_sensor_modii.txt
@@ -4,6 +4,7 @@ IMX708 skymaster hdr
                              2304x1296 [56.03 fps - (0, 0)/4608x2592 crop]
                              4608x2592 [14.35 fps - (0, 0)/4608x2592 crop]
 IMX462
+IMX662
 IMX477
 IMX219
 openhd@openhd:~/OpenHD/OpenHD/build_debug $ sudo libcamera-hello --list-cameras


### PR DESCRIPTION
## Summary
- add an Arducam IMX662 camera type to the RPi libcamera camera list
- expose 1280x720@60 and 1920x1080@30 as supported modes for the new sensor and detect its identifier
- document the IMX662 sensor alongside other libcamera modules

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5124e144832fa1f170fd8958ce89)