### PR TITLE
Avoid false-positive gst-perf metric matches and add plugin/perf logging

### DIFF
--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -26,6 +26,7 @@
 #include <gst/gst.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -68,18 +69,32 @@ bool parse_gst_perf_metric(const char* text, const char* key, double& out_value)
   if (text == nullptr || key == nullptr) {
     return false;
   }
-  const char* value_start = std::strstr(text, key);
-  if (value_start == nullptr) {
-    return false;
+  const auto key_len = std::strlen(key);
+  const char* search = text;
+  while (search != nullptr) {
+    const char* match = std::strstr(search, key);
+    if (match == nullptr) {
+      return false;
+    }
+    const char* value_start = match + key_len;
+    const bool at_start = match == text;
+    const unsigned char prev_char =
+        at_start ? static_cast<unsigned char>(' ')
+                 : static_cast<unsigned char>(*(match - 1));
+    // gst-perf INFO strings may contain similarly named keys like "mean_bps".
+    // Ensure we match a standalone metric key (e.g. "; bps: ") rather than a
+    // suffix inside another token.
+    if (at_start || !(std::isalnum(prev_char) != 0 || prev_char == '_')) {
+      char* value_end = nullptr;
+      const double parsed = std::strtod(value_start, &value_end);
+      if (value_end != value_start) {
+        out_value = parsed;
+        return true;
+      }
+    }
+    search = match + 1;
   }
-  value_start += std::strlen(key);
-  char* value_end = nullptr;
-  const double parsed = std::strtod(value_start, &value_end);
-  if (value_end == value_start) {
-    return false;
-  }
-  out_value = parsed;
-  return true;
+  return false;
 }
 
 bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,
@@ -92,9 +107,7 @@ bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,
   if (!parse_gst_perf_metric(info_text, "fps: ", parsed_fps)) {
     return false;
   }
-  if (parsed_bitrate < 0.0) {
-    parsed_bitrate = 0.0;
-  }
+  parsed_bitrate = std::max(0.0, parsed_bitrate);
   if (parsed_fps < 0.0) {
     parsed_fps = 0.0;
   }
@@ -290,6 +303,9 @@ void GStreamerStream::cleanup_perf_element() {
 }
 
 void GStreamerStream::handle_perf_info_message(const char* info_text) {
+  m_console->debug("Perf cam{} raw (gst-perf): {}",
+                   m_camera_holder->get_camera().index,
+                   info_text == nullptr ? "<null>" : info_text);
   uint32_t bitrate_bps = 0;
   uint16_t fps = 0;
   if (!parse_gst_perf_bitrate_fps(info_text, bitrate_bps, fps)) {
@@ -515,6 +531,23 @@ bool GStreamerStream::setup() {
                     "gstreamer1.0-plugins-bad",
                     m_camera_holder->get_camera().index));
     return false;
+  }
+  GstPlugin* perf_plugin =
+      gst_plugin_feature_get_plugin(GST_PLUGIN_FEATURE(perf_factory));
+  if (perf_plugin != nullptr) {
+    const gchar* plugin_name = gst_plugin_get_name(perf_plugin);
+    const gchar* plugin_description = gst_plugin_get_description(perf_plugin);
+    const gchar* plugin_filename = gst_plugin_get_filename(perf_plugin);
+    const gchar* plugin_version = gst_plugin_get_version(perf_plugin);
+    m_console->info(
+        "Using gst-perf plugin name:{} version:{} file:{} description:{}",
+        plugin_name != nullptr ? plugin_name : "n/a",
+        plugin_version != nullptr ? plugin_version : "n/a",
+        plugin_filename != nullptr ? plugin_filename : "n/a",
+        plugin_description != nullptr ? plugin_description : "n/a");
+    gst_object_unref(perf_plugin);
+  } else {
+    m_console->warn("Unable to query gst-perf plugin metadata");
   }
   gst_object_unref(perf_factory);
   pipeline_content << create_source_encode_pipeline(*m_camera_holder);


### PR DESCRIPTION
### Motivation

- Prevent incorrect parsing of perf metrics where keys like `"bps: "` could match substrings inside other tokens (e.g. `mean_bps`).
- Improve runtime diagnosability of gst-perf by logging raw perf lines and plugin metadata to help debug codec/perf issues.
- Ensure bitrate is never reported as negative when parsed from gst-perf output.

### Description

- Added `#include <cctype>` and rewrote `parse_gst_perf_metric` to search iteratively and verify the character before a key is not alphanumeric or underscore so only standalone metric keys are matched.
- Changed parsing loop to continue searching until a valid numeric value is found and return `true` only on successful parse, otherwise `false`.
- Clamped parsed bitrate using `std::max(0.0, parsed_bitrate)` to avoid negative bitrate values, and preserved existing FPS clamping.
- Added a debug log in `handle_perf_info_message` to emit the raw gst-perf text for each camera and added code in `setup` to query and log `gst-perf` plugin metadata (`gst_plugin_get_name`, `gst_plugin_get_version`, `gst_plugin_get_filename`, `gst_plugin_get_description`) or warn if metadata cannot be queried.

### Testing

- Project compiled successfully with the modified sources using the normal build (`cmake`/`make`).
- Existing automated tests were executed via `ctest`/`make test` and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a0f514883208ea401d140549d70)