### PR TITLE
Robust gst-perf parsing and warmup handling for encoder telemetry

### DIFF
--- a/OpenHD/ohd_video/inc/gstreamerstream.h
+++ b/OpenHD/ohd_video/inc/gstreamerstream.h
@@ -123,6 +123,8 @@ class GStreamerStream : public CameraStream {
   std::atomic<int64_t> m_last_perf_message_ms = 0;
   std::atomic<int64_t> m_last_required_perf_problem_ms = 0;
   int64_t m_last_perf_warning_ms = 0;
+  int64_t m_perf_first_message_ms = 0;
+  bool m_perf_seen_nonzero_bitrate = false;
 
  private:
   // The stuff here is to pull the data out of the gstreamer pipeline, such that

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -26,6 +26,7 @@
 #include <gst/gst.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -55,6 +56,7 @@ namespace {
 static constexpr auto kSkipDynamicBitrateLogInterval = std::chrono::seconds(5);
 static constexpr int64_t kPerfFirstMessageTimeoutMs = 5000;
 static constexpr int64_t kPerfMissingWarningIntervalMs = 10000;
+static constexpr int64_t kPerfBitrateWarmupMs = 3000;
 static constexpr size_t kPipelineDebugMaxChars = 1200;
 static constexpr size_t kPipelineDebugChunkChars = 34;
 
@@ -68,33 +70,63 @@ bool parse_gst_perf_metric(const char* text, const char* key, double& out_value)
   if (text == nullptr || key == nullptr) {
     return false;
   }
-  const char* value_start = std::strstr(text, key);
-  if (value_start == nullptr) {
-    return false;
+  const auto key_len = std::strlen(key);
+  const char* search = text;
+  while (search != nullptr) {
+    const char* match = std::strstr(search, key);
+    if (match == nullptr) {
+      return false;
+    }
+    const char* value_start = match + key_len;
+    const bool at_start = match == text;
+    const unsigned char prev_char =
+        at_start ? static_cast<unsigned char>(' ')
+                 : static_cast<unsigned char>(*(match - 1));
+    // gst-perf INFO strings may contain similarly named keys like "mean_bps".
+    // Ensure we match a standalone metric key (e.g. "; bps: ") rather than a
+    // suffix inside another token.
+    if (at_start || !(std::isalnum(prev_char) != 0 || prev_char == '_')) {
+      char* value_end = nullptr;
+      const double parsed = std::strtod(value_start, &value_end);
+      if (value_end != value_start) {
+        out_value = parsed;
+        return true;
+      }
+    }
+    search = match + 1;
   }
-  value_start += std::strlen(key);
-  char* value_end = nullptr;
-  const double parsed = std::strtod(value_start, &value_end);
-  if (value_end == value_start) {
-    return false;
-  }
-  out_value = parsed;
-  return true;
+  return false;
 }
 
 bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,
                                 uint16_t& fps) {
   double parsed_bitrate = 0.0;
   double parsed_fps = 0.0;
-  if (!parse_gst_perf_metric(info_text, "bps: ", parsed_bitrate)) {
+  bool has_any_bitrate = false;
+  const auto use_bitrate_candidate = [&](const char* key, double scale) {
+    double candidate = 0.0;
+    if (!parse_gst_perf_metric(info_text, key, candidate)) {
+      return;
+    }
+    has_any_bitrate = true;
+    parsed_bitrate = std::max(parsed_bitrate, candidate * scale);
+  };
+  use_bitrate_candidate("bps: ", 1.0);
+  use_bitrate_candidate("bps=", 1.0);
+  use_bitrate_candidate("mean_bps: ", 1.0);
+  use_bitrate_candidate("mean_bps=", 1.0);
+  // Some gst-perf variants report in kbps via bitrate fields.
+  use_bitrate_candidate("bitrate: ", 1000.0);
+  use_bitrate_candidate("bitrate=", 1000.0);
+  use_bitrate_candidate("mean_bitrate: ", 1000.0);
+  use_bitrate_candidate("mean_bitrate=", 1000.0);
+  if (!has_any_bitrate) {
     return false;
   }
   if (!parse_gst_perf_metric(info_text, "fps: ", parsed_fps)) {
     return false;
   }
-  if (parsed_bitrate < 0.0) {
-    parsed_bitrate = 0.0;
-  }
+  parsed_bitrate = std::max(0.0, parsed_bitrate);
   if (parsed_fps < 0.0) {
     parsed_fps = 0.0;
   }
@@ -290,9 +322,25 @@ void GStreamerStream::cleanup_perf_element() {
 }
 
 void GStreamerStream::handle_perf_info_message(const char* info_text) {
+  m_console->debug("Perf cam{} raw (gst-perf): {}",
+                   m_camera_holder->get_camera().index,
+                   info_text == nullptr ? "<null>" : info_text);
   uint32_t bitrate_bps = 0;
   uint16_t fps = 0;
   if (!parse_gst_perf_bitrate_fps(info_text, bitrate_bps, fps)) {
+    return;
+  }
+  const int64_t now_ms = steady_clock_ms();
+  if (m_perf_first_message_ms <= 0) {
+    m_perf_first_message_ms = now_ms;
+  }
+  if (bitrate_bps > 0) {
+    m_perf_seen_nonzero_bitrate = true;
+  } else if (fps > 0 && !m_perf_seen_nonzero_bitrate &&
+             now_ms - m_perf_first_message_ms < kPerfBitrateWarmupMs) {
+    m_console->debug(
+        "Perf cam{} (gst-perf): skipping warmup zero bitrate fps={} age_ms={}",
+        m_camera_holder->get_camera().index, fps, now_ms - m_perf_first_message_ms);
     return;
   }
   m_last_perf_message_ms.store(steady_clock_ms(), std::memory_order_relaxed);
@@ -507,6 +555,8 @@ bool GStreamerStream::setup() {
   m_bitrate_ctrl_element = std::nullopt;
   m_last_perf_message_ms.store(0, std::memory_order_relaxed);
   m_last_perf_warning_ms = steady_clock_ms() - kPerfMissingWarningIntervalMs;
+  m_perf_first_message_ms = 0;
+  m_perf_seen_nonzero_bitrate = false;
   auto* perf_factory = gst_element_factory_find("perf");
   if (perf_factory == nullptr) {
     report_required_perf_problem(


### PR DESCRIPTION
### Motivation
- Avoid mis-parsing gst-perf INFO strings and spurious telemetry from similarly named tokens, and handle variants that report bitrate in kbps. 
- Ignore transient zero-bitrate reports from the encoder during initial warmup to prevent unnecessary warnings or incorrect telemetry.

### Description
- Added tracking fields `m_perf_first_message_ms` and `m_perf_seen_nonzero_bitrate` to `GStreamerStream` and reset them in `setup()` to implement warmup logic. 
- Improved metric parsing by including `<cctype>`, implementing `parse_gst_perf_metric` to only match standalone metric keys (avoiding suffix collisions), and iterating to find a valid value. 
- Extended `parse_gst_perf_bitrate_fps` to accept multiple key variants (`bps:`, `bps=`, `mean_bps`, `bitrate`/`mean_bitrate` in kbps) and to scale/normalize kbps candidates and clamp negative values. 
- Added `kPerfBitrateWarmupMs` and warmup handling in `handle_perf_info_message` to skip initial zero-bitrate messages when `fps>0` until a non-zero bitrate is seen or the warmup timeout passes, and added debug logging of raw perf lines. 

### Testing
- Project build was run with the repository build system (e.g. `make`) and completed successfully. 
- The repository test runner was invoked (`ctest` / CI test job) and the existing automated tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a0f514883208ea401d140549d70)