### PR TITLE
Add Allwinner A733 detection and camera support

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_platform.h
+++ b/OpenHD/ohd_common/inc/openhd_platform.h
@@ -58,7 +58,7 @@ static constexpr int X_PLATFORM_TYPE_LUCKFOX_LYRA = 27;
 // Numbers 30..35 are reserved for allwinner
 static constexpr int X_PLATFORM_TYPE_ALWINNER_X20 = 30;
 static constexpr int X_PLATFORM_TYPE_ALWINNER_CUBIE_A7S = 31;
-static constexpr int X_PLATFORM_TYPE_ALWINNER_CUBIE_A7Z = 32;
+static constexpr int X_PLATFORM_TYPE_ALWINNER_CUBIE_A7Z = 32;  // A733
 
 // @Buldo is working on openipc / sigmastar, 36..39
 static constexpr int X_PLATFORM_TYPE_OPENIPC_SIGMASTAR_UNDEFINED = 36;
@@ -99,6 +99,7 @@ struct OHDPlatform {
   bool is_rpi_or_x86() const;
   // alwinner
   bool is_x20() const;
+  bool is_a733() const;
   // qualcomm
   bool is_qrb5165() const;
   bool is_qcs405() const;

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -61,6 +61,17 @@ static int internal_discover_platform() {
     }
   }
   if (OHDFilesystemUtil::exists(ALLWINNER_BOARDID_PATH)) {
+    if (OHDFilesystemUtil::exists("/proc/device-tree/model")) {
+      const std::string model_content =
+          OHDFilesystemUtil::read_file("/proc/device-tree/model");
+      if (OHDUtil::contains_after_uppercase(model_content, "SUN60IW2") ||
+          OHDUtil::contains_after_uppercase(model_content, "A733") ||
+          OHDUtil::contains_after_uppercase(model_content, "CUBIE-A7Z")) {
+        openhd::log::get_default()->warn(
+            "Detected Allwinner platform (A733/CUBIE-A7Z).");
+        return X_PLATFORM_TYPE_ALWINNER_CUBIE_A7Z;
+      }
+    }
     openhd::log::get_default()->warn("Detected Allwinner platform (X20).");
     return X_PLATFORM_TYPE_ALWINNER_X20;
   }
@@ -246,6 +257,8 @@ std::string x_platform_type_to_string(int platform_type) {
       return "UVX_MOD";
     case X_PLATFORM_TYPE_ALWINNER_X20:
       return "X20";
+    case X_PLATFORM_TYPE_ALWINNER_CUBIE_A7Z:
+      return "A733";
     case X_PLATFORM_TYPE_OPENIPC_SIGMASTAR_UNDEFINED:
       return "OPENIPC SIGMASTAR";
     case X_PLATFORM_TYPE_NVIDIA_XAVIER:
@@ -282,7 +295,8 @@ int get_fec_max_block_size_for_platform() {
       platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3588_RADXA_ROCK5_B) {
     return 20;
   }
-  if (platform_type == X_PLATFORM_TYPE_ALWINNER_X20) {
+  if (platform_type == X_PLATFORM_TYPE_ALWINNER_X20 ||
+      platform_type == X_PLATFORM_TYPE_ALWINNER_CUBIE_A7Z) {
     return 20;
   }
   if (platform_type == X_PLATFORM_TYPE_NVIDIA_XAVIER) {
@@ -326,6 +340,10 @@ bool OHDPlatform::is_rpi_or_x86() const {
 
 bool OHDPlatform::is_x20() const {
   return platform_type == X_PLATFORM_TYPE_ALWINNER_X20;
+}
+
+bool OHDPlatform::is_a733() const {
+  return platform_type == X_PLATFORM_TYPE_ALWINNER_CUBIE_A7Z;
 }
 
 bool OHDPlatform::is_willy() const {

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -106,6 +106,9 @@ static constexpr int X_CAM_TYPE_X20_HDZERO_RUNCAM_V3 = 73;
 static constexpr int X_CAM_TYPE_X20_HDZERO_RUNCAM_NANO_90 = 74;
 static constexpr int X_CAM_TYPE_X20_OHD_Jaguar = 75;
 static constexpr int X_CAM_TYPE_X21_OHD_Jaguar = 76;
+static constexpr int X_CAM_TYPE_A733_IMX415 = 77;
+static constexpr int X_CAM_TYPE_A733_IMX219 = 78;
+static constexpr int X_CAM_TYPE_A733_IMX214 = 79;
 
 // ... 9 reserved for future use
 //
@@ -223,6 +226,12 @@ static std::string x_cam_type_to_string(int camera_type) {
       return "X20_OHD_Jaguar";
     case X_CAM_TYPE_X21_OHD_Jaguar:
       return "X21_OHD_Jaguar";
+    case X_CAM_TYPE_A733_IMX415:
+      return "A733_IMX415";
+    case X_CAM_TYPE_A733_IMX219:
+      return "A733_IMX219";
+    case X_CAM_TYPE_A733_IMX214:
+      return "A733_IMX214";
     // All the rock begin
     case X_CAM_TYPE_ROCK_5_HDMI_IN:
       return "ROCK_5_HDMI_IN";
@@ -300,8 +309,9 @@ struct XCamera {
     return camera_type >= 30 && camera_type < 60;
   }
   bool requires_x20_cedar_pipeline() const {
-    return camera_type >= 70 && camera_type < 80;
+    return camera_type >= 70 && camera_type < 77;
   }
+  bool requires_a733_pipeline() const { return camera_type >= 77 && camera_type < 80; }
   bool requires_rpi_veye_pipeline() const {
     return camera_type >= 60 && camera_type < 70;
   }
@@ -350,6 +360,11 @@ struct XCamera {
     } else if (requires_x20_cedar_pipeline()) {
       // also easy, 720p60 only (for now)
       return {ResolutionFramerate{1280, 720, 60}};
+    } else if (requires_a733_pipeline()) {
+      std::vector<ResolutionFramerate> ret;
+      ret.push_back(ResolutionFramerate{1280, 720, 60});
+      ret.push_back(ResolutionFramerate{1920, 1080, 30});
+      return ret;
     } else if (requires_willy_pipeline()) {
       // also easy, 720p60 only (for now)
       return {ResolutionFramerate{960, 720, 120}};
@@ -794,6 +809,15 @@ static std::vector<ManufacturerForPlatform> get_camera_choices_for_platform(
     return std::vector<ManufacturerForPlatform>{
         ManufacturerForPlatform{"HDZERO", generic_cameras},
         ManufacturerForPlatform{"RUNCAM", runcam_cameras}};
+  } else if (platform_type == X_PLATFORM_TYPE_ALWINNER_CUBIE_A7Z) {
+    std::vector<CameraNameAndType> allwinner_cameras{
+        CameraNameAndType{"IMX415", X_CAM_TYPE_A733_IMX415},
+        CameraNameAndType{"IMX219", X_CAM_TYPE_A733_IMX219},
+        CameraNameAndType{"IMX214", X_CAM_TYPE_A733_IMX214},
+    };
+    return std::vector<ManufacturerForPlatform>{
+        ManufacturerForPlatform{"ALLWINNER", allwinner_cameras},
+        MANUFACTURER_USB, MANUFACTURER_DEBUG};
   } else if ((platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W) ||
              (platform_type == X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_CM3)) {
     std::vector<CameraNameAndType> arducam_cameras{

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -619,6 +619,24 @@ static std::string createAllwinnerEncoderPipeline(
   return ss.str();
 }
 
+static std::string createAllwinnerCsiStream(const CameraSettings& settings,
+                                            const int sensor_id) {
+  const int width = settings.streamed_video_format.width > 0
+                        ? settings.streamed_video_format.width
+                        : 1280;
+  const int height = settings.streamed_video_format.height > 0
+                         ? settings.streamed_video_format.height
+                         : 720;
+  const int framerate = settings.streamed_video_format.framerate > 0
+                            ? settings.streamed_video_format.framerate
+                            : 30;
+
+  std::stringstream ss;
+  ss << createAllwinnerSensorPipeline(sensor_id, width, height, framerate);
+  ss << createAllwinnerEncoderPipeline(settings);
+  return ss.str();
+}
+
 /**
  * Create a encoded stream for the allwinner, which is fully hardware
  * accelerated

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -176,6 +176,11 @@ std::string GStreamerStream::create_source_encode_pipeline(
   } else if (camera.requires_x20_cedar_pipeline()) {
     openhd::log::get_default()->debug("Camera requires X20 Cedar pipeline.");
     pipeline << OHDGstHelper::createAllwinnerStream(setting);
+  } else if (camera.requires_a733_pipeline()) {
+    openhd::log::get_default()->debug(
+        "Camera requires Allwinner A733 CSI pipeline.");
+    const int sensor_id = 0;
+    pipeline << OHDGstHelper::createAllwinnerCsiStream(setting, sensor_id);
   } else if (camera.requires_willy_pipeline()) {
     openhd::log::get_default()->debug("Camera requires Willy pipeline.");
     pipeline << OHDGstHelper::create_willy_camera1_stream(2, setting);

--- a/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
@@ -82,6 +82,8 @@ AirCameraGenericSettings AirCameraGenericSettingsHolder::create_default()
     ret.primary_camera_type = rpi_get_default_primary_cam_type();
   } else if (OHDPlatform::instance().is_x20()) {
     ret.primary_camera_type = openhd::x20::detect_camera_type();
+  } else if (OHDPlatform::instance().is_a733()) {
+    ret.primary_camera_type = X_CAM_TYPE_A733_IMX415;
   } else if ((OHDPlatform::instance().platform_type ==
               X_PLATFORM_TYPE_ROCKCHIP_RK3566_RADXA_ZERO3W) ||
              (OHDPlatform::instance().platform_type ==


### PR DESCRIPTION
## Summary
- Detect Allwinner A733/Cubie A7Z boards separately from the existing X20 platform
- Add Allwinner A733 camera types with IMX415/IMX219/IMX214 presets and UI choices
- Implement an Allwinner CSI-to-cedar video pipeline for the new platform and use it in defaults

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2fb5ed18832fb41bcaa238fa4c15)