### PR TITLE
Make gst-perf parsing robust, log raw perf lines, and add queue after perf element

### DIFF
--- a/OpenHD/ohd_video/inc/gst_helper.hpp
+++ b/OpenHD/ohd_video/inc/gst_helper.hpp
@@ -894,7 +894,9 @@ static constexpr auto kEncoderPerfElementName = "openhd_perf";
 // Add gst-perf right after encoding so bitrate/fps are measured on the encoder
 // output before packetization.
 static std::string createEncoderPerfElement() {
-  return fmt::format(" perf name={} bitrate-interval=1000 ! ",
+  // Keep a queue directly after perf, matching the known-good standalone test
+  // pipeline shape used for debugging bitrate measurements.
+  return fmt::format(" perf name={} bitrate-interval=1000 ! queue ! ",
                      kEncoderPerfElementName);
 }
 

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -26,6 +26,7 @@
 #include <gst/gst.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -68,33 +69,63 @@ bool parse_gst_perf_metric(const char* text, const char* key, double& out_value)
   if (text == nullptr || key == nullptr) {
     return false;
   }
-  const char* value_start = std::strstr(text, key);
-  if (value_start == nullptr) {
-    return false;
+  const auto key_len = std::strlen(key);
+  const char* search = text;
+  while (search != nullptr) {
+    const char* match = std::strstr(search, key);
+    if (match == nullptr) {
+      return false;
+    }
+    const char* value_start = match + key_len;
+    const bool at_start = match == text;
+    const unsigned char prev_char =
+        at_start ? static_cast<unsigned char>(' ')
+                 : static_cast<unsigned char>(*(match - 1));
+    // gst-perf INFO strings may contain similarly named keys like "mean_bps".
+    // Ensure we match a standalone metric key (e.g. "; bps: ") rather than a
+    // suffix inside another token.
+    if (at_start || !(std::isalnum(prev_char) != 0 || prev_char == '_')) {
+      char* value_end = nullptr;
+      const double parsed = std::strtod(value_start, &value_end);
+      if (value_end != value_start) {
+        out_value = parsed;
+        return true;
+      }
+    }
+    search = match + 1;
   }
-  value_start += std::strlen(key);
-  char* value_end = nullptr;
-  const double parsed = std::strtod(value_start, &value_end);
-  if (value_end == value_start) {
-    return false;
-  }
-  out_value = parsed;
-  return true;
+  return false;
 }
 
 bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,
                                 uint16_t& fps) {
   double parsed_bitrate = 0.0;
   double parsed_fps = 0.0;
-  if (!parse_gst_perf_metric(info_text, "bps: ", parsed_bitrate)) {
+  bool has_any_bitrate = false;
+  const auto use_bitrate_candidate = [&](const char* key, double scale) {
+    double candidate = 0.0;
+    if (!parse_gst_perf_metric(info_text, key, candidate)) {
+      return;
+    }
+    has_any_bitrate = true;
+    parsed_bitrate = std::max(parsed_bitrate, candidate * scale);
+  };
+  use_bitrate_candidate("bps: ", 1.0);
+  use_bitrate_candidate("bps=", 1.0);
+  use_bitrate_candidate("mean_bps: ", 1.0);
+  use_bitrate_candidate("mean_bps=", 1.0);
+  // Some gst-perf variants report in kbps via bitrate fields.
+  use_bitrate_candidate("bitrate: ", 1000.0);
+  use_bitrate_candidate("bitrate=", 1000.0);
+  use_bitrate_candidate("mean_bitrate: ", 1000.0);
+  use_bitrate_candidate("mean_bitrate=", 1000.0);
+  if (!has_any_bitrate) {
     return false;
   }
   if (!parse_gst_perf_metric(info_text, "fps: ", parsed_fps)) {
     return false;
   }
-  if (parsed_bitrate < 0.0) {
-    parsed_bitrate = 0.0;
-  }
+  parsed_bitrate = std::max(0.0, parsed_bitrate);
   if (parsed_fps < 0.0) {
     parsed_fps = 0.0;
   }
@@ -290,6 +321,9 @@ void GStreamerStream::cleanup_perf_element() {
 }
 
 void GStreamerStream::handle_perf_info_message(const char* info_text) {
+  m_console->debug("Perf cam{} raw (gst-perf): {}",
+                   m_camera_holder->get_camera().index,
+                   info_text == nullptr ? "<null>" : info_text);
   uint32_t bitrate_bps = 0;
   uint16_t fps = 0;
   if (!parse_gst_perf_bitrate_fps(info_text, bitrate_bps, fps)) {


### PR DESCRIPTION
### Motivation

- Improve robustness and accuracy of extracting bitrate/fps from `gst-perf` output across different gst-perf variants and formats.
- Ensure encoder performance measurement pipeline shape matches the known-good standalone test pipeline for consistent bitrate measurement.

### Description

- Add a `queue` immediately after the `perf` element in `createEncoderPerfElement()` to match the standalone test pipeline shape and stabilize bitrate measurements by formatting the pipeline as `" perf name={} bitrate-interval=1000 ! queue ! "`.
- Harden metric extraction in `parse_gst_perf_metric()` by scanning for standalone metric keys, avoiding accidental matches inside other tokens, and using `std::isalnum` to verify separator characters.
- Extend `parse_gst_perf_bitrate_fps()` to consider multiple key variants (`"bps: "`, `"bps=", `"mean_bps: "`, `"bitrate: "`, etc.), treat some fields as kbps (scaled by 1000), and choose the maximum candidate value while ensuring non-negative clamping before conversion.
- Add `#include <cctype>` and a debug log in `handle_perf_info_message()` to emit the raw `gst-perf` info string for easier debugging of parsing and telemetry.

### Testing

- Built the project to ensure the changes compile successfully and there are no compilation errors after adding `#include <cctype>`; build succeeded.
- Exercised the perf parsing logic with variants of `gst-perf` formatted strings (containing `bps`, `mean_bps`, `bitrate` with `:` and `=` separators and kbps values) and verified bitrate/fps are parsed and clamped correctly; tests succeeded.
- Verified that enabling the perf element results in the pipeline containing `perf ... ! queue !` as expected during runtime smoke tests; verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a0f514883208ea401d140549d70)