### PR TITLE
Extend UART telemetry configuration and prioritization

### DIFF
--- a/OpenHD/ohd_telemetry/CMakeLists.txt
+++ b/OpenHD/ohd_telemetry/CMakeLists.txt
@@ -44,6 +44,10 @@ SET(sources
     "src/internal/onboard_computer_status_rpi.hpp"
     "src/internal/OnboardComputerStatusProvider.cpp"
     "src/internal/OnboardComputerStatusProvider.h"
+    "src/internal/UartDeduplicator.cpp"
+    "src/internal/UartDeduplicator.h"
+    "src/internal/UartPrioritizer.cpp"
+    "src/internal/UartPrioritizer.h"
         src/last_known_position/LastKnowPosition.cpp
      src/last_known_position/LastKnowPosition.h
 

--- a/OpenHD/ohd_telemetry/README.md
+++ b/OpenHD/ohd_telemetry/README.md
@@ -12,6 +12,25 @@ An endpoint (under src/endpoints) receives and/ or transmits a continuous mavlin
 4) tcp - for creating a mavlink server on the ground / air, can also be used by GCS, not preferred but
    usefully in some networking situations.
 
+### UART roles and configuration
+OpenHD exposes every UART over MAVLink so that wiring choices are documented and configurable without
+rebuilding the image:
+
+- **Air unit**
+  - **Flight controller telemetry (RX/TX):** `FC_UART_CONN`, `FC_UART_BAUD`, `FC_UART_FLWCTL` remain the primary knobs.
+  - **OpenHD telemetry UART (RX/TX):** gate the link with `OHD_UART_EN`, select the device via `OHD_UART_TLM`
+    (for example `/dev/serial1`), and tune `OHD_UART_BAUD` / `OHD_UART_FLW`. Message buckets are prioritised via
+    `UART_PRI_RC`, `UART_PRI_OHD`, and `UART_PRI_FC` (RC/control traffic highest by default, OpenHD mid, FC lowest).
+
+- **Ground unit**
+  - **Tracker output (TX only):** `TRACKER_UART_OUT` chooses the port, `TRACK_UART_BAUD` and `TRACK_UART_FLOW`
+    control bandwidth/flow-control. Reading is intentionally disabled for this port to match one-way tracker wiring.
+  - **OpenHD telemetry UART (RX/TX):** mirror the air-side parameters (`OHD_UART_EN`, `OHD_UART_TLM`,
+    `OHD_UART_BAUD`, `OHD_UART_FLW`, plus the three `UART_PRI_*` settings) so both sides can be aligned from a GCS.
+
+UART telemetry frames are de-duplicated against traffic that already arrived via wifibroadcast using
+`sysid/compid/msgid/seq` so consumers do not see duplicate MAVLink messages when multiple links are active.
+
 ## OHDMainComponent (Component)
 Used by both the air and ground unit implementation, generates fire-and-forget mavlink statistics
 
@@ -74,4 +93,3 @@ station itself, but rather on another device (for example a smartphone connected
 arises from the necessity to route the messages over another network. For this, we probably should go with TCP, but the
 TCPEndpoint still needs some work. The corresponding endpoint in QOpenHD can be found
 here: https://github.com/OpenHD/QOpenHD/blob/consti-test/app/telemetry/OHDConnection.h
-

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.cpp
@@ -94,7 +94,9 @@ void AirTelemetry::send_messages_ground_unit(
     m_tcp_server->sendMessages(messages);
   }
   if (m_openhd_uart_serial) {
-    m_openhd_uart_serial->send_messages_if_enabled(messages);
+    const auto prioritized_messages = m_uart_prioritizer.sort_by_priority(
+        messages, get_openhd_uart_priority_profile());
+    m_openhd_uart_serial->send_messages_if_enabled(prioritized_messages);
   }
 }
 
@@ -218,6 +220,15 @@ void AirTelemetry::add_settings_camera_component(
   m_console->debug("Added camera component");
 }
 
+UartPriorityProfile AirTelemetry::get_openhd_uart_priority_profile() const {
+  const auto& settings = m_air_settings->get_settings();
+  UartPriorityProfile profile{};
+  profile.rc_priority = settings.openhd_uart_priority_rc;
+  profile.openhd_priority = settings.openhd_uart_priority_openhd;
+  profile.flight_controller_priority = settings.openhd_uart_priority_fc;
+  return profile;
+}
+
 std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
   std::vector<openhd::Setting> ret{};
   using namespace openhd::telemetry;
@@ -257,6 +268,47 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
     setup_openhd_uart_telemetry();
     return true;
   };
+  auto c_openhd_uart_enable = [this](std::string, int value) {
+    if (!openhd::validate_yes_or_no(value)) return false;
+    m_air_settings->unsafe_get_settings().openhd_uart_telemetry_enabled = value;
+    m_air_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
+  auto c_openhd_uart_baud = [this](std::string, int value) {
+    if (!SerialEndpoint::is_valid_linux_baudrate(value)) return false;
+    m_air_settings->unsafe_get_settings().openhd_uart_telemetry_baudrate =
+        value;
+    m_air_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
+  auto c_openhd_uart_flow = [this](std::string, int value) {
+    if (!openhd::validate_yes_or_no(value)) return false;
+    m_air_settings->unsafe_get_settings().openhd_uart_telemetry_flow_control =
+        value;
+    m_air_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
+  auto c_openhd_uart_prio_rc = [this](std::string, int value) {
+    if (!UartPrioritizer::valid_priority_value(value)) return false;
+    m_air_settings->unsafe_get_settings().openhd_uart_priority_rc = value;
+    m_air_settings->persist(false);
+    return true;
+  };
+  auto c_openhd_uart_prio_ohd = [this](std::string, int value) {
+    if (!UartPrioritizer::valid_priority_value(value)) return false;
+    m_air_settings->unsafe_get_settings().openhd_uart_priority_openhd = value;
+    m_air_settings->persist(false);
+    return true;
+  };
+  auto c_openhd_uart_prio_fc = [this](std::string, int value) {
+    if (!UartPrioritizer::valid_priority_value(value)) return false;
+    m_air_settings->unsafe_get_settings().openhd_uart_priority_fc = value;
+    m_air_settings->persist(false);
+    return true;
+  };
   ret.push_back(openhd::Setting{
       air::FC_UART_CONNECTION_TYPE,
       openhd::StringSetting{
@@ -282,6 +334,40 @@ std::vector<openhd::Setting> AirTelemetry::get_all_settings() {
       openhd::StringSetting{
           m_air_settings->get_settings().openhd_uart_telemetry_connection,
           c_openhd_uart_conn}});
+  ret.push_back(openhd::Setting{
+      air::OPENHD_UART_TELEMETRY_ENABLE_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_air_settings->get_settings().openhd_uart_telemetry_enabled),
+          c_openhd_uart_enable}});
+  ret.push_back(openhd::Setting{
+      air::OPENHD_UART_TELEMETRY_BAUD_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_air_settings->get_settings().openhd_uart_telemetry_baudrate),
+          c_openhd_uart_baud}});
+  ret.push_back(openhd::Setting{
+      air::OPENHD_UART_TELEMETRY_FLOW_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_air_settings->get_settings().openhd_uart_telemetry_flow_control),
+          c_openhd_uart_flow}});
+  ret.push_back(openhd::Setting{
+      air::OPENHD_UART_PRIORITY_RC_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(m_air_settings->get_settings().openhd_uart_priority_rc),
+          c_openhd_uart_prio_rc}});
+  ret.push_back(openhd::Setting{
+      air::OPENHD_UART_PRIORITY_OHD_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_air_settings->get_settings().openhd_uart_priority_openhd),
+          c_openhd_uart_prio_ohd}});
+  ret.push_back(openhd::Setting{
+      air::OPENHD_UART_PRIORITY_FC_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(m_air_settings->get_settings().openhd_uart_priority_fc),
+          c_openhd_uart_prio_fc}});
   // and this allows an advanced user to change its air unit to a ground unit
   // only expose this setting if OpenHD uses the file workaround to figure out
   // air or ground.
@@ -325,6 +411,10 @@ void AirTelemetry::setup_uart() {
 void AirTelemetry::setup_openhd_uart_telemetry() {
   if (!m_openhd_uart_serial) return;
   const auto& settings = m_air_settings->get_settings();
+  if (!settings.openhd_uart_telemetry_enabled) {
+    m_openhd_uart_serial->disable();
+    return;
+  }
   const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
       settings.openhd_uart_telemetry_connection);
   if (!uart_linux_fd.has_value()) {
@@ -333,13 +423,16 @@ void AirTelemetry::setup_openhd_uart_telemetry() {
   }
   SerialEndpoint::HWOptions options{};
   options.linux_filename = uart_linux_fd.value();
-  options.baud_rate = 115200;
+  options.baud_rate = settings.openhd_uart_telemetry_baudrate;
+  options.flow_control = settings.openhd_uart_telemetry_flow_control;
   options.enable_reading = true;
   m_openhd_uart_serial->configure(
       options, "openhd_uart",
       [this](const std::vector<MavlinkMessage> messages) {
-        auto copy = messages;
-        this->on_messages_ground_unit(copy);
+        auto filtered = m_uart_deduplicator.filter_and_mark(messages);
+        if (!filtered.empty()) {
+          this->on_messages_ground_unit(filtered);
+        }
       });
 }
 
@@ -352,6 +445,7 @@ void AirTelemetry::configure_openhd_uart_telemetry(
                   device_path.value());
   m_air_settings->unsafe_get_settings().openhd_uart_telemetry_connection =
       device_path.value();
+  m_air_settings->unsafe_get_settings().openhd_uart_telemetry_enabled = true;
   m_air_settings->persist();
   setup_openhd_uart_telemetry();
 }
@@ -359,6 +453,9 @@ void AirTelemetry::configure_openhd_uart_telemetry(
 void AirTelemetry::set_link_handle(std::shared_ptr<OHDLink> link) {
   m_wb_endpoint = std::make_unique<WBEndpoint>(link, "wb_tx");
   m_wb_endpoint->registerCallback([this](std::vector<MavlinkMessage> messages) {
-    on_messages_ground_unit(messages);
+    auto filtered = m_uart_deduplicator.filter_and_mark(messages);
+    if (!filtered.empty()) {
+      on_messages_ground_unit(filtered);
+    }
   });
 }

--- a/OpenHD/ohd_telemetry/src/AirTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetry.h
@@ -29,6 +29,8 @@
 
 #include "endpoints/SerialEndpoint.h"
 #include "internal/OHDMainComponent.h"
+#include "internal/UartDeduplicator.h"
+#include "internal/UartPrioritizer.h"
 #include "openhd_link_statistics.hpp"
 #include "openhd_platform.h"
 #include "openhd_settings_imp.h"
@@ -101,6 +103,7 @@ class AirTelemetry : public MavlinkSystem {
   // called every time one or more messages from the ground unit are received
   void on_messages_ground_unit(std::vector<MavlinkMessage>& messages);
   // R.N only on air, and only FC uart settings
+  [[nodiscard]] UartPriorityProfile get_openhd_uart_priority_profile() const;
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
   void setup_openhd_uart_telemetry();
@@ -113,6 +116,8 @@ class AirTelemetry : public MavlinkSystem {
   std::unique_ptr<WBEndpoint> m_wb_endpoint;
   // shared because we also push it onto our components list
   std::shared_ptr<OHDMainComponent> m_ohd_main_component;
+  UartDeduplicator m_uart_deduplicator;
+  UartPrioritizer m_uart_prioritizer;
   std::mutex m_components_lock;
   std::vector<std::shared_ptr<MavlinkComponent>> m_components;
   std::shared_ptr<XMavlinkParamProvider> m_generic_mavlink_param_provider;

--- a/OpenHD/ohd_telemetry/src/AirTelemetrySettings.cpp
+++ b/OpenHD/ohd_telemetry/src/AirTelemetrySettings.cpp
@@ -30,7 +30,13 @@ namespace openhd::telemetry::air {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Settings, fc_uart_connection_type,
                                    fc_uart_baudrate, fc_uart_flow_control,
                                    fc_battery_n_cells,
-                                   openhd_uart_telemetry_connection);
+                                   openhd_uart_telemetry_connection,
+                                   openhd_uart_telemetry_enabled,
+                                   openhd_uart_telemetry_baudrate,
+                                   openhd_uart_telemetry_flow_control,
+                                   openhd_uart_priority_rc,
+                                   openhd_uart_priority_openhd,
+                                   openhd_uart_priority_fc);
 
 std::optional<Settings> SettingsHolder::impl_deserialize(
     const std::string &file_as_string) const {

--- a/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
+++ b/OpenHD/ohd_telemetry/src/AirTelemetrySettings.h
@@ -62,6 +62,12 @@ struct Settings {
   // 0 means not configured (do not use)
   int fc_battery_n_cells = 0;
   std::string openhd_uart_telemetry_connection = UART_CONNECTION_TYPE_DISABLE;
+  bool openhd_uart_telemetry_enabled = true;
+  int openhd_uart_telemetry_baudrate = DEFAULT_UART_BAUDRATE;
+  bool openhd_uart_telemetry_flow_control = false;
+  int openhd_uart_priority_rc = 3;
+  int openhd_uart_priority_openhd = 2;
+  int openhd_uart_priority_fc = 1;
 };
 
 // 16 chars limit !
@@ -70,6 +76,12 @@ static constexpr auto FC_UART_BAUD_RATE = "FC_UART_BAUD";
 static constexpr auto FC_UART_FLOW_CONTROL = "FC_UART_FLWCTL";
 static constexpr auto FC_BATT_N_CELLS = "FC_BATT_N_CELLS";
 static constexpr auto OPENHD_UART_TELEMETRY_PARAM = "OHD_UART_TLM";
+static constexpr auto OPENHD_UART_TELEMETRY_ENABLE_PARAM = "OHD_UART_EN";
+static constexpr auto OPENHD_UART_TELEMETRY_BAUD_PARAM = "OHD_UART_BAUD";
+static constexpr auto OPENHD_UART_TELEMETRY_FLOW_PARAM = "OHD_UART_FLW";
+static constexpr auto OPENHD_UART_PRIORITY_RC_PARAM = "UART_PRI_RC";
+static constexpr auto OPENHD_UART_PRIORITY_OHD_PARAM = "UART_PRI_OHD";
+static constexpr auto OPENHD_UART_PRIORITY_FC_PARAM = "UART_PRI_FC";
 
 class SettingsHolder : public openhd::PersistentSettings<Settings> {
  public:

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.cpp
@@ -197,7 +197,9 @@ void GroundTelemetry::send_messages_ground_station_clients(
     m_tcp_server->sendMessages(messages);
   }
   if (m_openhd_uart_serial) {
-    m_openhd_uart_serial->send_messages_if_enabled(messages);
+    const auto prioritized_messages = m_uart_prioritizer.sort_by_priority(
+        messages, get_openhd_uart_priority_profile());
+    m_openhd_uart_serial->send_messages_if_enabled(prioritized_messages);
   }
 }
 
@@ -312,6 +314,15 @@ void GroundTelemetry::remove_external_ground_station_ip(
   }
 }
 
+UartPriorityProfile GroundTelemetry::get_openhd_uart_priority_profile() const {
+  const auto& settings = m_gnd_settings->get_settings();
+  UartPriorityProfile profile{};
+  profile.rc_priority = settings.openhd_uart_priority_rc;
+  profile.openhd_priority = settings.openhd_uart_priority_openhd;
+  profile.flight_controller_priority = settings.openhd_uart_priority_fc;
+  return profile;
+}
+
 std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
   std::vector<openhd::Setting> ret{};
   // and this allows an advanced user to change its air unit to a ground unit
@@ -392,11 +403,35 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
       setup_uart();
       return true;
     };
+    auto c_gnd_uart_baudrate = [this](std::string, int value) {
+      if (!SerialEndpoint::is_valid_linux_baudrate(value)) return false;
+      m_gnd_settings->unsafe_get_settings().gnd_uart_baudrate = value;
+      m_gnd_settings->persist();
+      setup_uart();
+      return true;
+    };
+    auto c_gnd_uart_flow = [this](std::string, int value) {
+      if (!openhd::validate_yes_or_no(value)) return false;
+      m_gnd_settings->unsafe_get_settings().gnd_uart_flow_control = value;
+      m_gnd_settings->persist();
+      setup_uart();
+      return true;
+    };
     ret.push_back(openhd::Setting{
         "TRACKER_UART_OUT",
         openhd::StringSetting{
             m_gnd_settings->get_settings().gnd_uart_connection_type,
             c_gnd_uart_connection_type}});
+    ret.push_back(openhd::Setting{
+        openhd::telemetry::ground::TRACKER_UART_BAUD_PARAM,
+        openhd::IntSetting{
+            static_cast<int>(m_gnd_settings->get_settings().gnd_uart_baudrate),
+            c_gnd_uart_baudrate}});
+    ret.push_back(openhd::Setting{
+        openhd::telemetry::ground::TRACKER_UART_FLOW_PARAM,
+        openhd::IntSetting{
+            static_cast<int>(m_gnd_settings->get_settings().gnd_uart_flow_control),
+            c_gnd_uart_flow}});
   }
   auto c_openhd_uart_conn = [this](std::string, std::string value) {
     m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_connection =
@@ -405,11 +440,86 @@ std::vector<openhd::Setting> GroundTelemetry::get_all_settings() {
     setup_openhd_uart_telemetry();
     return true;
   };
+  auto c_openhd_uart_enable = [this](std::string, int value) {
+    if (!openhd::validate_yes_or_no(value)) return false;
+    m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_enabled = value;
+    m_gnd_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
+  auto c_openhd_uart_baud = [this](std::string, int value) {
+    if (!SerialEndpoint::is_valid_linux_baudrate(value)) return false;
+    m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_baudrate =
+        value;
+    m_gnd_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
+  auto c_openhd_uart_flow = [this](std::string, int value) {
+    if (!openhd::validate_yes_or_no(value)) return false;
+    m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_flow_control =
+        value;
+    m_gnd_settings->persist();
+    setup_openhd_uart_telemetry();
+    return true;
+  };
+  auto c_openhd_uart_prio_rc = [this](std::string, int value) {
+    if (!UartPrioritizer::valid_priority_value(value)) return false;
+    m_gnd_settings->unsafe_get_settings().openhd_uart_priority_rc = value;
+    m_gnd_settings->persist(false);
+    return true;
+  };
+  auto c_openhd_uart_prio_ohd = [this](std::string, int value) {
+    if (!UartPrioritizer::valid_priority_value(value)) return false;
+    m_gnd_settings->unsafe_get_settings().openhd_uart_priority_openhd = value;
+    m_gnd_settings->persist(false);
+    return true;
+  };
+  auto c_openhd_uart_prio_fc = [this](std::string, int value) {
+    if (!UartPrioritizer::valid_priority_value(value)) return false;
+    m_gnd_settings->unsafe_get_settings().openhd_uart_priority_fc = value;
+    m_gnd_settings->persist(false);
+    return true;
+  };
   ret.push_back(openhd::Setting{
       openhd::telemetry::ground::OPENHD_UART_TELEMETRY_PARAM,
       openhd::StringSetting{
           m_gnd_settings->get_settings().openhd_uart_telemetry_connection,
           c_openhd_uart_conn}});
+  ret.push_back(openhd::Setting{
+      openhd::telemetry::ground::OPENHD_UART_TELEMETRY_ENABLE_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_gnd_settings->get_settings().openhd_uart_telemetry_enabled),
+          c_openhd_uart_enable}});
+  ret.push_back(openhd::Setting{
+      openhd::telemetry::ground::OPENHD_UART_TELEMETRY_BAUD_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_gnd_settings->get_settings().openhd_uart_telemetry_baudrate),
+          c_openhd_uart_baud}});
+  ret.push_back(openhd::Setting{
+      openhd::telemetry::ground::OPENHD_UART_TELEMETRY_FLOW_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_gnd_settings->get_settings().openhd_uart_telemetry_flow_control),
+          c_openhd_uart_flow}});
+  ret.push_back(openhd::Setting{
+      openhd::telemetry::ground::OPENHD_UART_PRIORITY_RC_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(m_gnd_settings->get_settings().openhd_uart_priority_rc),
+          c_openhd_uart_prio_rc}});
+  ret.push_back(openhd::Setting{
+      openhd::telemetry::ground::OPENHD_UART_PRIORITY_OHD_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(
+              m_gnd_settings->get_settings().openhd_uart_priority_openhd),
+          c_openhd_uart_prio_ohd}});
+  ret.push_back(openhd::Setting{
+      openhd::telemetry::ground::OPENHD_UART_PRIORITY_FC_PARAM,
+      openhd::IntSetting{
+          static_cast<int>(m_gnd_settings->get_settings().openhd_uart_priority_fc),
+          c_openhd_uart_prio_fc}});
   openhd::testing::append_dummy_if_empty(ret);
   return ret;
 }
@@ -423,8 +533,8 @@ void GroundTelemetry::setup_uart() {
     SerialEndpoint::HWOptions options{};
     options.linux_filename = uart_linux_fd.value();
     options.baud_rate = m_gnd_settings->get_settings().gnd_uart_baudrate;
-    options.flow_control = false;
-    options.enable_reading = true;
+    options.flow_control = m_gnd_settings->get_settings().gnd_uart_flow_control;
+    options.enable_reading = false;
     m_endpoint_tracker->configure(
         options, "gnd_ser",
         [this](std::vector<MavlinkMessage> messages) {
@@ -437,20 +547,28 @@ void GroundTelemetry::setup_uart() {
 
 void GroundTelemetry::setup_openhd_uart_telemetry() {
   if (!m_openhd_uart_serial) return;
+  const auto& settings = m_gnd_settings->get_settings();
+  if (!settings.openhd_uart_telemetry_enabled) {
+    m_openhd_uart_serial->disable();
+    return;
+  }
   const auto uart_linux_fd = serial_openhd_param_to_linux_fd(
-      m_gnd_settings->get_settings().openhd_uart_telemetry_connection);
+      settings.openhd_uart_telemetry_connection);
   if (!uart_linux_fd.has_value()) {
     m_openhd_uart_serial->disable();
     return;
   }
   SerialEndpoint::HWOptions options{};
   options.linux_filename = uart_linux_fd.value();
-  options.baud_rate = 115200;
+  options.baud_rate = settings.openhd_uart_telemetry_baudrate;
+  options.flow_control = settings.openhd_uart_telemetry_flow_control;
   options.enable_reading = true;
   m_openhd_uart_serial->configure(
       options, "openhd_uart",
       [this](const std::vector<MavlinkMessage> messages) {
-        on_messages_ground_station_clients(messages);
+        auto filtered = m_uart_deduplicator.filter_and_mark(messages);
+        if (filtered.empty()) return;
+        on_messages_ground_station_clients(filtered);
       });
 }
 
@@ -463,6 +581,7 @@ void GroundTelemetry::configure_openhd_uart_telemetry(
                   device_path.value());
   m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_connection =
       device_path.value();
+  m_gnd_settings->unsafe_get_settings().openhd_uart_telemetry_enabled = true;
   m_gnd_settings->persist();
   setup_openhd_uart_telemetry();
 }
@@ -472,7 +591,10 @@ void GroundTelemetry::set_link_handle(std::shared_ptr<OHDLink> link) {
   assert(m_wb_endpoint == nullptr);
   m_wb_endpoint = std::make_unique<WBEndpoint>(link, "wb_tx");
   m_wb_endpoint->registerCallback([this](std::vector<MavlinkMessage> messages) {
-    on_messages_air_unit(messages);
+    auto filtered = m_uart_deduplicator.filter_and_mark(messages);
+    if (!filtered.empty()) {
+      on_messages_air_unit(filtered);
+    }
   });
 }
 

--- a/OpenHD/ohd_telemetry/src/GroundTelemetry.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetry.h
@@ -32,6 +32,8 @@
 #include "endpoints/UDPEndpoint.h"
 #include "endpoints/WBEndpoint.h"
 #include "internal/OHDMainComponent.h"
+#include "internal/UartDeduplicator.h"
+#include "internal/UartPrioritizer.h"
 #include "mavsdk_temporary/XMavlinkParamProvider.h"
 #include "openhd_action_handler.h"
 #include "openhd_external_device.h"
@@ -107,6 +109,7 @@ class GroundTelemetry : public MavlinkSystem {
   std::vector<openhd::Setting> get_all_settings();
   void setup_uart();
   void setup_openhd_uart_telemetry();
+  [[nodiscard]] UartPriorityProfile get_openhd_uart_priority_profile() const;
 #ifdef OPENHD_TELEMETRY_SDL_FOR_JOYSTICK_FOUND
   void enable_joystick();
   void disable_joystick();
@@ -123,6 +126,8 @@ class GroundTelemetry : public MavlinkSystem {
   std::unique_ptr<TCPEndpoint> m_tcp_server = nullptr;
   // send/receive data via wb
   std::unique_ptr<WBEndpoint> m_wb_endpoint;
+  UartDeduplicator m_uart_deduplicator;
+  UartPrioritizer m_uart_prioritizer;
   std::shared_ptr<OHDMainComponent> m_ohd_main_component;
   std::mutex m_components_lock;
   std::vector<std::shared_ptr<MavlinkComponent>> m_components;

--- a/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.cpp
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.cpp
@@ -30,8 +30,14 @@ namespace openhd::telemetry::ground {
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Settings, enable_rc_over_joystick,
                                    rc_over_joystick_update_rate_hz,
                                    rc_channel_mapping, gnd_uart_connection_type,
-                                   gnd_uart_baudrate,
-                                   openhd_uart_telemetry_connection);
+                                   gnd_uart_baudrate, gnd_uart_flow_control,
+                                   openhd_uart_telemetry_connection,
+                                   openhd_uart_telemetry_enabled,
+                                   openhd_uart_telemetry_baudrate,
+                                   openhd_uart_telemetry_flow_control,
+                                   openhd_uart_priority_rc,
+                                   openhd_uart_priority_openhd,
+                                   openhd_uart_priority_fc);
 
 std::optional<Settings>
 openhd::telemetry::ground::SettingsHolder::impl_deserialize(

--- a/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.h
+++ b/OpenHD/ohd_telemetry/src/GroundTelemetrySettings.h
@@ -42,10 +42,25 @@ struct Settings {
   // This is for outputting FC mavlink data via serial on the ground station
   std::string gnd_uart_connection_type = UART_CONNECTION_TYPE_DISABLE;
   int gnd_uart_baudrate = 115200;
+  bool gnd_uart_flow_control = false;
   std::string openhd_uart_telemetry_connection = UART_CONNECTION_TYPE_DISABLE;
+  bool openhd_uart_telemetry_enabled = true;
+  int openhd_uart_telemetry_baudrate = 115200;
+  bool openhd_uart_telemetry_flow_control = false;
+  int openhd_uart_priority_rc = 3;
+  int openhd_uart_priority_openhd = 2;
+  int openhd_uart_priority_fc = 1;
 };
 
 static constexpr auto OPENHD_UART_TELEMETRY_PARAM = "OHD_UART_TLM";
+static constexpr auto OPENHD_UART_TELEMETRY_ENABLE_PARAM = "OHD_UART_EN";
+static constexpr auto OPENHD_UART_TELEMETRY_BAUD_PARAM = "OHD_UART_BAUD";
+static constexpr auto OPENHD_UART_TELEMETRY_FLOW_PARAM = "OHD_UART_FLW";
+static constexpr auto OPENHD_UART_PRIORITY_RC_PARAM = "UART_PRI_RC";
+static constexpr auto OPENHD_UART_PRIORITY_OHD_PARAM = "UART_PRI_OHD";
+static constexpr auto OPENHD_UART_PRIORITY_FC_PARAM = "UART_PRI_FC";
+static constexpr auto TRACKER_UART_BAUD_PARAM = "TRACK_UART_BAUD";
+static constexpr auto TRACKER_UART_FLOW_PARAM = "TRACK_UART_FLOW";
 
 static bool valid_joystick_update_rate(int value) {
   return value >= 1 && value <= 150;

--- a/OpenHD/ohd_telemetry/src/internal/UartDeduplicator.cpp
+++ b/OpenHD/ohd_telemetry/src/internal/UartDeduplicator.cpp
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#include "UartDeduplicator.h"
+
+UartDeduplicator::UartDeduplicator(std::chrono::milliseconds window)
+    : m_window(window) {}
+
+uint64_t UartDeduplicator::create_key(const mavlink_message_t& msg) const {
+  // sysid, compid and msgid are enough to uniquely identify the source. Adding
+  // the sequence number allows distinguishing between subsequent messages of
+  // the same type.
+  return (static_cast<uint64_t>(msg.sysid) << 40u) |
+         (static_cast<uint64_t>(msg.compid) << 32u) |
+         (static_cast<uint64_t>(msg.msgid) << 16u) |
+         static_cast<uint64_t>(msg.seq);
+}
+
+void UartDeduplicator::prune_locked(
+    std::chrono::steady_clock::time_point now) {
+  for (auto it = m_recent_messages.begin(); it != m_recent_messages.end();) {
+    if ((now - it->second) > m_window) {
+      it = m_recent_messages.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+std::vector<MavlinkMessage> UartDeduplicator::filter_and_mark(
+    const std::vector<MavlinkMessage>& messages) {
+  const auto now = std::chrono::steady_clock::now();
+  std::lock_guard<std::mutex> guard(m_mutex);
+  prune_locked(now);
+  std::vector<MavlinkMessage> filtered;
+  filtered.reserve(messages.size());
+  for (const auto& message : messages) {
+    const auto key = create_key(message.m);
+    const auto it = m_recent_messages.find(key);
+    if (it != m_recent_messages.end() &&
+        (now - it->second) <= m_window) {
+      continue;
+    }
+    filtered.push_back(message);
+    m_recent_messages[key] = now;
+  }
+  return filtered;
+}

--- a/OpenHD/ohd_telemetry/src/internal/UartDeduplicator.h
+++ b/OpenHD/ohd_telemetry/src/internal/UartDeduplicator.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#ifndef OPENHD_OPENHD_OHD_TELEMETRY_SRC_INTERNAL_UARTDEDUPLICATOR_H_
+#define OPENHD_OPENHD_OHD_TELEMETRY_SRC_INTERNAL_UARTDEDUPLICATOR_H_
+
+#include <chrono>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "mav_include.h"
+
+/**
+ * Keeps track of recently forwarded mavlink messages and drops duplicates
+ * regardless of which link they arrive on (wifibroadcast or UART). This lets
+ * us transmit on multiple paths while only forwarding a single copy to
+ * consumers.
+ */
+class UartDeduplicator {
+ public:
+  explicit UartDeduplicator(
+      std::chrono::milliseconds window = std::chrono::milliseconds(1500));
+
+  std::vector<MavlinkMessage> filter_and_mark(
+      const std::vector<MavlinkMessage>& messages);
+
+ private:
+  [[nodiscard]] uint64_t create_key(const mavlink_message_t& msg) const;
+  void prune_locked(std::chrono::steady_clock::time_point now);
+
+ private:
+  std::unordered_map<uint64_t, std::chrono::steady_clock::time_point>
+      m_recent_messages;
+  std::chrono::milliseconds m_window;
+  std::mutex m_mutex;
+};
+
+#endif  // OPENHD_OPENHD_OHD_TELEMETRY_SRC_INTERNAL_UARTDEDUPLICATOR_H_

--- a/OpenHD/ohd_telemetry/src/internal/UartPrioritizer.cpp
+++ b/OpenHD/ohd_telemetry/src/internal/UartPrioritizer.cpp
@@ -1,0 +1,67 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#include "UartPrioritizer.h"
+
+#include <algorithm>
+
+bool UartPrioritizer::valid_priority_value(int value) {
+  return value >= 0 && value <= 10;
+}
+
+int UartPrioritizer::determine_priority(
+    const MavlinkMessage& message, const UartPriorityProfile& profile) {
+  const auto& msg = message.m;
+  if (msg.msgid == MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE ||
+      msg.msgid == MAVLINK_MSG_ID_MANUAL_CONTROL ||
+      msg.msgid == MAVLINK_MSG_ID_RC_CHANNELS) {
+    return profile.rc_priority;
+  }
+  if (msg.sysid == OHD_SYS_ID_AIR || msg.sysid == OHD_SYS_ID_GROUND) {
+    return profile.openhd_priority;
+  }
+  if (msg.sysid == OHD_SYS_ID_FC || msg.sysid == OHD_SYS_ID_FC_BETAFLIGHT) {
+    return profile.flight_controller_priority;
+  }
+  return profile.default_priority;
+}
+
+std::vector<MavlinkMessage> UartPrioritizer::sort_by_priority(
+    const std::vector<MavlinkMessage>& messages,
+    const UartPriorityProfile& profile) const {
+  std::vector<std::pair<MavlinkMessage, int>> prioritized;
+  prioritized.reserve(messages.size());
+  for (const auto& message : messages) {
+    prioritized.emplace_back(message,
+                             determine_priority(message, profile));
+  }
+  std::stable_sort(
+      prioritized.begin(), prioritized.end(),
+      [](const auto& lhs, const auto& rhs) { return lhs.second > rhs.second; });
+  std::vector<MavlinkMessage> sorted;
+  sorted.reserve(prioritized.size());
+  for (auto& entry : prioritized) {
+    sorted.push_back(entry.first);
+  }
+  return sorted;
+}

--- a/OpenHD/ohd_telemetry/src/internal/UartPrioritizer.h
+++ b/OpenHD/ohd_telemetry/src/internal/UartPrioritizer.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+ * OpenHD
+ *
+ * Licensed under the GNU General Public License (GPL) Version 3.
+ *
+ * This software is provided "as-is," without warranty of any kind, express or
+ * implied, including but not limited to the warranties of merchantability,
+ * fitness for a particular purpose, and non-infringement. For details, see the
+ * full license in the LICENSE file provided with this source code.
+ *
+ * Non-Military Use Only:
+ * This software and its associated components are explicitly intended for
+ * civilian and non-military purposes. Use in any military or defense
+ * applications is strictly prohibited unless explicitly and individually
+ * licensed otherwise by the OpenHD Team.
+ *
+ * Contributors:
+ * A full list of contributors can be found at the OpenHD GitHub repository:
+ * https://github.com/OpenHD
+ *
+ * © OpenHD, All Rights Reserved.
+ ******************************************************************************/
+
+#ifndef OPENHD_OPENHD_OHD_TELEMETRY_SRC_INTERNAL_UARTPRIORITIZER_H_
+#define OPENHD_OPENHD_OHD_TELEMETRY_SRC_INTERNAL_UARTPRIORITIZER_H_
+
+#include <vector>
+
+#include "mav_include.h"
+
+struct UartPriorityProfile {
+  int rc_priority = 3;
+  int openhd_priority = 2;
+  int flight_controller_priority = 1;
+  int default_priority = 0;
+};
+
+class UartPrioritizer {
+ public:
+  static bool valid_priority_value(int value);
+  std::vector<MavlinkMessage> sort_by_priority(
+      const std::vector<MavlinkMessage>& messages,
+      const UartPriorityProfile& profile) const;
+
+ private:
+  static int determine_priority(const MavlinkMessage& message,
+                                const UartPriorityProfile& profile);
+};
+
+#endif  // OPENHD_OPENHD_OHD_TELEMETRY_SRC_INTERNAL_UARTPRIORITIZER_H_


### PR DESCRIPTION
## Summary
- add UART deduplication and priority helpers for OpenHD telemetry links, and apply them on air and ground units
- expose MAVLink parameters for enabling, baud/flow-control, and per-category priorities across FC, tracker, and OpenHD UARTs
- enforce symmetric de-duplication across wifibroadcast/UART receive paths while keeping dual transmit, preventing duplicate forwarding into UDP clients

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0b0694b8832faecd8b2582293ae9)