### PR TITLE
gst-perf: robust parsing, logging, and perf element handling in GStreamerStream

### DIFF
--- a/OpenHD/ohd_video/inc/gstreamerstream.h
+++ b/OpenHD/ohd_video/inc/gstreamerstream.h
@@ -86,7 +86,7 @@ class GStreamerStream : public CameraStream {
   void handle_gst_message(GstMessage* message);
   bool setup_perf_element();
   void cleanup_perf_element();
-  void handle_perf_info_message(const char* info_text);
+  bool handle_perf_info_message(const char* info_text);
   void check_required_perf_telemetry(int64_t now_ms, int64_t first_frame_ms);
   void report_required_perf_problem(const std::string& code,
                                     const std::string& description);

--- a/OpenHD/ohd_video/src/gstreamerstream.cpp
+++ b/OpenHD/ohd_video/src/gstreamerstream.cpp
@@ -26,6 +26,7 @@
 #include <gst/gst.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
@@ -68,18 +69,32 @@ bool parse_gst_perf_metric(const char* text, const char* key, double& out_value)
   if (text == nullptr || key == nullptr) {
     return false;
   }
-  const char* value_start = std::strstr(text, key);
-  if (value_start == nullptr) {
-    return false;
+  const auto key_len = std::strlen(key);
+  const char* search = text;
+  while (search != nullptr) {
+    const char* match = std::strstr(search, key);
+    if (match == nullptr) {
+      return false;
+    }
+    const char* value_start = match + key_len;
+    const bool at_start = match == text;
+    const unsigned char prev_char =
+        at_start ? static_cast<unsigned char>(' ')
+                 : static_cast<unsigned char>(*(match - 1));
+    // gst-perf INFO strings may contain similarly named keys like "mean_bps".
+    // Ensure we match a standalone metric key (e.g. "; bps: ") rather than a
+    // suffix inside another token.
+    if (at_start || !(std::isalnum(prev_char) != 0 || prev_char == '_')) {
+      char* value_end = nullptr;
+      const double parsed = std::strtod(value_start, &value_end);
+      if (value_end != value_start) {
+        out_value = parsed;
+        return true;
+      }
+    }
+    search = match + 1;
   }
-  value_start += std::strlen(key);
-  char* value_end = nullptr;
-  const double parsed = std::strtod(value_start, &value_end);
-  if (value_end == value_start) {
-    return false;
-  }
-  out_value = parsed;
-  return true;
+  return false;
 }
 
 bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,
@@ -92,9 +107,7 @@ bool parse_gst_perf_bitrate_fps(const char* info_text, uint32_t& bitrate_bps,
   if (!parse_gst_perf_metric(info_text, "fps: ", parsed_fps)) {
     return false;
   }
-  if (parsed_bitrate < 0.0) {
-    parsed_bitrate = 0.0;
-  }
+  parsed_bitrate = std::max(0.0, parsed_bitrate);
   if (parsed_fps < 0.0) {
     parsed_fps = 0.0;
   }
@@ -239,10 +252,20 @@ void GStreamerStream::handle_gst_message(GstMessage* message) {
   GError* info_error = nullptr;
   gchar* info_debug = nullptr;
   gst_message_parse_info(message, &info_error, &info_debug);
-  if (info_debug != nullptr) {
-    handle_perf_info_message(info_debug);
-  } else if (info_error != nullptr && info_error->message != nullptr) {
-    handle_perf_info_message(info_error->message);
+  const char* info_text = nullptr;
+  if (info_error != nullptr && info_error->message != nullptr) {
+    info_text = info_error->message;
+  } else if (info_debug != nullptr) {
+    info_text = info_debug;
+  }
+  if (info_text != nullptr) {
+    handle_perf_info_message(info_text);
+  }
+  if (info_error != nullptr && info_error->message != nullptr &&
+      info_debug != nullptr && std::strcmp(info_error->message, info_debug) != 0) {
+    m_console->debug("Perf cam{} parse_info mismatch error_msg=[{}] debug=[{}]",
+                     m_camera_holder->get_camera().index, info_error->message,
+                     info_debug);
   }
   if (info_error != nullptr) {
     g_error_free(info_error);
@@ -289,17 +312,21 @@ void GStreamerStream::cleanup_perf_element() {
   }
 }
 
-void GStreamerStream::handle_perf_info_message(const char* info_text) {
+bool GStreamerStream::handle_perf_info_message(const char* info_text) {
+  m_console->debug("Perf cam{} raw (gst-perf): {}",
+                   m_camera_holder->get_camera().index,
+                   info_text == nullptr ? "<null>" : info_text);
   uint32_t bitrate_bps = 0;
   uint16_t fps = 0;
   if (!parse_gst_perf_bitrate_fps(info_text, bitrate_bps, fps)) {
-    return;
+    return false;
   }
   m_last_perf_message_ms.store(steady_clock_ms(), std::memory_order_relaxed);
   m_console->debug("Perf cam{} (gst-perf): bitrate={} bps fps={}",
                    m_camera_holder->get_camera().index, bitrate_bps, fps);
   openhd::LinkActionHandler::instance().set_cam_info_perf(
       m_camera_holder->get_camera().index, bitrate_bps, fps);
+  return true;
 }
 
 void GStreamerStream::check_required_perf_telemetry(int64_t now_ms,
@@ -515,6 +542,23 @@ bool GStreamerStream::setup() {
                     "gstreamer1.0-plugins-bad",
                     m_camera_holder->get_camera().index));
     return false;
+  }
+  GstPlugin* perf_plugin =
+      gst_plugin_feature_get_plugin(GST_PLUGIN_FEATURE(perf_factory));
+  if (perf_plugin != nullptr) {
+    const gchar* plugin_name = gst_plugin_get_name(perf_plugin);
+    const gchar* plugin_description = gst_plugin_get_description(perf_plugin);
+    const gchar* plugin_filename = gst_plugin_get_filename(perf_plugin);
+    const gchar* plugin_version = gst_plugin_get_version(perf_plugin);
+    m_console->info(
+        "Using gst-perf plugin name:{} version:{} file:{} description:{}",
+        plugin_name != nullptr ? plugin_name : "n/a",
+        plugin_version != nullptr ? plugin_version : "n/a",
+        plugin_filename != nullptr ? plugin_filename : "n/a",
+        plugin_description != nullptr ? plugin_description : "n/a");
+    gst_object_unref(perf_plugin);
+  } else {
+    m_console->warn("Unable to query gst-perf plugin metadata");
   }
   gst_object_unref(perf_factory);
   pipeline_content << create_source_encode_pipeline(*m_camera_holder);


### PR DESCRIPTION
### Motivation
- Make gst-perf metric parsing more robust to avoid false matches and handle malformed messages gracefully.
- Improve diagnostics and observability when the `perf` plugin is present or when info/error fields disagree.

### Description
- Strengthened metric parsing in `parse_gst_perf_metric` to avoid matching substrings inside other tokens and to iterate until a valid numeric value is found.
- Changed `handle_perf_info_message` to return `bool`, added debug logging of raw perf text, and only report metrics when parsing succeeds.
- Made `parse_gst_perf_bitrate_fps` clamp negative bitrate to zero using `std::max` and preserved safe rounding to limits for `bitrate_bps` and `fps`.
- Improved `handle_gst_message` to prefer the `info_error->message` when available, log mismatches between `info_error` and `info_debug`, and free resources safely.
- During `setup`, query the `perf` plugin metadata (name/version/filename/description) and log it if available, with a warning if metadata cannot be queried.
- Added `#include <cctype>` for character classification used in parsing and updated the header signature of `handle_perf_info_message` to return `bool`.

### Testing
- Built the project using an automated build (`cmake --build`) which completed successfully.
- Ran automated tests via `ctest` where available; no failing tests were reported or no tests were present in the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2a0f514883208ea401d140549d70)