### PR TITLE
Robust gst-perf metric parsing and use mean_bps fallback

### DIFF
--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -26,6 +26,7 @@
 #include <gst/gst.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -68,33 +69,53 @@ bool parse_gst_perf_metric(const char* text, const char* key, double& out_value)
   if (text == nullptr || key == nullptr) {
     return false;
   }
-  const char* value_start = std::strstr(text, key);
-  if (value_start == nullptr) {
-    return false;
+  const auto key_len = std::strlen(key);
+  const char* search = text;
+  while (search != nullptr) {
+    const char* match = std::strstr(search, key);
+    if (match == nullptr) {
+      return false;
+    }
+    const char* value_start = match + key_len;
+    const bool at_start = match == text;
+    const unsigned char prev_char =
+        at_start ? static_cast<unsigned char>(' ')
+                 : static_cast<unsigned char>(*(match - 1));
+    // gst-perf INFO strings may contain similarly named keys like "mean_bps".
+    // Ensure we match a standalone metric key (e.g. "; bps: ") rather than a
+    // suffix inside another token.
+    if (at_start || !(std::isalnum(prev_char) != 0 || prev_char == '_')) {
+      char* value_end = nullptr;
+      const double parsed = std::strtod(value_start, &value_end);
+      if (value_end != value_start) {
+        out_value = parsed;
+        return true;
+      }
+    }
+    search = match + 1;
   }
-  value_start += std::strlen(key);
-  char* value_end = nullptr;
-  const double parsed = std::strtod(value_start, &value_end);
-  if (value_end == value_start) {
-    return false;
-  }
-  out_value = parsed;
-  return true;
+  return false;
 }
 
 bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,
                                 uint16_t& fps) {
   double parsed_bitrate = 0.0;
+  double parsed_mean_bitrate = 0.0;
   double parsed_fps = 0.0;
-  if (!parse_gst_perf_metric(info_text, "bps: ", parsed_bitrate)) {
+  const bool has_bitrate =
+      parse_gst_perf_metric(info_text, "bps: ", parsed_bitrate);
+  const bool has_mean_bitrate =
+      parse_gst_perf_metric(info_text, "mean_bps: ", parsed_mean_bitrate);
+  if (!has_bitrate && !has_mean_bitrate) {
     return false;
   }
   if (!parse_gst_perf_metric(info_text, "fps: ", parsed_fps)) {
     return false;
   }
-  if (parsed_bitrate < 0.0) {
-    parsed_bitrate = 0.0;
-  }
+  // Some gst-perf builds can emit instantaneous bps as 0 while mean_bps is
+  // populated, so use the higher of the two metrics when both are present.
+  parsed_bitrate = std::max(parsed_bitrate, parsed_mean_bitrate);
+  parsed_bitrate = std::max(0.0, parsed_bitrate);
   if (parsed_fps < 0.0) {
     parsed_fps = 0.0;
   }


### PR DESCRIPTION
### Motivation
- Prevent false-positive matches when parsing `gst-perf` INFO strings (e.g. avoiding matching `bps` inside `mean_bps`) and handle cases where instantaneous `bps` is 0 by using the reported `mean_bps`.

### Description
- Add `#include <cctype>` and rewrite `parse_gst_perf_metric` to search iteratively and ensure a matched key is standalone by checking the preceding character is not alphanumeric or underscore before attempting to parse the value.
- Update `parse_gst_perf_bitrate_fps` to parse both `bps` and `mean_bps`, prefer the higher of the two metrics, clamp bitrate and fps to non-negative values, and keep the existing saturation to `uint32_t`/`uint16_t` limits.
- Minor robustness and readability improvements to parsing control flow and variable usage.

### Testing
- Built the project successfully (`cmake`/`make` build) after the changes and ran the existing automated test suite; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a0f514883208ea401d140549d70)