### PR TITLE
Add NXP i.MX8 V4L2 video pipeline support

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_platform.h
+++ b/OpenHD/ohd_common/inc/openhd_platform.h
@@ -70,6 +70,9 @@ static constexpr int X_PLATFORM_TYPE_NVIDIA_XAVIER = 40;
 static constexpr int X_PLATFORM_TYPE_QUALCOMM_QRB5165 = 46;
 static constexpr int X_PLATFORM_TYPE_QUALCOMM_QCS405 = 47;
 
+// Numbers 61..65 are reserved for NXP
+static constexpr int X_PLATFORM_TYPE_NXP_IMX8 = 61;
+
 // Numbers 51..60 are reserved for Enterprise Customers
 static constexpr int X_PLATFORM_TYPE_ORQA = 51;
 static constexpr int X_PLATFORM_TYPE_UVX_MOD = 52;

--- a/OpenHD/ohd_common/src/openhd_platform.cpp
+++ b/OpenHD/ohd_common/src/openhd_platform.cpp
@@ -106,10 +106,16 @@ static int internal_discover_platform() {
   }
 
   if (OHDFilesystemUtil::exists(DEVICE_TREE_COMPATIBLE_PATH)) {
-    openhd::log::get_default()->warn("Checking for Rockchip platforms...");
+    openhd::log::get_default()->warn("Checking device tree compatible...");
 
     const std::string compatible_content =
         OHDFilesystemUtil::read_file(DEVICE_TREE_COMPATIBLE_PATH);
+    if (OHDUtil::contains_after_uppercase(compatible_content, "IMX8")) {
+      openhd::log::get_default()->warn("Detected NXP i.MX8 platform.");
+      return X_PLATFORM_TYPE_NXP_IMX8;
+    }
+
+    openhd::log::get_default()->warn("Checking for Rockchip platforms...");
     const std::string device_tree_model =
         OHDFilesystemUtil::read_file("/proc/device-tree/model");
     std::regex r("rockchip,(r[kv][0-9]+)");
@@ -267,6 +273,8 @@ std::string x_platform_type_to_string(int platform_type) {
       return "QUALCOMM_QCS405";
     case X_PLATFORM_TYPE_QUALCOMM_QRB5165:
       return "QUALCOMM_QRB5165";
+    case X_PLATFORM_TYPE_NXP_IMX8:
+      return "NXP_IMX8";
     default:
       std::stringstream ss;
       ss << "ERR-UNDEFINED{" << platform_type << "}";

--- a/OpenHD/ohd_video/inc/camera.hpp
+++ b/OpenHD/ohd_video/inc/camera.hpp
@@ -145,6 +145,8 @@ static constexpr int X_CAM_TYPE_QC_OV9282 = 121;
 static constexpr int X_CAM_TYPE_ORQA_HORNET = 122;
 static constexpr int X_CAM_TYPE_ORQA_JAGUAR = 123;
 static constexpr int X_CAM_TYPE_ORQA_REKINDLE = 124;
+// NXP specific starts here
+static constexpr int X_CAM_TYPE_NXP_IMX8_V4L2 = 130;
 
 //
 // ... rest is reserved for future use
@@ -281,6 +283,8 @@ static std::string x_cam_type_to_string(int camera_type) {
       return "ORQA_JAGUAR";
     case X_CAM_TYPE_ORQA_REKINDLE:
       return "ORQA_REKINDLE";
+    case X_CAM_TYPE_NXP_IMX8_V4L2:
+      return "NXP_IMX8_V4L2";
     default:
       break;
   }
@@ -334,6 +338,9 @@ struct XCamera {
   bool requires_orqa_pipeline() const {
     return camera_type >= 122 && camera_type < 124;
   }
+  bool requires_nxp_imx8_v4l2_pipeline() const {
+    return camera_type >= 130 && camera_type < 140;
+  }
   std::string cam_type_as_verbose_string() const {
     return x_cam_type_to_string(camera_type);
   }
@@ -374,6 +381,11 @@ struct XCamera {
     } else if (requires_orqa_pipeline()) {
       // also easy, 720p60 only (for now)
       return {ResolutionFramerate{960, 720, 120}};
+    } else if (requires_nxp_imx8_v4l2_pipeline()) {
+      std::vector<ResolutionFramerate> ret;
+      ret.push_back(ResolutionFramerate{1280, 720, 60});
+      ret.push_back(ResolutionFramerate{1920, 1080, 30});
+      return ret;
     } else if (camera_type == X_CAM_TYPE_USB_INFIRAY) {
       return {ResolutionFramerate{384, 292, 25}};
     } else if (camera_type == X_CAM_TYPE_USB_INFIRAY_T2) {
@@ -884,6 +896,13 @@ static std::vector<ManufacturerForPlatform> get_camera_choices_for_platform(
     };
     return std::vector<ManufacturerForPlatform>{
         ManufacturerForPlatform{"ORQA", orqa_cameras}, MANUFACTURER_USB,
+        MANUFACTURER_DEBUG};
+  } else if (platform_type == X_PLATFORM_TYPE_NXP_IMX8) {
+    std::vector<CameraNameAndType> nxp_cameras{
+        CameraNameAndType{"V4L2 CSI", X_CAM_TYPE_NXP_IMX8_V4L2},
+    };
+    return std::vector<ManufacturerForPlatform>{
+        ManufacturerForPlatform{"NXP", nxp_cameras}, MANUFACTURER_USB,
         MANUFACTURER_DEBUG};
   }
   return std::vector<ManufacturerForPlatform>{MANUFACTURER_DEBUG};

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -591,6 +591,37 @@ static std::string createRockchipCSIStream(int v4l2_filenumber,
   return ss.str();
 }
 
+static std::string create_nxp_imx8_v4l2_stream(
+    const CameraSettings& settings, int device_index = 0) {
+  const int width = settings.streamed_video_format.width > 0
+                        ? settings.streamed_video_format.width
+                        : 1280;
+  const int height = settings.streamed_video_format.height > 0
+                         ? settings.streamed_video_format.height
+                         : 720;
+  const int framerate = settings.streamed_video_format.framerate > 0
+                            ? settings.streamed_video_format.framerate
+                            : 30;
+
+  const bool use_h264 = settings.streamed_video_format.videoCodec == VideoCodec::H264;
+  const auto iframe_control = use_h264 ? "h264_i_frame_period" : "h265_i_frame_period";
+  const auto encoder_name = use_h264 ? "v4l2h264enc" : "v4l2h265enc";
+  const auto bitrate_bits_per_second =
+      openhd::kbits_to_bits_per_second(settings.h26x_bitrate_kbits);
+
+  std::stringstream ss;
+  ss << fmt::format(
+      "v4l2src device=/dev/video{} io-mode=dmabuf do-timestamp=true ! "
+      "video/x-raw,format=NV12,width={},height={},framerate={}/1 ! ",
+      device_index, width, height, framerate);
+  ss << "queue max-size-buffers=4 leaky=downstream ! ";
+  ss << fmt::format(
+      "{} extra-controls=\\\"controls,video_bitrate={},{}={}\\\" ! ",
+      encoder_name, bitrate_bits_per_second, iframe_control,
+      settings.h26x_keyframe_interval);
+  return ss.str();
+}
+
 static std::string createAllwinnerCsiStream(const CameraSettings& settings,
                                             const int sensor_id) {
   const int width = settings.streamed_video_format.width > 0

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -185,6 +185,10 @@ std::string GStreamerStream::create_source_encode_pipeline(
   } else if (camera.requires_orqa_pipeline()) {
     openhd::log::get_default()->debug("Camera requires ORQA pipeline.");
     pipeline << OHDGstHelper::create_orqa_camera1_stream(2, setting);
+  } else if (camera.requires_nxp_imx8_v4l2_pipeline()) {
+    openhd::log::get_default()->debug(
+        "Camera requires NXP i.MX8 V4L2 pipeline.");
+    pipeline << OHDGstHelper::create_nxp_imx8_v4l2_stream(setting);
   } else if (is_usb_camera(camera.camera_type)) {
     openhd::log::get_default()->warn("Detected USB camera.");
     const auto v4l2_device_name =

--- a/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air_generic_settings.cpp
@@ -106,6 +106,8 @@ AirCameraGenericSettings AirCameraGenericSettingsHolder::create_default()
     ret.primary_camera_type = X_CAM_TYPE_QC_IMX577;
   } else if (OHDPlatform::instance().platform_type == X_PLATFORM_TYPE_ORQA) {
     ret.primary_camera_type = X_CAM_TYPE_ORQA_HORNET;
+  } else if (OHDPlatform::instance().platform_type == X_PLATFORM_TYPE_NXP_IMX8) {
+    ret.primary_camera_type = X_CAM_TYPE_NXP_IMX8_V4L2;
   }
 
   return ret;


### PR DESCRIPTION
## Summary
- add an NXP i.MX8 V4L2 camera type with default selection for the platform
- integrate an i.MX8 V4L2 hardware-encoding pipeline into GStreamer stream creation
- expose i.MX8 camera choices and supported resolutions in the UI helpers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693da5b5b878832fa1bcfeae2a58f185)