### PR TITLE
Handle bullseye backports repo removal

### DIFF
--- a/build_chroot.sh
+++ b/build_chroot.sh
@@ -27,6 +27,13 @@
 # Ensure /tmp has correct permissions
 chmod 1777 /tmp || { echo "Failed to set permissions on /tmp"; exit 1; }
 
+# Disable stale bullseye-backports entries that now 404
+if grep -Rq "bullseye-backports" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+    for source_file in /etc/apt/sources.list /etc/apt/sources.list.d/*.list; do
+        [[ -f "$source_file" ]] && sed -i '/bullseye-backports/s/^/#/' "$source_file"
+    done
+fi
+
 # Update package lists and install necessary packages as root
 su -c "apt-get update --fix-missing && apt-get install -y sudo" || { echo "Failed to update and install sudo"; exit 1; }
 


### PR DESCRIPTION
## Summary
- comment out bullseye-backports apt sources when present
- ensure chroot build apt update succeeds on outdated bullseye base images

## Testing
- not run (script change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f7aee3384832f81594cf0cdbad341)