### PR TITLE
Enable dynamic bitrate control on NXP v4l2

### DIFF
--- a/OpenHD/ohd_video/inc/gst_bitrate_controll_wrapper.hpp
+++ b/OpenHD/ohd_video/inc/gst_bitrate_controll_wrapper.hpp
@@ -26,10 +26,12 @@
 
 #include <gst/gst.h>
 
+#include <functional>
 #include <optional>
 
 #include "openhd_spdlog.h"
 #include "openhd_spdlog_include.h"
+#include "gst_helper.hpp"
 
 // #define EXPERIMENTAL_USE_OPENH264_ENCODER
 
@@ -43,6 +45,10 @@ struct GstBitrateControlElement {
   GstElement* encoder;
   // Not all encoders / elements call the bitrate property "bitrate"
   std::string property_name = "bitrate";
+  // Optional handler for backends that don't expose a GStreamer property
+  std::function<bool(int)> set_bitrate_kbits;
+  // Optional cleanup for custom handlers
+  std::function<void()> cleanup;
 };
 
 static std::optional<GstBitrateControlElement>
@@ -70,12 +76,40 @@ get_dynamic_bitrate_control_element_in_pipeline(
     ret.encoder = gst_bin_get_by_name(GST_BIN(gst_pipeline), "sunxisrc");
     ret.property_name = "bitrate";
     ret.takes_kbit = true;
+  } else if (camera.requires_nxp_imx8_v4l2_pipeline()) {
+    ret.encoder = nullptr;
+    ret.property_name = "bitrate";
+    ret.takes_kbit = false;
+    ret.set_bitrate_kbits = [](int bitrate_kbits) {
+      NxpV4L2ControlSession ctrl(kNxpV4L2EncoderDevice);
+      if (!ctrl.valid()) return false;
+
+      const auto bitrate_bits_per_second =
+          openhd::kbits_to_bits_per_second(bitrate_kbits);
+
+      bool ok = true;
+      ok &= ctrl.set_menu(V4L2_CID_MPEG_VIDEO_BITRATE_MODE,
+                          V4L2_MPEG_VIDEO_BITRATE_MODE_CBR,
+                          "video_bitrate_mode");
+      ok &= ctrl.set_int(V4L2_CID_MPEG_VIDEO_BITRATE, bitrate_bits_per_second,
+                         "video_bitrate");
+      ok &= ctrl.set_int(V4L2_CID_MPEG_VIDEO_FRAME_RC_ENABLE, 1,
+                         "frame_level_rate_control_enable");
+      return ok;
+    };
+    ret.cleanup = []() {};
   }
-  if (ret.encoder == nullptr) {
+  if (ret.encoder == nullptr && !ret.set_bitrate_kbits) {
     openhd::log::get_default()->debug(
         "Cannot find dynamic bitrate control element for camera {}",
         camera.cam_type_as_verbose_string());
     return std::nullopt;
+  }
+  if (ret.set_bitrate_kbits) {
+    openhd::log::get_default()->info(
+        "Using V4L2 bitrate control for camera {}",
+        camera.cam_type_as_verbose_string());
+    return ret;
   }
   // try fetching the value for testing if it actually works
   gint actual_bits_per_second = -1;
@@ -94,6 +128,9 @@ get_dynamic_bitrate_control_element_in_pipeline(
 
 static bool change_bitrate(const GstBitrateControlElement& ctrl_el,
                            int bitrate_kbits) {
+  if (ctrl_el.set_bitrate_kbits) {
+    return ctrl_el.set_bitrate_kbits(bitrate_kbits);
+  }
   const auto bitrate = ctrl_el.takes_kbit
                            ? bitrate_kbits
                            : openhd::kbits_to_bits_per_second(bitrate_kbits);
@@ -113,6 +150,9 @@ static bool change_bitrate(const GstBitrateControlElement& ctrl_el,
 }
 
 static void unref_bitrate_element(GstBitrateControlElement& element) {
+  if (element.cleanup) {
+    element.cleanup();
+  }
   if (element.encoder) {
     openhd::log::get_default()->debug("Unref bitrate control element begin");
     gst_object_unref(element.encoder);


### PR DESCRIPTION
## Summary
- add V4L2-based bitrate control for the NXP v4l2 pipeline to keep CBR
- allow bitrate adjustments without restarting the pipeline by applying controls dynamically

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dee469c64832fba2708f88776e028)