### PR TITLE
Handle AUD flag per codec for NXP IMX8 pipeline

### DIFF
--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -621,8 +621,10 @@ static std::string create_nxp_imx8_v4l2_stream(
       "video/x-raw,format=NV12,width={},height={},framerate={}/1 ! ",
       device_index, width, height, framerate);
   ss << "queue max-size-buffers=4 leaky=downstream ! ";
-  ss << fmt::format("{} bitrate={} gop-size={} enable-aud=true ", encoder_name,
-                    settings.h26x_bitrate_kbits, keyframe_interval);
+  const std::string aud_parameter = use_h264 ? " enable-aud=true" : "";
+  ss << fmt::format("{} bitrate={} gop-size={}{} ", encoder_name,
+                    settings.h26x_bitrate_kbits, keyframe_interval,
+                    aud_parameter);
   if (use_intra_refresh) {
     ss << fmt::format("intra-refresh={} ", intra_refresh_mbs);
   }


### PR DESCRIPTION
## Summary
- avoid setting enable-aud for H.265 when building the NXP i.MX8 V4L2 encoder pipeline
- keep AUD enabled only for H.264 configurations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69488caf01e4832fb147d24b853de76f)