### PR TITLE
Add MAVLink AUD toggle for NXP VPU pipeline

### DIFF
--- a/OpenHD/ohd_video/inc/camera_holder.h
+++ b/OpenHD/ohd_video/inc/camera_holder.h
@@ -118,6 +118,12 @@ class CameraHolder :
     persist();
     return true;
   }
+  bool set_nxp_enable_aud(int value) {
+    if (!openhd::validate_yes_or_no(value)) return false;
+    unsafe_get_settings().nxp_enable_aud = static_cast<bool>(value);
+    persist();
+    return true;
+  }
   bool set_openhd_flip(int value) {
     if (!(value >= OPENHD_FLIP_NONE &&
           value <= OPENHD_FLIP_VERTICAL_AND_HORIZONTAL))

--- a/OpenHD/ohd_video/inc/camera_settings.hpp
+++ b/OpenHD/ohd_video/inc/camera_settings.hpp
@@ -108,6 +108,8 @@ struct CameraSettings {
   // N of slices. Not supported on all hardware (none to be exact unless the
   // cisco sw encoder) as of now 0 == frame slicing off
   int h26x_num_slices = 0;
+  // Whether to emit Access Unit Delimiters in the NXP VPU pipeline (h264 only)
+  bool nxp_enable_aud = true;
   // enable/disable recording to file
   int air_recording = AIR_RECORDING_OFF;
   //

--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -617,7 +617,8 @@ static std::string create_nxp_imx8_v4l2_stream(
       "video/x-raw,format=NV12,width={},height={},framerate={}/1 ! ",
       device_index, width, height, framerate);
   ss << "queue max-size-buffers=4 leaky=downstream ! ";
-  const std::string aud_parameter = use_h264 ? " enable-aud=true" : "";
+  const std::string aud_parameter =
+      use_h264 && settings.nxp_enable_aud ? " enable-aud=true" : "";
   ss << fmt::format("{} bitrate={} gop-size={}{} ", encoder_name,
                     settings.h26x_bitrate_kbits, keyframe_interval,
                     aud_parameter);

--- a/OpenHD/ohd_video/src/camera_holder.cpp
+++ b/OpenHD/ohd_video/src/camera_holder.cpp
@@ -37,7 +37,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(VideoFormat, videoCodec, width, height,
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(
     CameraSettings, enable_streaming, streamed_video_format, h26x_bitrate_kbits,
     h26x_keyframe_interval, h26x_intra_refresh_type, h26x_num_slices,
-    air_recording, camera_rotation_degree, openhd_flip, openhd_brightness,
+    nxp_enable_aud, air_recording, camera_rotation_degree, openhd_flip, openhd_brightness,
     openhd_sharpness, openhd_saturation, openhd_contrast,
     // rpi libcamera specific IQ params begin
     rpi_libcamera_ev_value, rpi_libcamera_denoise_index,
@@ -87,6 +87,15 @@ std::vector<openhd::Setting> CameraHolder::get_all_settings() {
         openhd::IntSetting{
             video_codec_to_int(get_settings().streamed_video_format.videoCodec),
             c_codec}});
+  }
+  if (m_camera.requires_nxp_imx8_v4l2_pipeline()) {
+    auto c_nxp_aud = [this](std::string, int value) {
+      return set_nxp_enable_aud(value);
+    };
+    ret.push_back(openhd::Setting{
+        "NXP_ENABLE_AUD",
+        openhd::IntSetting{static_cast<int>(get_settings().nxp_enable_aud),
+                           c_nxp_aud}});
   }
   {
     // Supported by all cameras, since it has actually nothing to do with the


### PR DESCRIPTION
## Summary
- add a persisted nxp_enable_aud camera setting to control AUD insertion
- expose the new toggle as a camera MAVLink setting for NXP IMX8 VPU pipelines
- honor the setting when building the NXP GStreamer pipeline so AUDs can be enabled or disabled

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69495b088c6c832f952f7af8c3551cda)