### PR TITLE
Align A733 pipeline with gst-launch reference

### DIFF
--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -122,9 +122,9 @@ static std::string gst_create_rtp_caps(const VideoCodec& videoCodec) {
 static std::string create_rtp_packetize_for_codec(const VideoCodec codec,
                                                   const uint32_t mtu) {
   if (codec == VideoCodec::H264)
-    return fmt::format("rtph264pay mtu={} ! ", mtu);
+    return fmt::format("rtph264pay mtu={} pt=96 config-interval=-1 ! ", mtu);
   if (codec == VideoCodec::H265)
-    return fmt::format("rtph265pay mtu={} ! ", mtu);
+    return fmt::format("rtph265pay mtu={} config-interval=-1 ! ", mtu);
   assert(false);
   return "";
 }
@@ -616,8 +616,6 @@ static std::string createAllwinnerCsiStream(const CameraSettings& settings,
   ss << "queue max-size-buffers=4 leaky=downstream ! ";
   ss << "omxh264videoenc target-bitrate=" << bitrate_bits_per_second
      << " control-rate=constant ! ";
-  // Keep SPS / PPS inserted regularly for downstream compatibility
-  ss << "h264parse config-interval=1 ! ";
   return ss.str();
 }
 
@@ -825,6 +823,7 @@ static std::string create_parse_and_rtp_packetize(
   std::stringstream ss;
   ss << "queue ! ";
   ss << create_parse_for_codec(videoCodec);
+  ss << create_caps_nal(videoCodec, true);
   ss << create_rtp_packetize_for_codec(videoCodec, rtp_fragment_size);
   return ss.str();
 }


### PR DESCRIPTION
## Summary
- adjust the Allwinner A733 pipeline to mirror the working gst-launch pipeline by removing redundant parsing and relying on generic RTP setup
- ensure RTP packetization adds the required caps and config-interval settings for H.264/H.265 payloaders

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b4dc1e950832fa910b60dc26dbe16)