### PR TITLE
Add runtime bitrate and IDR controls for NXP V4L2 encoder

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_action_handler.h
+++ b/OpenHD/ohd_common/inc/openhd_action_handler.h
@@ -129,6 +129,15 @@ class LinkActionHandler {
     m_action_request_bitrate_change =
         std::make_shared<ACTION_REQUEST_BITRATE_CHANGE>(cb);
   }
+  typedef std::function<void()> ACTION_REQUEST_KEYFRAME;
+  void action_request_keyframe_register(
+      const ACTION_REQUEST_KEYFRAME& cb) {
+    if (cb == nullptr) {
+      m_action_request_keyframe = nullptr;
+      return;
+    }
+    m_action_request_keyframe = std::make_shared<ACTION_REQUEST_KEYFRAME>(cb);
+  }
   // called by ohd_interface / wb
   void action_request_bitrate_change_handle(
       LinkBitrateInformation link_bitrate_info) {
@@ -140,6 +149,13 @@ class LinkActionHandler {
       // The cb will update setting the global atomic value for cam1 / cam2
       // accordingly
       cb(link_bitrate_info);
+    }
+  }
+  void action_request_keyframe_handle() {
+    auto tmp = m_action_request_keyframe;
+    if (tmp) {
+      auto& cb = *tmp;
+      cb();
     }
   }
 
@@ -156,6 +172,7 @@ class LinkActionHandler {
   // Cleanup, set all lambdas that handle things to nullptr
   void disable_all_callables() {
     action_request_bitrate_change_register(nullptr);
+    action_request_keyframe_register(nullptr);
     wb_cmd_scan_channels = nullptr;
     wb_cmd_analyze_channels = nullptr;
     wb_get_supported_channels = nullptr;
@@ -165,6 +182,8 @@ class LinkActionHandler {
   // By using shared_ptr to wrap the stored the cb we are semi thread-safe
   std::shared_ptr<ACTION_REQUEST_BITRATE_CHANGE>
       m_action_request_bitrate_change = nullptr;
+  std::shared_ptr<ACTION_REQUEST_KEYFRAME> m_action_request_keyframe =
+      nullptr;
   std::shared_ptr<openhd::link_statistics::STATS_CALLBACK>
       m_link_statistics_callback = nullptr;
 

--- a/OpenHD/ohd_video/inc/README.md
+++ b/OpenHD/ohd_video/inc/README.md
@@ -1,0 +1,12 @@
+# NXP V4L2 runtime controls
+
+This directory contains the NXP i.MX8 V4L2 pipeline helpers. Runtime control
+support here is **NXP-specific** because it relies on the encoder being exposed
+as a V4L2 device (`/dev/video0`) that accepts the NXP control set.
+
+* Supported pipeline: NXP i.MX8 V4L2 encoder only.
+* Runtime bitrate and IDR: bitrate overrides use `VIDIOC_S_CTRL` on the active
+  encoder FD and force-IDR requests use either the vendor IDR control or the
+  generic `V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME` fallback.
+* No pipeline restart is needed for these controls; the encoder FD is tracked
+  while streaming so IOCTL updates apply in-place.

--- a/OpenHD/ohd_video/inc/camerastream.h
+++ b/OpenHD/ohd_video/inc/camerastream.h
@@ -90,6 +90,10 @@ class CameraStream {
    * interface method properly, e.g leave it empty.
    */
   virtual void handle_update_arming_state(bool armed) = 0;
+  // Optional force-IDR/keyframe request coming from the link layer.
+  // Default implementation is a no-op for pipelines that do not expose
+  // runtime keyframe injection.
+  virtual void request_keyframe() {}
 
  public:
   std::shared_ptr<CameraHolder> m_camera_holder;

--- a/OpenHD/ohd_video/inc/gst_bitrate_controll_wrapper.hpp
+++ b/OpenHD/ohd_video/inc/gst_bitrate_controll_wrapper.hpp
@@ -83,7 +83,7 @@ get_dynamic_bitrate_control_element_in_pipeline(
     ret.set_bitrate_kbits = [](int bitrate_kbits) {
       return OHDGstHelper::nxp_v4l2_set_cbr_bitrate_kbits(bitrate_kbits);
     };
-    ret.cleanup = []() {};
+    ret.cleanup = []() { nxp_release_tracked_encoder_fd(); };
   }
   if (ret.encoder == nullptr && !ret.set_bitrate_kbits) {
     openhd::log::get_default()->debug(

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -38,6 +38,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <mutex>
 #include <vector>
 #include <unistd.h>
 
@@ -606,6 +607,40 @@ static std::string createRockchipCSIStream(int v4l2_filenumber,
 namespace {
 constexpr auto kNxpV4L2EncoderDevice = "/dev/video0";
 
+// Track the currently streaming NXP V4L2 encoder FD so we can issue controls
+// without restarting the pipeline. This is intentionally NXP-only because the
+// control set (and the fact that the encoder is exposed as a V4L2 device) is
+// specific to the i.MX8 stack.
+std::mutex g_nxp_encoder_fd_mutex;
+int g_nxp_encoder_fd = -1;
+
+static int nxp_get_tracked_encoder_fd() {
+  std::lock_guard<std::mutex> lock(g_nxp_encoder_fd_mutex);
+  return g_nxp_encoder_fd;
+}
+
+static int nxp_open_and_track_encoder_fd(const std::string& device_path) {
+  std::lock_guard<std::mutex> lock(g_nxp_encoder_fd_mutex);
+  if (g_nxp_encoder_fd >= 0) return g_nxp_encoder_fd;
+  g_nxp_encoder_fd = open(device_path.c_str(), O_RDWR);
+  if (g_nxp_encoder_fd >= 0) {
+    openhd::log::get_default()->info("NXP V4L2: tracking encoder fd {} for {}",
+                                     g_nxp_encoder_fd, device_path);
+  } else {
+    openhd::log::get_default()->warn(
+        "NXP V4L2: failed to open {} ({})", device_path, errno);
+  }
+  return g_nxp_encoder_fd;
+}
+
+static void nxp_release_tracked_encoder_fd() {
+  std::lock_guard<std::mutex> lock(g_nxp_encoder_fd_mutex);
+  if (g_nxp_encoder_fd >= 0) {
+    close(g_nxp_encoder_fd);
+    g_nxp_encoder_fd = -1;
+  }
+}
+
 struct V4L2ControlLogState {
   std::unordered_map<uint32_t, bool> support_cache{};
   std::unordered_set<uint32_t> unsupported_logged{};
@@ -694,8 +729,14 @@ static bool v4l2_ctrl_press_button(int fd, uint32_t cid, const char* name) {
 
 class NxpV4L2ControlSession {
  public:
-  explicit NxpV4L2ControlSession(const std::string& device_path)
-      : m_fd(open(device_path.c_str(), O_RDWR)) {
+  explicit NxpV4L2ControlSession(const std::string& device_path,
+                                 bool track_active_encoder_fd = false)
+      : m_fd(-1), m_owns_fd(!track_active_encoder_fd) {
+    if (track_active_encoder_fd) {
+      m_fd = nxp_open_and_track_encoder_fd(device_path);
+    } else {
+      m_fd = open(device_path.c_str(), O_RDWR);
+    }
     if (m_fd < 0) {
       openhd::log::get_default()->warn(
           "NXP V4L2: failed to open {} ({})", device_path, errno);
@@ -703,7 +744,7 @@ class NxpV4L2ControlSession {
   }
 
   ~NxpV4L2ControlSession() {
-    if (m_fd >= 0) close(m_fd);
+    if (m_fd >= 0 && m_owns_fd) close(m_fd);
   }
 
   [[nodiscard]] bool valid() const { return m_fd >= 0; }
@@ -723,19 +764,51 @@ class NxpV4L2ControlSession {
     return v4l2_ctrl_press_button(m_fd, cid, name);
   }
 
-  bool is_supported(uint32_t cid, const char* name = nullptr) const {
+ bool is_supported(uint32_t cid, const char* name = nullptr) const {
     if (!valid()) return false;
     return v4l2_ctrl_is_supported(m_fd, cid, name);
   }
 
  private:
   int m_fd{ -1 };
+  bool m_owns_fd{true};
 };
 
 [[maybe_unused]] static void nxp_force_keyframe_now(
     const std::string& device_path) {
   NxpV4L2ControlSession ctrl(device_path);
   ctrl.press_button(V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME, "force_key_frame");
+}
+
+static void nxp_clear_cached_ctrl_value(uint32_t cid) {
+  auto& state = nxp_v4l2_log_state();
+  state.last_values.erase(cid);
+}
+
+static bool nxp_set_bitrate(uint32_t bitrate_bps) {
+  const int fd = nxp_open_and_track_encoder_fd(kNxpV4L2EncoderDevice);
+  if (fd < 0) return false;
+  return v4l2_ctrl_set_int(fd, V4L2_CID_MPEG_VIDEO_BITRATE, bitrate_bps,
+                           "video_bitrate");
+}
+
+static bool nxp_force_idr() {
+  const int fd = nxp_open_and_track_encoder_fd(kNxpV4L2EncoderDevice);
+  if (fd < 0) return false;
+
+  nxp_clear_cached_ctrl_value(V4L2_CID_MPEG_VIDEO_FORCE_FRAME_TYPE);
+  nxp_clear_cached_ctrl_value(V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME);
+
+  if (v4l2_ctrl_is_supported(fd, V4L2_CID_MPEG_VIDEO_FORCE_FRAME_TYPE,
+                              "force_frame_type")) {
+    if (v4l2_ctrl_set_menu(fd, V4L2_CID_MPEG_VIDEO_FORCE_FRAME_TYPE,
+                           V4L2_MPEG_VIDEO_FORCE_FRAME_TYPE_IDR,
+                           "force_frame_type")) {
+      return true;
+    }
+  }
+  return v4l2_ctrl_press_button(fd, V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME,
+                                "force_key_frame");
 }
 
 static int nxp_calculate_intra_refresh_mbs(int width, int height,
@@ -752,7 +825,7 @@ static int nxp_calculate_intra_refresh_mbs(int width, int height,
 }  // namespace
 
 static bool nxp_v4l2_set_cbr_bitrate_kbits(int bitrate_kbits) {
-  NxpV4L2ControlSession ctrl(kNxpV4L2EncoderDevice);
+  NxpV4L2ControlSession ctrl(kNxpV4L2EncoderDevice, true);
   if (!ctrl.valid()) return false;
 
   const auto bitrate_bits_per_second =
@@ -762,8 +835,7 @@ static bool nxp_v4l2_set_cbr_bitrate_kbits(int bitrate_kbits) {
   ok &= ctrl.set_menu(V4L2_CID_MPEG_VIDEO_BITRATE_MODE,
                       V4L2_MPEG_VIDEO_BITRATE_MODE_CBR,
                       "video_bitrate_mode");
-  ok &= ctrl.set_int(V4L2_CID_MPEG_VIDEO_BITRATE, bitrate_bits_per_second,
-                     "video_bitrate");
+  ok &= nxp_set_bitrate(bitrate_bits_per_second);
   ok &= ctrl.set_int(V4L2_CID_MPEG_VIDEO_FRAME_RC_ENABLE, 1,
                      "frame_level_rate_control_enable");
   return ok;
@@ -787,7 +859,7 @@ static std::string create_nxp_imx8_v4l2_stream(
   const auto bitrate_bits_per_second =
       openhd::kbits_to_bits_per_second(settings.h26x_bitrate_kbits);
 
-  NxpV4L2ControlSession ctrl(kNxpV4L2EncoderDevice);
+  NxpV4L2ControlSession ctrl(kNxpV4L2EncoderDevice, true);
 
   if (ctrl.valid()) {
     ctrl.set_menu(V4L2_CID_MPEG_VIDEO_BITRATE_MODE,

--- a/OpenHD/ohd_video/inc/gstreamerstream.h
+++ b/OpenHD/ohd_video/inc/gstreamerstream.h
@@ -55,6 +55,7 @@ class GStreamerStream : public CameraStream {
   ~GStreamerStream();
   void start_looping() override;
   void terminate_looping() override;
+  void request_keyframe() override;
 
  private:
   // Creates a valid gstreamer pipeline for the given camera,

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -448,6 +448,16 @@ void GStreamerStream::handle_update_arming_state(bool armed) {
   }
 }
 
+void GStreamerStream::request_keyframe() {
+  const auto camera = m_camera_holder->get_camera();
+  if (camera.requires_nxp_imx8_v4l2_pipeline()) {
+    if (!nxp_force_idr()) {
+      m_console->warn(
+          "NXP V4L2: failed to request IDR on active encoder fd");
+    }
+  }
+}
+
 void GStreamerStream::loop_infinite() {
   while (m_keep_looping) {
     try {

--- a/OpenHD/ohd_video/src/ohd_video_air.cpp
+++ b/OpenHD/ohd_video/src/ohd_video_air.cpp
@@ -87,6 +87,12 @@ OHDVideoAir::OHDVideoAir(std::vector<XCamera> cameras,
       [this](openhd::LinkActionHandler::LinkBitrateInformation lb) {
         this->handle_change_bitrate_request(lb);
       });
+  openhd::LinkActionHandler::instance().action_request_keyframe_register(
+      [this]() {
+        for (auto& stream : m_camera_streams) {
+          if (stream) stream->request_keyframe();
+        }
+      });
   auto cb_armed = [this](bool armed) { this->update_arming_state(armed); };
   openhd::ArmingStateHelper::instance().register_listener("ohd_video_air",
                                                           cb_armed);
@@ -104,6 +110,8 @@ OHDVideoAir::OHDVideoAir(std::vector<XCamera> cameras,
 OHDVideoAir::~OHDVideoAir() {
   openhd::ArmingStateHelper::instance().unregister_listener("ohd_video_air");
   openhd::LinkActionHandler::instance().action_request_bitrate_change_register(
+      nullptr);
+  openhd::LinkActionHandler::instance().action_request_keyframe_register(
       nullptr);
   // Stop all the camera stream(s)
   m_camera_streams.resize(0);


### PR DESCRIPTION
## Summary
- track the active NXP V4L2 encoder file descriptor for runtime controls
- add helper calls to update bitrate and trigger IDR frames without restarting the pipeline
- expose keyframe request handling through the video action handler and document the NXP-only runtime path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f00498dbc832f91265ff8043fb880)