### PR TITLE
Fix configured Ethernet and Microhard endpoints

### DIFF
--- a/OpenHD/ohd_common/src/openhd_config.cpp
+++ b/OpenHD/ohd_common/src/openhd_config.cpp
@@ -124,10 +124,10 @@ static openhd::Config load_or_default() {
           r.Get<int>("microhard", "MICROHARD_VIDEO_PORT", 5910);
       std::cout << "DEBUG: MICROHARD_VIDEO_PORT: " << ret.MICROHARD_VIDEO_PORT
                 << std::endl;
-      ret.TELEMETRY_PORT =
+      ret.MICROHARD_TELEMETRY_PORT =
           r.Get<int>("microhard", "MICROHARD_TELEMETRY_PORT", 5920);
-      std::cout << "DEBUG: MICROHARD_TELEMETRY_PORT: " << ret.TELEMETRY_PORT
-                << std::endl;
+      std::cout << "DEBUG: MICROHARD_TELEMETRY_PORT: "
+                << ret.MICROHARD_TELEMETRY_PORT << std::endl;
     }
     // Parse Generic configuration
     ret.GEN_ENABLE_LAST_KNOWN_POSITION =

--- a/OpenHD/ohd_interface/src/ethernet_link.cpp
+++ b/OpenHD/ohd_interface/src/ethernet_link.cpp
@@ -46,14 +46,18 @@ EthernetLink::EthernetLink(const openhd::Config& config, OHDProfile profile)
     std::cout << "ethernet config load " << std::endl;
 
     try {
-      static const auto GROUND_UNIT_IP = config.GROUND_UNIT_IP;
-      static const auto AIR_UNIT_IP = config.AIR_UNIT_IP;
-      static const auto VIDEO_PORT = config.VIDEO_PORT;
-      static const auto TELEMETRY_PORT = config.TELEMETRY_PORT;
+      if (!config.GROUND_UNIT_IP.empty()) {
+        GROUND_UNIT_IP = config.GROUND_UNIT_IP;
+      }
+      if (!config.AIR_UNIT_IP.empty()) {
+        AIR_UNIT_IP = config.AIR_UNIT_IP;
+      }
+      VIDEO_PORT = config.VIDEO_PORT;
+      TELEMETRY_PORT = config.TELEMETRY_PORT;
 
       // Debugging the values after assignment
       std::cout << "Assigned ethernet parameters:" << std::endl;
-      std::cout << "  GROUND_UNIT_IP: " << config.GROUND_UNIT_IP << std::endl;
+      std::cout << "  GROUND_UNIT_IP: " << GROUND_UNIT_IP << std::endl;
       std::cout << "  AIR_UNIT_IP: " << AIR_UNIT_IP << std::endl;
       std::cout << "  VIDEO_PORT: " << VIDEO_PORT << std::endl;
       std::cout << "  TELEMETRY_PORT: " << TELEMETRY_PORT << std::endl;

--- a/OpenHD/ohd_interface/src/microhard_link.cpp
+++ b/OpenHD/ohd_interface/src/microhard_link.cpp
@@ -74,21 +74,33 @@ static std::string clean_config_token(std::string value) {
   return value;
 }
 
-static const auto CONFIG = openhd::load_config();
-static const std::string MICROHARD_IP_RANGE =
-    CONFIG.MICROHARD_IP_RANGE.empty() ? "192.168.168"
-                                      : CONFIG.MICROHARD_IP_RANGE;
-static const std::string MICROHARD_AIR_IP = CONFIG.MICROHARD_IP_AIR;
-static const std::string MICROHARD_GND_IP = CONFIG.MICROHARD_IP_GROUND;
-static const int MICROHARD_UDP_PORT_TELEMETRY_AIR_TX =
-    CONFIG.MICROHARD_TELEMETRY_PORT;
-static const int MICROHARD_UDP_PORT_VIDEO_AIR_TX = CONFIG.MICROHARD_VIDEO_PORT;
-static const std::string DEFAULT_DEVICE_IP_GND = CONFIG.MICROHARD_IP_GROUND;
-static const std::string DEFAULT_DEVICE_IP_AIR = "";
-const std::string username =
-    clean_config_token(CONFIG.MICROHARD_USERNAME) + "\n";
-const std::string password =
-    clean_config_token(CONFIG.MICROHARD_PASSWORD) + "\n";
+struct MicrohardRuntimeConfig {
+  std::string ip_range;
+  std::string air_ip;
+  std::string ground_ip;
+  int telemetry_port;
+  int video_port;
+  std::string username;
+  std::string password;
+};
+
+static MicrohardRuntimeConfig make_microhard_config(
+    const openhd::Config& config) {
+  return MicrohardRuntimeConfig{
+      config.MICROHARD_IP_RANGE.empty() ? "192.168.168"
+                                        : config.MICROHARD_IP_RANGE,
+      config.MICROHARD_IP_AIR,
+      config.MICROHARD_IP_GROUND,
+      config.MICROHARD_TELEMETRY_PORT,
+      config.MICROHARD_VIDEO_PORT,
+      clean_config_token(config.MICROHARD_USERNAME) + "\n",
+      clean_config_token(config.MICROHARD_PASSWORD) + "\n"};
+}
+
+static const MicrohardRuntimeConfig& get_microhard_config() {
+  static const auto config = make_microhard_config(openhd::load_config());
+  return config;
+}
 
 // Helper function to retrieve IP addresses starting with a specific prefix
 std::vector<std::string> get_ip_addresses(const std::string& prefix) {
@@ -184,13 +196,15 @@ void communicate_with_device(const std::string& ip,
     // Login to the device
     std::this_thread::sleep_for(
         std::chrono::seconds(1));  // Wait for a second to process username
-    openhd::log::get_default()->debug("Sending username: {}", username);
-    stream << username << std::flush;
+    openhd::log::get_default()->debug("Sending username: {}",
+                                       get_microhard_config().username);
+    stream << get_microhard_config().username << std::flush;
     std::this_thread::sleep_for(
         std::chrono::seconds(1));  // Wait for a second to process username
 
-    openhd::log::get_default()->debug("Sending password: {}", password);
-    stream << password << std::flush;
+    openhd::log::get_default()->debug("Sending password: {}",
+                                       get_microhard_config().password);
+    stream << get_microhard_config().password << std::flush;
     std::this_thread::sleep_for(
         std::chrono::seconds(3));  // Wait for a second to process password
 
@@ -246,12 +260,14 @@ void communicate_with_device_slow(const std::string& ip,
 
     // Login to the device
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    openhd::log::get_default()->debug("Sending username: {}", username);
-    stream << username << std::flush;
+    openhd::log::get_default()->debug("Sending username: {}",
+                                       get_microhard_config().username);
+    stream << get_microhard_config().username << std::flush;
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    openhd::log::get_default()->debug("Sending password: {}", password);
-    stream << password << std::flush;
+    openhd::log::get_default()->debug("Sending password: {}",
+                                       get_microhard_config().password);
+    stream << get_microhard_config().password << std::flush;
     std::this_thread::sleep_for(std::chrono::seconds(3));
 
     const std::vector<std::pair<std::string, std::regex>> commands = {
@@ -357,44 +373,38 @@ bool check_ip_alive(const std::string& ip, int port = 23) {
   return connected;
 }
 
-std::string find_device_ip_gnd() {
-  if (!DEFAULT_DEVICE_IP_GND.empty()) {
-    return DEFAULT_DEVICE_IP_GND;
+std::string find_device_ip_gnd(const MicrohardRuntimeConfig& config) {
+  if (!config.ground_ip.empty()) {
+    return config.ground_ip;
   }
-  auto ip_addresses = get_ip_addresses(MICROHARD_IP_RANGE);
+  auto ip_addresses = get_ip_addresses(config.ip_range);
   for (const auto& ip : ip_addresses) {
-    if (ip != MICROHARD_AIR_IP && ip != MICROHARD_GND_IP) {
+    if (ip != config.air_ip && ip != config.ground_ip) {
       return ip;
     }
   }
   openhd::log::get_default()->warn(
       "No suitable IP address found for DEVICE_IP_GND. Using default.");
 
-  return DEFAULT_DEVICE_IP_GND;
+  return config.ground_ip;
 }
 
-std::string find_device_ip_air() {
-  if (!DEFAULT_DEVICE_IP_AIR.empty()) {
-    return DEFAULT_DEVICE_IP_AIR;
-  }
-  auto ip_addresses = get_ip_addresses(MICROHARD_IP_RANGE);
+std::string find_device_ip_air(const MicrohardRuntimeConfig& config) {
+  auto ip_addresses = get_ip_addresses(config.ip_range);
   for (const auto& ip : ip_addresses) {
-    if (ip != MICROHARD_AIR_IP && ip != MICROHARD_GND_IP) {
+    if (ip != config.air_ip && ip != config.ground_ip) {
       return ip;
     }
   }
   openhd::log::get_default()->warn(
       "No suitable IP address found for DEVICE_IP_AIR. Using default.");
 
-  return DEFAULT_DEVICE_IP_AIR;
+  return "";
 }
 
-// The assigned IP
-static const std::string DEVICE_IP_GND = find_device_ip_gnd();
-static const std::string DEVICE_IP_AIR = find_device_ip_air();
-
 void log_ip_addresses() {
-  auto ip_addresses = get_ip_addresses(MICROHARD_IP_RANGE);
+  const auto& config = get_microhard_config();
+  auto ip_addresses = get_ip_addresses(config.ip_range);
   if (!ip_addresses.empty()) {
     for (const auto& ip : ip_addresses) {
       openhd::log::get_default()->warn("Found IP address: {}", ip);
@@ -403,17 +413,18 @@ void log_ip_addresses() {
     }
   } else {
     openhd::log::get_default()->warn("No IP addresses starting with {} found.",
-                                     MICROHARD_IP_RANGE);
+                                     config.ip_range);
   }
 }
 
 std::string get_detected_ip_address() {
-  auto ip_addresses = get_ip_addresses(MICROHARD_IP_RANGE);
+  const auto& config = get_microhard_config();
+  auto ip_addresses = get_ip_addresses(config.ip_range);
   if (!ip_addresses.empty()) {
     return ip_addresses.front();
   } else {
     openhd::log::get_default()->warn("No IP addresses starting with {} found.",
-                                     MICROHARD_IP_RANGE);
+                                     config.ip_range);
 
     return "";  // Return an empty string if no IP found
   }
@@ -439,24 +450,28 @@ static void wait_for_microhard_module(bool is_air) {
 }
 
 MicrohardLink::MicrohardLink(OHDProfile profile) : m_profile(profile) {
+  const auto& config = get_microhard_config();
+  const auto device_ip_gnd = find_device_ip_gnd(config);
+  const auto device_ip_air = find_device_ip_air(config);
+
   wait_for_microhard_module(m_profile.is_air);
 
   if (m_profile.is_air) {
     m_video_tx = std::make_unique<openhd::UDPForwarder>(
-        DEVICE_IP_GND, MICROHARD_UDP_PORT_VIDEO_AIR_TX);
+        device_ip_gnd, config.video_port);
     auto cb_telemetry_rx = [this](const uint8_t* data, std::size_t data_len) {
       auto shared =
           std::make_shared<std::vector<uint8_t>>(data, data + data_len);
       on_receive_telemetry_data(shared);
     };
     m_telemetry_tx_rx = std::make_unique<openhd::UDPReceiver>(
-        DEVICE_IP_AIR, MICROHARD_UDP_PORT_TELEMETRY_AIR_TX, cb_telemetry_rx);
+        device_ip_air, config.telemetry_port, cb_telemetry_rx);
   } else {
     auto cb_video_rx = [this](const uint8_t* payload, std::size_t payloadSize) {
       on_receive_video_data(0, payload, payloadSize);
     };
     m_video_rx = std::make_unique<openhd::UDPReceiver>(
-        DEVICE_IP_GND, MICROHARD_UDP_PORT_VIDEO_AIR_TX, cb_video_rx);
+        device_ip_gnd, config.video_port, cb_video_rx);
 
     auto cb_telemetry_rx = [this](const uint8_t* data, std::size_t data_len) {
       auto shared =
@@ -464,7 +479,7 @@ MicrohardLink::MicrohardLink(OHDProfile profile) : m_profile(profile) {
       on_receive_telemetry_data(shared);
     };
     m_telemetry_tx_rx = std::make_unique<openhd::UDPReceiver>(
-        DEVICE_IP_GND, MICROHARD_UDP_PORT_TELEMETRY_AIR_TX, cb_telemetry_rx);
+        device_ip_gnd, config.telemetry_port, cb_telemetry_rx);
   }
 
   if (m_telemetry_tx_rx) {
@@ -486,9 +501,11 @@ MicrohardLink::MicrohardLink(OHDProfile profile) : m_profile(profile) {
 }
 
 void MicrohardLink::transmit_telemetry_data(OHDLink::TelemetryTxPacket packet) {
-  const auto destination_ip = m_profile.is_air ? DEVICE_IP_GND : DEVICE_IP_AIR;
+  const auto& config = get_microhard_config();
+  const auto destination_ip = m_profile.is_air ? find_device_ip_gnd(config)
+                                               : find_device_ip_air(config);
   m_telemetry_tx_rx->forwardPacketViaUDP(
-      destination_ip, MICROHARD_UDP_PORT_TELEMETRY_AIR_TX, packet.data->data(),
+      destination_ip, config.telemetry_port, packet.data->data(),
       packet.data->size());
 }
 

--- a/OpenHD/ohd_interface/src/microhard_link.cpp
+++ b/OpenHD/ohd_interface/src/microhard_link.cpp
@@ -36,6 +36,7 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -59,28 +60,35 @@ const std::string command5 = "AT+MWVRATE\n";
 const std::string command6 = "AT+MWNOISEFLOOR\n";
 const std::string command7 = "AT+MWSNR\n";
 
-// Parse hardware.config
-// const auto config = openhd::load_config();
-// static const auto MICROHARD_IP_RANGE = config.MICROHARD_IP_AIR;
-// static const auto MICROHARD_AIR_IP = config.MICROHARD_IP_AIR;
-// static const auto MICROHARD_GND_IP = config.MICROHARD_IP_GROUND;
-// static const int MICROHARD_UDP_PORT_TELEMETRY_AIR_TX =
-//     config.MICROHARD_TELEMETRY_PORT;
-// static const int MICROHARD_UDP_PORT_VIDEO_AIR_TX =
-// config.MICROHARD_VIDEO_PORT; static const std::string DEFAULT_DEVICE_IP_GND =
-// config.GROUND_UNIT_IP; static const std::string DEFAULT_DEVICE_IP_AIR =
-// config.AIR_UNIT_IP; const std::string username = config.MICROHARD_USERNAME +
-// "\n"; const std::string password = config.MICROHARD_PASSWORD + "\n";
+static std::string clean_config_token(std::string value) {
+  while (!value.empty() &&
+         (std::isspace(static_cast<unsigned char>(value.front())) ||
+          value.front() == '"' || value.front() == '\'')) {
+    value.erase(value.begin());
+  }
+  while (!value.empty() &&
+         (std::isspace(static_cast<unsigned char>(value.back())) ||
+          value.back() == '"' || value.back() == '\'' || value.back() == ';')) {
+    value.pop_back();
+  }
+  return value;
+}
 
-static const auto MICROHARD_IP_RANGE = "192.168.168";
-static const auto MICROHARD_AIR_IP = "";
-static const auto MICROHARD_GND_IP = "";
-static const int MICROHARD_UDP_PORT_TELEMETRY_AIR_TX = 5000;
-static const int MICROHARD_UDP_PORT_VIDEO_AIR_TX = 5001;
-static const std::string DEFAULT_DEVICE_IP_GND = "";
+static const auto CONFIG = openhd::load_config();
+static const std::string MICROHARD_IP_RANGE =
+    CONFIG.MICROHARD_IP_RANGE.empty() ? "192.168.168"
+                                      : CONFIG.MICROHARD_IP_RANGE;
+static const std::string MICROHARD_AIR_IP = CONFIG.MICROHARD_IP_AIR;
+static const std::string MICROHARD_GND_IP = CONFIG.MICROHARD_IP_GROUND;
+static const int MICROHARD_UDP_PORT_TELEMETRY_AIR_TX =
+    CONFIG.MICROHARD_TELEMETRY_PORT;
+static const int MICROHARD_UDP_PORT_VIDEO_AIR_TX = CONFIG.MICROHARD_VIDEO_PORT;
+static const std::string DEFAULT_DEVICE_IP_GND = CONFIG.MICROHARD_IP_GROUND;
 static const std::string DEFAULT_DEVICE_IP_AIR = "";
-const std::string username = "admin\n";
-const std::string password = "qwertz1\n";
+const std::string username =
+    clean_config_token(CONFIG.MICROHARD_USERNAME) + "\n";
+const std::string password =
+    clean_config_token(CONFIG.MICROHARD_PASSWORD) + "\n";
 
 // Helper function to retrieve IP addresses starting with a specific prefix
 std::vector<std::string> get_ip_addresses(const std::string& prefix) {
@@ -350,6 +358,9 @@ bool check_ip_alive(const std::string& ip, int port = 23) {
 }
 
 std::string find_device_ip_gnd() {
+  if (!DEFAULT_DEVICE_IP_GND.empty()) {
+    return DEFAULT_DEVICE_IP_GND;
+  }
   auto ip_addresses = get_ip_addresses(MICROHARD_IP_RANGE);
   for (const auto& ip : ip_addresses) {
     if (ip != MICROHARD_AIR_IP && ip != MICROHARD_GND_IP) {
@@ -363,6 +374,9 @@ std::string find_device_ip_gnd() {
 }
 
 std::string find_device_ip_air() {
+  if (!DEFAULT_DEVICE_IP_AIR.empty()) {
+    return DEFAULT_DEVICE_IP_AIR;
+  }
   auto ip_addresses = get_ip_addresses(MICROHARD_IP_RANGE);
   for (const auto& ip : ip_addresses) {
     if (ip != MICROHARD_AIR_IP && ip != MICROHARD_GND_IP) {


### PR DESCRIPTION
  This PR fixes configured endpoint handling for Ethernet and Microhard links.

  Changes:
  - Apply configured Ethernet endpoints instead of hardcoded/default values.
  - Use configured Microhard IP addresses and UDP ports.
  - Load Microhard configuration at runtime to avoid stale static configuration.
  - Use configured Microhard username/password when communicating with the module.

  Tested:
  - tested on etherent/microhard pmddl.
  - Built locally.