### PR TITLE
Align A733 GStreamer pipeline with expected configuration

### DIFF
--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -122,7 +122,7 @@ static std::string gst_create_rtp_caps(const VideoCodec& videoCodec) {
 static std::string create_rtp_packetize_for_codec(const VideoCodec codec,
                                                   const uint32_t mtu) {
   if (codec == VideoCodec::H264)
-    return fmt::format("rtph264pay mtu={} ! ", mtu);
+    return fmt::format("rtph264pay mtu={} pt=96 config-interval=-1 ! ", mtu);
   if (codec == VideoCodec::H265)
     return fmt::format("rtph265pay mtu={} ! ", mtu);
   assert(false);
@@ -616,8 +616,6 @@ static std::string createAllwinnerCsiStream(const CameraSettings& settings,
   ss << "queue max-size-buffers=4 leaky=downstream ! ";
   ss << "omxh264videoenc target-bitrate=" << bitrate_bits_per_second
      << " control-rate=constant ! ";
-  // Keep SPS / PPS inserted regularly for downstream compatibility
-  ss << "h264parse config-interval=1 ! ";
   return ss.str();
 }
 
@@ -825,6 +823,7 @@ static std::string create_parse_and_rtp_packetize(
   std::stringstream ss;
   ss << "queue ! ";
   ss << create_parse_for_codec(videoCodec);
+  ss << create_caps_nal(videoCodec, true);
   ss << create_rtp_packetize_for_codec(videoCodec, rtp_fragment_size);
   return ss.str();
 }
@@ -860,7 +859,7 @@ static std::string createOutputUdpLocalhost(const int udpOutPort) {
 static std::string createOutputAppSink() {
   // @wait-on-eos: set to false since when terminating, we don't care if all
   // buffers of appsink have been consumed or not.
-  return " appsink drop=true name=out_appsink wait-on-eos=false";
+  return " appsink name=out_appsink max-buffers=1000 drop=true sync=false wait-on-eos=false";
 }
 
 // Needs to match below


### PR DESCRIPTION
## Summary
- remove redundant h264 parsing from the Allwinner CSI pipeline so downstream parsing handles SPS/PPS
- add nal-aligned caps and updated rtph264pay settings to match the expected pipeline configuration
- adjust appsink configuration to mirror the desired buffer and sync behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b4dc1e950832fa910b60dc26dbe16)