### PR TITLE
Stop RTP packetization for Allwinner A733 pipeline

### DIFF
--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -260,11 +260,17 @@ void GStreamerStream::setup() {
     /*pipeline_content << "video/x-h264,stream-format=byte-stream ! ";
     pipeline_content << OHDGstHelper::createOutputAppSink();*/
   } else {
-    const int rtp_fragment_size = 1440;
-    m_console->debug("Using {} for rtp fragmentation", rtp_fragment_size);
-    pipeline_content << OHDGstHelper::create_parse_and_rtp_packetize(
-        setting.streamed_video_format.videoCodec, rtp_fragment_size);
-    pipeline_content << OHDGstHelper::createOutputAppSink();
+    if (camera.requires_a733_pipeline()) {
+      pipeline_content <<
+          "video/x-h264,stream-format=byte-stream,alignment=au ! ";
+      pipeline_content << OHDGstHelper::createOutputAppSink();
+    } else {
+      const int rtp_fragment_size = 1440;
+      m_console->debug("Using {} for rtp fragmentation", rtp_fragment_size);
+      pipeline_content << OHDGstHelper::create_parse_and_rtp_packetize(
+          setting.streamed_video_format.videoCodec, rtp_fragment_size);
+      pipeline_content << OHDGstHelper::createOutputAppSink();
+    }
   }
   if (ADD_RECORDING_TO_PIPELINE) {
     const auto recording_filename =


### PR DESCRIPTION
## Summary
- adjust the A733 camera pipeline to deliver H.264 access units directly to the appsink
- bypass the RTP parse and packetization stage for the Allwinner A733 configuration

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b3e471e1c832fa7f7fd2f75357f01)