### PR TITLE
Enable intra refresh for NXP imxvpu H.265 pipeline

### DIFF
--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -608,14 +608,8 @@ static std::string create_nxp_imx8_v4l2_stream(
   const int keyframe_interval =
       settings.h26x_keyframe_interval > 0 ? settings.h26x_keyframe_interval
                                           : DEFAULT_KEYFRAME_INTERVAL;
-  // Intra refresh currently supported only for H.264 on this encoder.
-  // Disable for H.265 to avoid unsupported configuration (see upstream issues).
-  const bool use_intra_refresh = use_h264 &&
+  const bool use_intra_refresh =
       settings.h26x_intra_refresh_type != -1 && keyframe_interval > 0;
-  const int intra_refresh_mbs =
-      use_intra_refresh
-          ? rpi_calculate_intra_refresh_period(width, height, keyframe_interval)
-          : 0;
 
   std::stringstream ss;
   ss << fmt::format(
@@ -628,7 +622,7 @@ static std::string create_nxp_imx8_v4l2_stream(
                     settings.h26x_bitrate_kbits, keyframe_interval,
                     aud_parameter);
   if (use_intra_refresh) {
-    ss << fmt::format("intra-refresh={} ", intra_refresh_mbs);
+    ss << "use-intra-refresh=true ";
   }
   ss << "! ";
   return ss.str();


### PR DESCRIPTION
## Summary
- simplify the NXP imx8 V4L2 pipeline configuration
- use the encoder's use-intra-refresh flag for both H.264 and H.265 without manual macroblock calculations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69492672e968832f9f288f309fb9d61b)