### PR TITLE
Send indicator status immediately

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_sock.h
+++ b/OpenHD/ohd_common/inc/openhd_sock.h
@@ -66,6 +66,8 @@ class IndicatorReporter {
   void send_state(const IndicatorStatus& status);
   void send_clear();
   bool send_payload(const std::string& serialized_payload);
+  void send_pending_now();
+  bool prepare_send_locked(std::optional<IndicatorStatus>& status_copy);
   static std::string state_to_string(IndicatorState state);
   static std::string socket_path();
 

--- a/OpenHD/ohd_common/src/openhd_sock.cpp
+++ b/OpenHD/ohd_common/src/openhd_sock.cpp
@@ -112,6 +112,7 @@ void IndicatorReporter::report_state(IndicatorState state, int severity,
     m_pending_send = true;
   }
   m_condition.notify_one();
+  send_pending_now();
 }
 
 void IndicatorReporter::clear() {
@@ -121,6 +122,7 @@ void IndicatorReporter::clear() {
     m_pending_send = true;
   }
   m_condition.notify_one();
+  send_pending_now();
 }
 
 void IndicatorReporter::worker_loop() {
@@ -139,12 +141,8 @@ void IndicatorReporter::worker_loop() {
     if (m_shutdown) {
       return;
     }
-    const auto now = std::chrono::steady_clock::now();
-    const bool should_refresh = m_status.has_value() &&
-                                now - m_last_sent >= m_refresh_interval;
-    bool should_send = m_pending_send || should_refresh;
-    m_pending_send = false;
-    auto status_copy = m_status;
+    std::optional<IndicatorStatus> status_copy;
+    const bool should_send = prepare_send_locked(status_copy);
     lock.unlock();
 
     if (!should_send) {
@@ -229,6 +227,32 @@ bool IndicatorReporter::send_payload(const std::string& serialized_payload) {
     return false;
   }
   return true;
+}
+
+void IndicatorReporter::send_pending_now() {
+  std::optional<IndicatorStatus> status_copy;
+  std::unique_lock<std::mutex> lock(m_mutex);
+  const bool should_send = prepare_send_locked(status_copy);
+  if (!should_send) {
+    return;
+  }
+  lock.unlock();
+  if (status_copy.has_value()) {
+    send_state(status_copy.value());
+  } else {
+    send_clear();
+  }
+}
+
+bool IndicatorReporter::prepare_send_locked(
+    std::optional<IndicatorStatus>& status_copy) {
+  const auto now = std::chrono::steady_clock::now();
+  const bool should_refresh = m_status.has_value() &&
+                              now - m_last_sent >= m_refresh_interval;
+  bool should_send = m_pending_send || should_refresh;
+  m_pending_send = false;
+  status_copy = m_status;
+  return should_send;
 }
 
 std::string IndicatorReporter::state_to_string(IndicatorState state) {


### PR DESCRIPTION
### Motivation
- Ensure the indicator Unix socket at `/run/openhd/openhd_sys.sock` is used during normal `openhd` runs by making state changes write immediately. 
- Avoid waiting for the background worker refresh interval before sending critical indicator updates. 
- Reduce duplicate scheduling logic between synchronous sends and the worker thread. 

### Description
- Added `send_pending_now()` and `prepare_send_locked()` to `openhd_sock` and declared them in `ohd_common/inc/openhd_sock.h` to centralize send scheduling logic. 
- Call `send_pending_now()` from `IndicatorReporter::report_state()` and `IndicatorReporter::clear()` so state changes perform a synchronous send in addition to notifying the worker. 
- Refactored `IndicatorReporter::worker_loop()` to use `prepare_send_locked()` and return a prepared `status_copy` for the worker path, sharing logic with the synchronous path. 
- Updated `OpenHD/ohd_common/src/openhd_sock.cpp` and header to implement the above and keep refresh semantics via `m_refresh_interval`. 

### Testing
- No automated tests were executed for this change. 
- The repository changes were staged and committed with the message `Send indicator status immediately`. 
- Manual runtime validation was not performed as part of this PR. 
- Recommend running the existing test executables under `ohd_common/test` and exercising `openhd` to validate socket behavior after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c767ab790832fb17790eb40933a4d)