### PR TITLE
Send indicator updates immediately (bypass refresh gating)

### DIFF
--- a/OpenHD/ohd_common/inc/openhd_sock.h
+++ b/OpenHD/ohd_common/inc/openhd_sock.h
@@ -66,6 +66,8 @@ class IndicatorReporter {
   void send_state(const IndicatorStatus& status);
   void send_clear();
   bool send_payload(const std::string& serialized_payload);
+  void send_pending_now();
+  bool prepare_send_locked(std::optional<IndicatorStatus>& status_copy);
   static std::string state_to_string(IndicatorState state);
   static std::string socket_path();
 

--- a/OpenHD/ohd_common/src/openhd_sock.cpp
+++ b/OpenHD/ohd_common/src/openhd_sock.cpp
@@ -112,6 +112,7 @@ void IndicatorReporter::report_state(IndicatorState state, int severity,
     m_pending_send = true;
   }
   m_condition.notify_one();
+  send_pending_now();
 }
 
 void IndicatorReporter::clear() {
@@ -121,6 +122,7 @@ void IndicatorReporter::clear() {
     m_pending_send = true;
   }
   m_condition.notify_one();
+  send_pending_now();
 }
 
 void IndicatorReporter::worker_loop() {
@@ -139,12 +141,8 @@ void IndicatorReporter::worker_loop() {
     if (m_shutdown) {
       return;
     }
-    const auto now = std::chrono::steady_clock::now();
-    const bool should_refresh = m_status.has_value() &&
-                                now - m_last_sent >= m_refresh_interval;
-    bool should_send = m_pending_send || should_refresh;
-    m_pending_send = false;
-    auto status_copy = m_status;
+    std::optional<IndicatorStatus> status_copy;
+    const bool should_send = prepare_send_locked(status_copy);
     lock.unlock();
 
     if (!should_send) {
@@ -229,6 +227,31 @@ bool IndicatorReporter::send_payload(const std::string& serialized_payload) {
     return false;
   }
   return true;
+}
+
+void IndicatorReporter::send_pending_now() {
+  std::optional<IndicatorStatus> status_copy;
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    status_copy = m_status;
+    m_pending_send = false;
+  }
+  if (status_copy.has_value()) {
+    send_state(status_copy.value());
+  } else {
+    send_clear();
+  }
+}
+
+bool IndicatorReporter::prepare_send_locked(
+    std::optional<IndicatorStatus>& status_copy) {
+  const auto now = std::chrono::steady_clock::now();
+  const bool should_refresh = m_status.has_value() &&
+                              now - m_last_sent >= m_refresh_interval;
+  bool should_send = m_pending_send || should_refresh;
+  m_pending_send = false;
+  status_copy = m_status;
+  return should_send;
 }
 
 std::string IndicatorReporter::state_to_string(IndicatorState state) {


### PR DESCRIPTION
### Motivation
- Ensure the indicator Unix socket at `/run/openhd/openhd_sys.sock` is written to immediately when state changes instead of waiting for the background refresh interval.
- Make synchronous state changes actively attempt a socket connect/write so `openhd` reaches the indicator server promptly.
- Avoid duplicate scheduling between the synchronous flush path and the worker thread while preserving periodic refresh behavior.

### Description
- Implemented `IndicatorReporter::send_pending_now()` to lock, copy `m_status`, clear `m_pending_send`, and synchronously call `send_state` or `send_clear` for immediate sends. 
- Added `IndicatorReporter::prepare_send_locked()` to centralize send decision logic and updated `worker_loop()` to use it for the worker path. 
- Declared `send_pending_now()` and `prepare_send_locked()` in `OpenHD/ohd_common/inc/openhd_sock.h` and updated `OpenHD/ohd_common/src/openhd_sock.cpp` accordingly.

### Testing
- No automated tests were executed for this change.
- It is recommended to run the existing test executables under `ohd_common/test` and exercise `openhd` to validate socket behavior after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c767ab790832fb17790eb40933a4d)