### PR TITLE
Emit structured indicator status messages for runtime errors

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -37,6 +37,7 @@
 #include <cstring>
 #include <exception>
 #include <iostream>
+#include <algorithm>
 #include <memory>
 #include <cstdlib>
 #include <optional>
@@ -392,6 +393,17 @@ auto ohdInterface =
     std::unique_ptr<OHDVideoAir> ohd_video_air = nullptr;
     if (profile.is_air) {
       auto cameras = OHDVideoAir::discover_cameras();
+      const bool using_dummy_camera = std::any_of(
+          cameras.begin(), cameras.end(),
+          [](const XCamera& camera) {
+            return camera.camera_type == X_CAM_TYPE_DUMMY_SW;
+          });
+      if (using_dummy_camera) {
+        indicator_reporter.report_status_message(
+            "dummy_camera",
+            "Using dummy camera configuration - no physical camera detected",
+            1, 10000);
+      }
       ohd_video_air = std::make_unique<OHDVideoAir>(
           cameras, ohdInterface->get_link_handle());
       // First add camera specific settings (primary & secondary camera)

--- a/OpenHD/ohd_common/inc/openhd_sock.h
+++ b/OpenHD/ohd_common/inc/openhd_sock.h
@@ -30,6 +30,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 namespace openhd {
 
@@ -48,6 +49,9 @@ class IndicatorReporter {
 
   void report_state(IndicatorState state, int severity = 0,
                     int ttl_ms = 3000);
+  void report_status_message(const std::string& code,
+                             const std::string& message, int severity = 0,
+                             int ttl_ms = 3000);
   void clear();
 
  private:
@@ -78,7 +82,10 @@ class IndicatorReporter {
   bool m_shutdown;
   std::chrono::steady_clock::time_point m_last_sent;
   const std::chrono::milliseconds m_refresh_interval;
+  const std::chrono::milliseconds m_status_message_refresh_interval;
   std::thread m_worker;
+  std::unordered_map<std::string, std::chrono::steady_clock::time_point>
+      m_last_status_messages;
 };
 
 }  // namespace openhd

--- a/OpenHD/ohd_common/src/openhd_sock.cpp
+++ b/OpenHD/ohd_common/src/openhd_sock.cpp
@@ -78,6 +78,7 @@ IndicatorReporter::IndicatorReporter()
       m_shutdown(false),
       m_last_sent(std::chrono::steady_clock::time_point::min()),
       m_refresh_interval(std::chrono::hours(24)),
+      m_status_message_refresh_interval(std::chrono::seconds(5)),
       m_worker(&IndicatorReporter::worker_loop, this) {}
 
 IndicatorReporter::~IndicatorReporter() {
@@ -109,6 +110,31 @@ void IndicatorReporter::report_state(IndicatorState state, int severity,
   }
   m_condition.notify_one();
   send_pending_now();
+}
+
+void IndicatorReporter::report_status_message(const std::string& code,
+                                              const std::string& message,
+                                              int severity, int ttl_ms) {
+  const auto now = std::chrono::steady_clock::now();
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto it = m_last_status_messages.find(code);
+    if (it != m_last_status_messages.end() &&
+        now - it->second < m_status_message_refresh_interval) {
+      return;
+    }
+    m_last_status_messages[code] = now;
+  }
+  nlohmann::json payload;
+  payload["type"] = "indicator.status";
+  payload["source"] = "openhd";
+  payload["code"] = code;
+  payload["message"] = message;
+  payload["severity"] = severity;
+  payload["ttl_ms"] = ttl_ms;
+  auto serialized = payload.dump();
+  serialized.push_back('\n');
+  send_payload(serialized);
 }
 
 void IndicatorReporter::clear() {

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -106,6 +106,8 @@ OHDInterface::OHDInterface(OHDProfile profile1, bool disable_wifi_hotspot)
         "Cannot start ohd_interface, no wifi card for monitor mode");
     const std::string message_for_user = "No WiFi card found, please reboot";
     m_console->warn(message_for_user);
+    openhd::IndicatorReporter::instance().report_status_message(
+        "no_wifi_card", "No WiFi card found for monitor mode", 2, 10000);
     openhd::IndicatorReporter::instance().report_state(
         openhd::IndicatorState::Error, 2);
     // TODO reason what to do. We do not support dynamically adding wifi cards

--- a/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.cpp
+++ b/OpenHD/ohd_telemetry/src/endpoints/SerialEndpoint.cpp
@@ -34,6 +34,7 @@
 #include <utility>
 
 #include "openhd_platform.h"
+#include "openhd_sock.h"
 #include "openhd_spdlog_include.h"
 #include "openhd_util.h"
 #include "openhd_util_filesystem.h"
@@ -295,6 +296,12 @@ void SerialEndpoint::receive_data_until_error() {
       m_n_failed_reads++;
       if (!warned_once && m_options.enable_reading) {
         m_console->warn("{} failed reads - FC connected ?", m_n_failed_reads);
+        if (TAG == "fc_ser") {
+          openhd::IndicatorReporter::instance().report_status_message(
+              "no_air_telemetry",
+              "No telemetry received from flight controller over UART", 2,
+              10000);
+        }
         warned_once = true;
       }
       continue;

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -25,6 +25,7 @@
 
 #include <gst/gst.h>
 
+#include <fmt/format.h>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -38,6 +39,7 @@
 #include "nalu/CodecConfigFinder.hpp"
 #include "nalu/fragment_helper.h"
 #include "nalu/nalu_helper.h"
+#include "openhd_sock.h"
 #include "openhd_rtp.h"
 #include "openhd_util.h"
 #include "rpi_hdmi_to_csi_v4l2_helper.h"
@@ -540,6 +542,11 @@ void GStreamerStream::stream_once() {
     if (std::chrono::steady_clock::now() - m_last_camera_frame >
         std::chrono::seconds(10)) {
       m_console->warn("Restarting camera due to no frame after 10 seconds");
+      openhd::IndicatorReporter::instance().report_status_message(
+          "camera_no_frames",
+          fmt::format("No frames received from camera {}",
+                      m_camera_holder->get_camera().index),
+          2, 10000);
       m_request_restart = true;
     }
     // Check if we need to set a new bitrate


### PR DESCRIPTION
### Motivation
- The existing indicator socket only sent a few messages and lacked structured status events for common runtime error conditions.
- Provide explicit, machine-readable status messages so system utilities can react to problems like missing hardware or stalled streams.
- Avoid spamming by rate-limiting repeated status reports while still surfacing transient and persistent issues.
- Cover conditions that make sense as actionable errors: no WiFi card, dummy camera usage, missing FC telemetry, and camera frame stalls.

### Description
- Added `report_status_message(const std::string& code, const std::string& message, int severity, int ttl_ms)` to `IndicatorReporter` and implemented JSON `indicator.status` payloads with a per-code rate limiter backed by `m_last_status_messages` and `m_status_message_refresh_interval` (default 5s).
- Integrated status emission points: `OHDInterface` reports `no_wifi_card` when no monitor-mode WiFi card is found, `main.cpp` reports `dummy_camera` when a dummy camera is used, `SerialEndpoint` reports `no_air_telemetry` for FC UART read failures (tag `fc_ser`), and `GStreamerStream` reports `camera_no_frames` when no frames arrive for 10s.
- Added necessary includes (`<unordered_map>`, `openhd_sock.h`, and `fmt/format.h`) and a small `#include <algorithm>` addition to `main.cpp` to support the new checks.
- Kept `report_state` behavior intact and implemented the status messages as separate, structured events so both legacy state and new status messages can coexist.

### Testing
- No automated tests were executed for this change. 
- Code was updated and committed; runtime verification and CI builds were not performed in this rollout. 
- Manual validation should include starting air/ground builds and exercising cases that trigger each new status code. 
- Rate-limiting behavior can be validated by repeatedly triggering the same condition and confirming only one status message every ~5s is emitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c838f6090832fb935803436c67826)