### PR TITLE
Fix gst-perf bitrate parsing to avoid mean_bps collisions

### DIFF
--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -26,6 +26,7 @@
 #include <gst/gst.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -68,18 +69,32 @@ bool parse_gst_perf_metric(const char* text, const char* key, double& out_value)
   if (text == nullptr || key == nullptr) {
     return false;
   }
-  const char* value_start = std::strstr(text, key);
-  if (value_start == nullptr) {
-    return false;
+  const auto key_len = std::strlen(key);
+  const char* search = text;
+  while (search != nullptr) {
+    const char* match = std::strstr(search, key);
+    if (match == nullptr) {
+      return false;
+    }
+    const char* value_start = match + key_len;
+    const bool at_start = match == text;
+    const unsigned char prev_char =
+        at_start ? static_cast<unsigned char>(' ')
+                 : static_cast<unsigned char>(*(match - 1));
+    // gst-perf INFO strings may contain similarly named keys like "mean_bps".
+    // Ensure we match a standalone metric key (e.g. "; bps: ") rather than a
+    // suffix inside another token.
+    if (at_start || !(std::isalnum(prev_char) != 0 || prev_char == '_')) {
+      char* value_end = nullptr;
+      const double parsed = std::strtod(value_start, &value_end);
+      if (value_end != value_start) {
+        out_value = parsed;
+        return true;
+      }
+    }
+    search = match + 1;
   }
-  value_start += std::strlen(key);
-  char* value_end = nullptr;
-  const double parsed = std::strtod(value_start, &value_end);
-  if (value_end == value_start) {
-    return false;
-  }
-  out_value = parsed;
-  return true;
+  return false;
 }
 
 bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,


### PR DESCRIPTION
### Motivation
- The gst-perf INFO strings may include both instantaneous (`bps`) and aggregated names like `mean_bps`, and the previous parser could match the wrong substring (e.g. `bps:` inside `mean_bps`) causing incorrect or zero bitrate mapping while FPS remained valid.

### Description
- Update `parse_gst_perf_metric` in `ohd_video/src/gstreamerstream.cpp` to scan occurrences of the key and ensure the match is a standalone metric (checks the preceding character isn't alphanumeric or underscore) before calling `strtod`.
- Return `false` when no valid standalone match is found so callers won't use an incorrect parsed value.
- Add `#include <cctype>` to enable safe use of `std::isalnum` for the boundary check.

### Testing
- Ran an on-repo build attempt with `cmake -S . -B build && cmake --build build --target ohd_video -j4`, which failed during configuration due to missing submodules and dependencies (`ohd_common/lib/json`, `lib/wifibroadcast/wifibroadcast/WBLib.cmake`, and missing Poco development libraries) so the target could not be built in this environment (failed).
- A direct build attempt in a non-existent prior `build` directory (`cd OpenHD/build && cmake --build . --target ohd_video -j4`) also failed because the directory was absent (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a0f514883208ea401d140549d70)