### PR TITLE
Report startup errors for missing link/camera and expose link detection

### DIFF
--- a/OpenHD/main.cpp
+++ b/OpenHD/main.cpp
@@ -41,6 +41,7 @@
 #include <memory>
 #include <cstdlib>
 #include <optional>
+#include <vector>
 
 #include "openhd_buttons.h"
 #include "openhd_global_constants.hpp"
@@ -274,6 +275,7 @@ int main(int argc, char *argv[]) {
 
   // Create and link all the OpenHD modules.
   try {
+    std::vector<std::string> startup_errors;
     // This results in fresh default values for all modules (e.g. interface,
     // telemetry, video)
     if (options.reset_all_settings) {
@@ -377,8 +379,15 @@ int main(int argc, char *argv[]) {
     }
 
     // Then start ohdInterface, which discovers detected wifi cards and more.
-auto ohdInterface =
-    std::make_shared<OHDInterface>(profile, options.no_hotspot);
+    auto ohdInterface =
+        std::make_shared<OHDInterface>(profile, options.no_hotspot);
+    if (!ohdInterface->has_primary_link()) {
+      const std::string no_link_message =
+          "No functional link detected (WiFi/Microhard/Ethernet)";
+      startup_errors.push_back(no_link_message);
+      indicator_reporter.report_status_message("no_link", no_link_message, 2,
+                                               10000);
+    }
 
     // Telemetry allows changing all settings (even from other modules)
     ohdTelemetry->add_settings_generic(ohdInterface->get_all_settings());
@@ -399,10 +408,11 @@ auto ohdInterface =
             return camera.camera_type == X_CAM_TYPE_DUMMY_SW;
           });
       if (using_dummy_camera) {
+        const std::string dummy_camera_message =
+            "No physical camera detected; using dummy camera configuration";
         indicator_reporter.report_status_message(
-            "dummy_camera",
-            "Using dummy camera configuration - no physical camera detected",
-            1, 10000);
+            "dummy_camera", dummy_camera_message, 2, 10000);
+        startup_errors.push_back(dummy_camera_message);
       }
       ohd_video_air = std::make_unique<OHDVideoAir>(
           cameras, ohdInterface->get_link_handle());
@@ -419,8 +429,18 @@ auto ohdInterface =
     ohdTelemetry->settings_generic_ready();
     // now telemetry can send / receive data via wifibroadcast
     ohdTelemetry->set_link_handle(ohdInterface->get_link_handle());
-    std::cout << green << "OpenHD was successfully started." << reset << std::endl;
-    indicator_reporter.report_state(openhd::IndicatorState::Ready, 0);
+    if (startup_errors.empty()) {
+      std::cout << green << "OpenHD was successfully started." << reset
+                << std::endl;
+      indicator_reporter.report_state(openhd::IndicatorState::Ready, 0);
+    } else {
+      std::cout << red << "OpenHD started with errors:" << reset << std::endl;
+      for (const auto& error_message : startup_errors) {
+        std::cout << red << " - " << error_message << reset << std::endl;
+        m_console->error("Startup issue: {}", error_message);
+      }
+      indicator_reporter.report_state(openhd::IndicatorState::Error, 2);
+    }
     // run forever, everything has its own threads. Note that the only way to
     // break out basically is when one of the modules encounters an exception.
     static bool quit = false;

--- a/OpenHD/ohd_interface/inc/ohd_interface.h
+++ b/OpenHD/ohd_interface/inc/ohd_interface.h
@@ -76,6 +76,9 @@ class OHDInterface {
   // Agnostic of the link, even though r.n we only have a wifibroadcast
   // implementation (but this might change).
   std::shared_ptr<OHDLink> get_link_handle();
+  // Whether we detected any functional primary link implementation
+  // (WiFi/microhard/ethernet).
+  bool has_primary_link() const;
 
  private:
   void apply_wifi_operating_mode();

--- a/OpenHD/ohd_interface/src/ohd_interface.cpp
+++ b/OpenHD/ohd_interface/src/ohd_interface.cpp
@@ -457,6 +457,11 @@ std::shared_ptr<OHDLink> OHDInterface::get_link_handle() {
   return nullptr;
 }
 
+bool OHDInterface::has_primary_link() const {
+  return static_cast<bool>(m_wb_link) || static_cast<bool>(m_microhard_link) ||
+         static_cast<bool>(m_ethernet_link);
+}
+
 void OHDInterface::generate_keys_from_pw_if_exists_and_delete() {
   // Make sure this stupid sodium init has been called
   if (sodium_init() == -1) {


### PR DESCRIPTION
### Motivation
- The process could print "OpenHD was successfully started." even when critical hardware (WiFi/Microhard/Ethernet link or a physical camera) was missing. 
- The indicator/socket state was set to `Ready` despite startup issues, which can mislead operators and clients. 
- The code needed a simple API to determine whether any primary link implementation was available for better startup validation. 

### Description
- Added `has_primary_link()` to `OHDInterface` (`ohd_interface.h` / `ohd_interface.cpp`) to report whether any of `WBLink`, `MicrohardLink` or `EthernetLink` is present. 
- Added a `startup_errors` vector in `main.cpp` and collect startup problems for missing link (`no_link`) and missing physical camera (`dummy_camera`). 
- Emit indicator/socket messages with `report_status_message()` for these conditions and push human-readable messages into `startup_errors`. 
- Print a consolidated "OpenHD started with errors:" summary and keep the indicator state as `Error` instead of `Ready` when `startup_errors` is non-empty, and log each issue with the main logger. 

### Testing
- No automated tests were run against these changes. 
- The patch was built into the working tree and committed but no CI or unit test job was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c8843dbe0832f9de75fa7c044ee69)