### PR TITLE
Add Linux 6.x NXP V4L2 encoder pipeline with intra refresh

### DIFF
--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -68,6 +68,7 @@ set(sources
     "src/openhd_tcp.cpp"
     "src/openhd_led.cpp"
     "src/openhd_buttons.cpp"
+    "src/kernel_version.cpp"
     "src/openhd_settings_imp.cpp"
     "src/openhd_settings_directories.cpp"
     "src/openhd_settings_persistent.cpp"

--- a/OpenHD/ohd_common/inc/kernel_version.h
+++ b/OpenHD/ohd_common/inc/kernel_version.h
@@ -1,0 +1,47 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace openhd {
+
+struct KernelVersion {
+  int major{0};
+  int minor{0};
+  int patch{0};
+};
+
+// Parse uname(2) release into a semantic version (major.minor.patch).
+std::optional<KernelVersion> get_kernel_version();
+
+// Convenience helper for simple selection logic.
+bool is_kernel_major(int expected_major);
+
+// Convert to human readable string for logs / debugging.
+std::string kernel_version_to_string(const KernelVersion& version);
+
+}  // namespace openhd
+

--- a/OpenHD/ohd_common/src/kernel_version.cpp
+++ b/OpenHD/ohd_common/src/kernel_version.cpp
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#include "kernel_version.h"
+
+#include <regex>
+#include <sys/utsname.h>
+
+namespace openhd {
+
+static std::regex version_regex{"([0-9]+)\\.([0-9]+)\\.([0-9]+).*"};
+
+std::optional<KernelVersion> get_kernel_version() {
+  struct utsname uts {};
+  if (uname(&uts) != 0) return std::nullopt;
+
+  std::cmatch matches;
+  if (!std::regex_match(uts.release, matches, version_regex)) {
+    return std::nullopt;
+  }
+
+  KernelVersion version;
+  version.major = std::stoi(matches[1]);
+  version.minor = std::stoi(matches[2]);
+  version.patch = std::stoi(matches[3]);
+  return version;
+}
+
+bool is_kernel_major(int expected_major) {
+  const auto version = get_kernel_version();
+  return version.has_value() && version->major == expected_major;
+}
+
+std::string kernel_version_to_string(const KernelVersion& version) {
+  return std::to_string(version.major) + "." + std::to_string(version.minor) +
+         "." + std::to_string(version.patch);
+}
+
+}  // namespace openhd
+

--- a/OpenHD/ohd_video/CMakeLists.txt
+++ b/OpenHD/ohd_video/CMakeLists.txt
@@ -53,6 +53,7 @@ if(ENABLE_AIR)
             src/validate_settings.cpp
             src/usb_thermal_cam_helper.cpp
             src/gstaudiostream.cpp
+            src/nxp_v4l2_helper.cpp
     )
 
     pkg_search_module(GST REQUIRED

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -30,7 +30,9 @@
 #include <string>
 
 #include "camera_settings.hpp"
+#include "kernel_version.h"
 #include "libcamera_iq_helper.h"
+#include "nxp_v4l2_helper.h"
 #include "openhd_bitrate.h"
 #include "openhd_platform.h"
 #include "openhd_spdlog.h"
@@ -696,6 +698,51 @@ static int nxp_calculate_number_of_mbs_in_a_slice(int frame_height_px,
 //   return ss.str();
 // }
 
+static std::string create_willy_source_and_convert(const int device_index,
+                                                   int target_w, int target_h) {
+  std::ostringstream ss;
+  ss << "v4l2src io-mode=dmabuf device=/dev/video" << device_index << " ! "
+     << "video/x-raw,format=YUY2,width=960,height=720,framerate=120/"
+        "1,interlace-mode=progressive ! "
+     << "queue max-size-buffers=1 leaky=downstream ! "
+     << "imxvideoconvert_g2d ! "
+     << "video/x-raw,format=RGBx,width=" << target_w << ",height=" << target_h
+     << " ! "
+     << "queue max-size-buffers=1 leaky=downstream ! ";
+  return ss.str();
+}
+
+static std::string create_willy_vpuenc_stream(const int device_index,
+                                              const CameraSettings& settings,
+                                              int target_w, int target_h) {
+  const bool use_h264 =
+      (settings.streamed_video_format.videoCodec == VideoCodec::H264);
+  const char* enc_name = use_h264 ? "vpuenc_h264" : "vpuenc_h265";
+  const int bps = settings.h26x_bitrate_kbits;
+
+  std::ostringstream ss;
+  ss << create_willy_source_and_convert(device_index, target_w, target_h);
+  ss << enc_name << " gop-size=" << settings.h26x_keyframe_interval
+     << " bitrate=" << bps << " ! ";
+  return ss.str();
+}
+
+static std::string create_willy_v4l2_encoder_stream(
+    const int device_index, const CameraSettings& settings, int target_w,
+    int target_h, const openhd::nxp::NxpEncoderNode& encoder_node) {
+  const bool use_h264 =
+      (settings.streamed_video_format.videoCodec == VideoCodec::H264);
+  const char* enc_name = use_h264 ? "v4l2h264enc" : "v4l2h265enc";
+  const auto bitrate_bps =
+      openhd::kbits_to_bits_per_second(settings.h26x_bitrate_kbits);
+
+  std::ostringstream ss;
+  ss << create_willy_source_and_convert(device_index, target_w, target_h);
+  ss << enc_name << " device=" << encoder_node.device_path
+     << " bitrate=" << bitrate_bps << " ! ";
+  return ss.str();
+}
+
 static std::string create_willy_camera1_stream(const int device_index,
                                                const CameraSettings& settings) {
   using namespace openhd;
@@ -707,41 +754,36 @@ static std::string create_willy_camera1_stream(const int device_index,
   int target_h = settings.streamed_video_format.height > 0
                      ? settings.streamed_video_format.height
                      : 720;
-  int target_fps = settings.streamed_video_format.framerate > 0
-                       ? settings.streamed_video_format.framerate
-                       : 120;
 
   // Keep encoder-friendly alignment
   target_w = ALIGN_UP(target_w, 16);
   target_h = ALIGN_UP(target_h, 16);
 
-  // VPU bitrate expects bits/s on this stack
-  const int bps = settings.h26x_bitrate_kbits;
+  // Prefer the new V4L2 pipeline on Linux 6.x when available.
+  const bool prefer_v4l2 = openhd::is_kernel_major(6);
+  if (prefer_v4l2) {
+    const bool needs_hevc =
+        settings.streamed_video_format.videoCodec == VideoCodec::H265;
+    auto encoder_node = nxp::find_v4l2_encoder_node(needs_hevc);
+    if (encoder_node.has_value()) {
+      const int intra_period_frames =
+          settings.h26x_intra_refresh_type != -1
+              ? settings.h26x_keyframe_interval
+              : 0;
+      nxp::log_cir_examples(openhd::log::get_default());
+      nxp::set_cyclic_intra_refresh(encoder_node.value(), target_w, target_h,
+                                    intra_period_frames,
+                                    openhd::log::get_default());
+      return create_willy_v4l2_encoder_stream(device_index, settings, target_w,
+                                              target_h, encoder_node.value());
+    }
+    openhd::log::get_default()->warn(
+        "NXP V4L2 encoder not found, using proprietary pipeline");
+  }
 
-  // Select encoder by codec (both NXP plugins use same knobs here)
-  const bool use_h264 =
-      (settings.streamed_video_format.videoCodec == VideoCodec::H264);
-  const char* enc_name = use_h264 ? "vpuenc_h264" : "vpuenc_h265";
-
-  std::ostringstream ss;
-  // Source: WILLY camera path is YUY2 952x720 @120; dmabuf from v4l2src into
-  // g2d
-  ss << "v4l2src io-mode=dmabuf device=/dev/video" << device_index << " ! "
-     << "video/x-raw,format=YUY2,width=960,height=720,framerate=120/"
-        "1,interlace-mode=progressive ! "
-     << "queue max-size-buffers=1 leaky=downstream ! "
-     << "imxvideoconvert_g2d ! ";
-
-  // Convert + scale to encoder target; RGBx is known-good on this BSP
-  ss << "video/x-raw,format=RGBx,width=" << target_w << ",height=" << target_h
-     << " ! "
-     << "queue max-size-buffers=1 leaky=downstream ! ";
-
-  // Hardware encoder
-  ss << enc_name << " gop-size=" << settings.h26x_keyframe_interval
-     << " bitrate=" << bps << " ! ";
-
-  return ss.str();
+  // Fall back to proprietary encoder (Linux 5.x stack).
+  return create_willy_vpuenc_stream(device_index, settings, target_w,
+                                    target_h);
 }
 
 /**

--- a/OpenHD/ohd_video/inc/nxp_v4l2_helper.h
+++ b/OpenHD/ohd_video/inc/nxp_v4l2_helper.h
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "openhd_spdlog.h"
+
+namespace openhd::nxp {
+
+struct NxpEncoderNode {
+  std::string device_path;
+  bool supports_cir{false};
+};
+
+// Enumerate video devices and return the first mem2mem encoder that advertises
+// H.264/H.265 capture formats.
+std::optional<NxpEncoderNode> find_v4l2_encoder_node(bool needs_hevc);
+
+// Translate RPi-style intra refresh period (frames) to V4L2 MB-per-frame value.
+int calculate_cyclic_intra_refresh_mb(int width_px, int height_px,
+                                      int period_frames);
+
+// Set V4L2_CID_MPEG_VIDEO_CYCLIC_INTRA_REFRESH_MB if supported. Logs once when
+// unsupported. Returns true on success.
+bool set_cyclic_intra_refresh(const NxpEncoderNode& node, int width_px,
+                              int height_px, int period_frames,
+                              const std::shared_ptr<spdlog::logger>& logger);
+
+// Emit a small set of sample calculations for debug builds / unit-ish
+// validation.
+void log_cir_examples(const std::shared_ptr<spdlog::logger>& logger);
+
+}  // namespace openhd::nxp
+

--- a/OpenHD/ohd_video/src/nxp_v4l2_helper.cpp
+++ b/OpenHD/ohd_video/src/nxp_v4l2_helper.cpp
@@ -1,0 +1,171 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#include "nxp_v4l2_helper.h"
+
+#include <fcntl.h>
+#include <linux/videodev2.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <cmath>
+#include <set>
+#include <tuple>
+#include <vector>
+
+#include <fmt/format.h>
+
+namespace openhd::nxp {
+
+namespace {
+
+constexpr int MAX_V4L2_NODE = 63;
+
+bool supports_codec(int fd, __u32 pixfmt) {
+  v4l2_fmtdesc fmt{};
+  fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
+  while (ioctl(fd, VIDIOC_ENUM_FMT, &fmt) == 0) {
+    if (fmt.pixelformat == pixfmt) return true;
+    fmt.index++;
+  }
+  return false;
+}
+
+bool is_mem2mem_encoder(const v4l2_capability& caps) {
+  const bool m2m = caps.device_caps & V4L2_CAP_VIDEO_M2M ||
+                   caps.device_caps & V4L2_CAP_VIDEO_M2M_MPLANE;
+  const bool capture = caps.device_caps & V4L2_CAP_VIDEO_CAPTURE ||
+                       caps.device_caps & V4L2_CAP_VIDEO_CAPTURE_MPLANE;
+  const bool output = caps.device_caps & V4L2_CAP_VIDEO_OUTPUT ||
+                      caps.device_caps & V4L2_CAP_VIDEO_OUTPUT_MPLANE;
+  return m2m && capture && output;
+}
+
+}  // namespace
+
+std::optional<NxpEncoderNode> find_v4l2_encoder_node(bool needs_hevc) {
+  std::set<int> seen;
+  for (int idx = 0; idx <= MAX_V4L2_NODE; ++idx) {
+    if (seen.count(idx) != 0) continue;
+    const auto path = fmt::format("/dev/video{}", idx);
+    const int fd = open(path.c_str(), O_RDWR | O_NONBLOCK);
+    if (fd < 0) continue;
+    seen.insert(idx);
+
+    v4l2_capability caps{};
+    if (ioctl(fd, VIDIOC_QUERYCAP, &caps) != 0) {
+      close(fd);
+      continue;
+    }
+
+    if (!is_mem2mem_encoder(caps)) {
+      close(fd);
+      continue;
+    }
+
+    const bool has_h264 = supports_codec(fd, V4L2_PIX_FMT_H264);
+    const bool has_h265 = supports_codec(fd, V4L2_PIX_FMT_HEVC);
+    if (!has_h264 && !has_h265) {
+      close(fd);
+      continue;
+    }
+    if (needs_hevc && !has_h265) {
+      close(fd);
+      continue;
+    }
+
+    v4l2_queryctrl qctrl{};
+    qctrl.id = V4L2_CID_MPEG_VIDEO_CYCLIC_INTRA_REFRESH_MB;
+    const bool supports_cir = ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0 &&
+                              !(qctrl.flags & V4L2_CTRL_FLAG_DISABLED);
+    close(fd);
+    return NxpEncoderNode{path, supports_cir};
+  }
+  return std::nullopt;
+}
+
+int calculate_cyclic_intra_refresh_mb(int width_px, int height_px,
+                                      int period_frames) {
+  const int mb_w = (width_px + 15) / 16;
+  const int mb_h = (height_px + 15) / 16;
+  const int total_mbs = mb_w * mb_h;
+  if (period_frames <= 0) return 0;
+  int mbs_per_frame = static_cast<int>(
+      std::ceil(static_cast<double>(total_mbs) / period_frames));
+  if (mbs_per_frame < 1) mbs_per_frame = 1;
+  if (mbs_per_frame > total_mbs) mbs_per_frame = total_mbs;
+  return mbs_per_frame;
+}
+
+bool set_cyclic_intra_refresh(const NxpEncoderNode& node, int width_px,
+                              int height_px, int period_frames,
+                              const std::shared_ptr<spdlog::logger>& logger) {
+  static bool logged_unsupported = false;
+  if (!node.supports_cir) {
+    if (!logged_unsupported && logger) {
+      logger->warn("CIR not supported on this encoder");
+    }
+    logged_unsupported = true;
+    return false;
+  }
+
+  const int value = calculate_cyclic_intra_refresh_mb(width_px, height_px,
+                                                      period_frames);
+  const int fd = open(node.device_path.c_str(), O_RDWR | O_NONBLOCK);
+  if (fd < 0) return false;
+
+  v4l2_control ctrl{};
+  ctrl.id = V4L2_CID_MPEG_VIDEO_CYCLIC_INTRA_REFRESH_MB;
+  ctrl.value = value;
+  const bool ok = ioctl(fd, VIDIOC_S_CTRL, &ctrl) == 0;
+  close(fd);
+
+  if (logger) {
+    const int mb_w = (width_px + 15) / 16;
+    const int mb_h = (height_px + 15) / 16;
+    const int total_mbs = mb_w * mb_h;
+    if (value == 0) {
+      logger->info("CIR disabled");
+    } else {
+      logger->info("CIR enabled: period={} frames => {} MB/frame (total={})",
+                   period_frames, value, total_mbs);
+    }
+  }
+
+  return ok;
+}
+
+void log_cir_examples(const std::shared_ptr<spdlog::logger>& logger) {
+  if (!logger) return;
+  const std::vector<std::tuple<int, int, int>> samples = {
+      {1280, 720, 30}, {1920, 1080, 30}, {640, 480, 30}};
+  for (const auto& sample : samples) {
+    const auto mb = calculate_cyclic_intra_refresh_mb(
+        std::get<0>(sample), std::get<1>(sample), std::get<2>(sample));
+    logger->debug("{}x{} period={} -> {} MB/frame", std::get<0>(sample),
+                  std::get<1>(sample), std::get<2>(sample), mb);
+  }
+}
+
+}  // namespace openhd::nxp
+


### PR DESCRIPTION
## Summary
- add runtime kernel version helper for selecting pipelines
- introduce NXP V4L2 encoder utilities and intra refresh mapping to MB-per-frame
- prefer Linux 6.x V4L2 encoder pipeline with intra refresh while keeping legacy fallback

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d811233cc832fbabe756e1fe87c31)