### PR TITLE
Align OpenHD status socket with sys utils and rename indicator reporter to openhd_sock

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -45,7 +45,7 @@
 #include "openhd_global_constants.hpp"
 #include "openhd_platform.h"
 #include "openhd_profile.h"
-#include "openhd_indicator_reporter.h"
+#include "openhd_sock.h"
 #include "openhd_spdlog.h"
 #include "openhd_temporary_air_or_ground.h"
 #include "openhd_config.h"

--- a/OpenHD/ohd_common/CMakeLists.txt
+++ b/OpenHD/ohd_common/CMakeLists.txt
@@ -66,7 +66,7 @@ set(sources
     "src/openhd_telemetry_recorder.cpp"
     "src/openhd_udp.cpp"
     "src/openhd_tcp.cpp"
-    "src/openhd_indicator_reporter.cpp"
+    "src/openhd_sock.cpp"
     "src/openhd_buttons.cpp"
     "src/openhd_settings_imp.cpp"
     "src/openhd_settings_directories.cpp"

--- a/OpenHD/ohd_common/inc/openhd_sock.h
+++ b/OpenHD/ohd_common/inc/openhd_sock.h
@@ -21,8 +21,8 @@
  * © OpenHD, All Rights Reserved.
  ******************************************************************************/
 
-#ifndef OPENHD_INDICATOR_REPORTER_H
-#define OPENHD_INDICATOR_REPORTER_H
+#ifndef OPENHD_SOCK_H
+#define OPENHD_SOCK_H
 
 #include <chrono>
 #include <condition_variable>
@@ -81,4 +81,4 @@ class IndicatorReporter {
 
 }  // namespace openhd
 
-#endif  // OPENHD_INDICATOR_REPORTER_H
+#endif  // OPENHD_SOCK_H

--- a/OpenHD/ohd_common/src/openhd_sock.cpp
+++ b/OpenHD/ohd_common/src/openhd_sock.cpp
@@ -21,16 +21,16 @@
  * © OpenHD, All Rights Reserved.
  ******************************************************************************/
 
-#include "openhd_indicator_reporter.h"
+#include "openhd_sock.h"
 
-#include <fcntl.h>
-#include <poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 
 #include <cerrno>
 #include <cstring>
+#include <filesystem>
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -39,10 +39,33 @@
 
 namespace {
 
+constexpr const char* kSocketPath = "/run/openhd/openhd_sys.sock";
+
 std::shared_ptr<spdlog::logger> indicator_logger() {
   static std::shared_ptr<spdlog::logger> logger =
       openhd::log::create_or_get("indicator");
   return logger;
+}
+
+void print_to_screen(const std::string& message) {
+  std::cout << "[OpenHD status] " << message << std::endl;
+}
+
+bool write_all(int fd, const void* data, size_t len) {
+  const auto* ptr = static_cast<const char*>(data);
+  size_t remaining = len;
+  while (remaining > 0) {
+    const ssize_t written = ::send(fd, ptr, remaining, MSG_NOSIGNAL);
+    if (written < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    ptr += written;
+    remaining -= static_cast<size_t>(written);
+  }
+  return true;
 }
 
 }  // namespace
@@ -142,6 +165,9 @@ void IndicatorReporter::send_state(const IndicatorStatus& status) {
   payload["state"] = state_to_string(status.state);
   payload["severity"] = status.severity;
   payload["ttl_ms"] = status.ttl_ms;
+  print_to_screen("indicator.set state=" + state_to_string(status.state) +
+                  " severity=" + std::to_string(status.severity) +
+                  " ttl_ms=" + std::to_string(status.ttl_ms));
   auto serialized = payload.dump();
   serialized.push_back('\n');
   send_payload(serialized);
@@ -152,6 +178,7 @@ void IndicatorReporter::send_clear() {
   nlohmann::json payload;
   payload["type"] = "indicator.clear";
   payload["source"] = "openhd";
+  print_to_screen("indicator.clear");
   auto serialized = payload.dump();
   serialized.push_back('\n');
   send_payload(serialized);
@@ -164,51 +191,41 @@ bool IndicatorReporter::send_payload(const std::string& serialized_payload) {
     indicator_logger()->debug("indicator socket path too long: {}", path);
     return false;
   }
-  const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (fd < 0) {
-    indicator_logger()->debug("indicator socket creation failed: {}", strerror(errno));
-    return false;
+  std::error_code ec;
+  const auto parent = std::filesystem::path(path).parent_path();
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent, ec);
+    if (ec) {
+      indicator_logger()->debug("unable to create indicator socket dir {}: {}",
+                                parent.string(), ec.message());
+    }
   }
 
-  int flags = fcntl(fd, F_GETFL, 0);
-  if (flags != -1) {
-    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+  // The status reader listens with a blocking AF_UNIX/STREAM server. Use a
+  // simple blocking connect/write loop for maximum compatibility.
+  const int fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0) {
+    indicator_logger()->debug("indicator socket creation failed: {}",
+                              strerror(errno));
+    return false;
   }
 
   sockaddr_un addr {};
   addr.sun_family = AF_UNIX;
   std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
 
-  int result = ::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
-  if (result < 0 && errno == EINPROGRESS) {
-    pollfd pfd{};
-    pfd.fd = fd;
-    pfd.events = POLLOUT;
-    result = ::poll(&pfd, 1, 100);
-    if (result > 0) {
-      int socket_error = 0;
-      socklen_t len = sizeof(socket_error);
-      if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &socket_error, &len) < 0 ||
-          socket_error != 0) {
-        close(fd);
-        return false;
-      }
-    } else {
-      close(fd);
-      return false;
-    }
-  } else if (result < 0) {
+  if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+    indicator_logger()->debug("indicator socket connect failed: {}",
+                              strerror(errno));
     close(fd);
     return false;
   }
 
-  const ssize_t bytes_sent =
-      ::send(fd, serialized_payload.data(), serialized_payload.size(),
-             MSG_NOSIGNAL);
+  const bool sent_ok =
+      write_all(fd, serialized_payload.data(), serialized_payload.size());
   close(fd);
-  if (bytes_sent != static_cast<ssize_t>(serialized_payload.size())) {
-    indicator_logger()->debug("indicator send failed, sent {} of {}", bytes_sent,
-                              serialized_payload.size());
+  if (!sent_ok) {
+    indicator_logger()->debug("indicator send failed: {}", strerror(errno));
     return false;
   }
   return true;
@@ -232,8 +249,6 @@ std::string IndicatorReporter::state_to_string(IndicatorState state) {
   return "UNKNOWN";
 }
 
-std::string IndicatorReporter::socket_path() {
-  return "/run/openhd/openhd_sys.sock";
-}
+std::string IndicatorReporter::socket_path() { return kSocketPath; }
 
 }  // namespace openhd

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -36,7 +36,7 @@
 #include "microhard_link.h"
 #include "openhd_config.h"
 #include "openhd_global_constants.hpp"
-#include "openhd_indicator_reporter.h"
+#include "openhd_sock.h"
 #include "openhd_util_filesystem.h"
 #include "wb_link.h"
 // Helper function to execute a shell command and return the output


### PR DESCRIPTION
### Motivation
- Make the OpenHD status output compatible with the `openhd_sys_utils` reader by sending newline-delimited JSON over a blocking AF_UNIX stream socket. 
- Use a more generic name for the component (`openhd_sock`) to reflect its role as a socket-based status sender. 
- Ensure status messages are visible on the OpenHD console and reliably delivered to the status service. 
- Reduce silent failures and simplify socket behavior for better interoperability with the existing sysutils server.

### Description
- Renamed `openhd_indicator_reporter.{h,cpp}` to `openhd_sock.{h,cpp}`, updated `CMakeLists.txt`, and replaced includes in `main.cpp` and `ohd_interface.cpp` to `#include "openhd_sock.h"`.
- Reworked the send path to create the socket parent directory (`std::filesystem::create_directories()`), open a blocking `AF_UNIX` `SOCK_STREAM` socket, `connect()` to `"/run/openhd/openhd_sys.sock"`, and use a `write_all()` loop with `MSG_NOSIGNAL` to ensure the full newline-terminated JSON payload is written.
- Emit a console echo with `print_to_screen()` for both `indicator.set` and `indicator.clear` payloads so messages appear on the OpenHD console while being sent to the socket.
- Simplified behavior by removing non-blocking/poll/dgram fallback logic in favor of the blocking stream approach used by `openhd_sys_utils`, and kept `state_to_string()` and JSON payload format (newline-delimited) intact.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c6ce2bee8832f9ad29df62c980690)